### PR TITLE
feat(driver): ELYZAモデル（Llama 2ベース）のサポートを追加

### DIFF
--- a/packages/driver/src/mlx-ml/process/model-handlers.ts
+++ b/packages/driver/src/mlx-ml/process/model-handlers.ts
@@ -151,6 +151,30 @@ export function processGemmaCompletion(prompt: string): string {
 }
 
 /**
+ * ELYZA (Llama 2ベース) 用のCompletion処理
+ *
+ * ELYZAはLlama 2のinstruction formatを使用:
+ * <s>[INST] <<SYS>>
+ * システムプロンプト
+ * <</SYS>>
+ *
+ * ユーザープロンプト [/INST]
+ *
+ * Note: <<SYS>>, [INST]などはspecial tokensではなく、複数トークンに分割される
+ */
+export function processElyzaCompletion(prompt: string): string {
+  const B_INST = '[INST]';
+  const E_INST = '[/INST]';
+  const B_SYS = '<<SYS>>\n';
+  const E_SYS = '\n<</SYS>>\n\n';
+  const DEFAULT_SYSTEM = 'あなたは誠実で優秀な日本人のアシスタントです。';
+
+  // Llama 2 instruction format
+  // <s>は自動的に追加されるため含めない（add_bos_token: true）
+  return `${B_INST} ${B_SYS}${DEFAULT_SYSTEM}${E_SYS}${prompt} ${E_INST} `;
+}
+
+/**
  * モデル名に基づいてChat処理を選択
  */
 export function selectChatProcessor(modelName: string): ((messages: MlxMessage[]) => MlxMessage[]) | null {
@@ -183,6 +207,10 @@ export function selectCompletionProcessor(modelName: string): ((prompt: string) 
   }
   if (modelName.includes('gemma-3')) {
     return processGemmaCompletion;
+  }
+  // ELYZA models (elyza/ELYZA-japanese-Llama-2-*)
+  if (modelName.toLowerCase().includes('elyza')) {
+    return processElyzaCompletion;
   }
   return null;
 }


### PR DESCRIPTION
## 概要

ELYZA-japanese-Llama-2シリーズモデル用のCompletion処理を追加しました。

## 変更内容

### 新規追加（`packages/driver/src/mlx-ml/process/model-handlers.ts`）

1. **`processElyzaCompletion()` 関数**
   - Llama 2 instruction formatに準拠
   - デフォルトシステムプロンプト: 「あなたは誠実で優秀な日本人のアシスタントです。」
   - フォーマット: `[INST] <<SYS>>システムプロンプト<</SYS>>ユーザープロンプト [/INST]`

2. **`selectCompletionProcessor()` の更新**
   - モデル名に "elyza" が含まれる場合に `processElyzaCompletion()` を適用

## 対象モデル

- `elyza/ELYZA-japanese-Llama-2-*` シリーズ
  - ELYZA-japanese-Llama-2-7b
  - ELYZA-japanese-Llama-2-7b-instruct
  - ELYZA-japanese-Llama-2-7b-fast
  - ELYZA-japanese-Llama-2-7b-fast-instruct
  - など

## 実装の詳細

### Llama 2 Instruction Format

```
[INST] <<SYS>>
あなたは誠実で優秀な日本人のアシスタントです。
<</SYS>>

{ユーザープロンプト} [/INST] 
```

### 注意事項

- `<<SYS>>`, `[INST]` などは**special tokensではなく**、複数トークンに分割されます
- `<s>` (BOS token) は自動的に追加される（`add_bos_token: true`）ため、プロンプトには含めません

## テスト

- ✓ ビルド成功
- ✓ 型チェック通過

## 参考

- [ELYZA公式](https://huggingface.co/elyza)
- [Llama 2 Chat Template](https://huggingface.co/blog/llama2#how-to-prompt-llama-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)