### PR TITLE
fix(driver): MLXブロックトークンサポートとEcho二重出力修正

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moduler-prompt/driver",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## 概要
MLX Pythonドライバーとテスト用Echoドライバーの改善を実施しました。

## MLX Pythonドライバー
- 専用special_tokenがない場合のブロックトークンサポートを追加
- トークン優先順位を実装: 専用トークン → 汎用ブロック → HTMLコメント
- ブロックトークン使用時のフォーマット: `{block_begin}{role}:\n...{block_end}`

## Echoドライバー
- `both`モードと`debug`モードでoutputSchemaメッセージが二重出力される問題を修正
- outputSchemaを一時的に削除してフォーマット後、最後に一度だけ追加する方式に変更

## 変更内容
- `packages/driver/src/mlx-ml/python/__main__.py`: generate_merged_prompt関数を修正
- `packages/driver/src/echo-driver.ts`: both/debugケースでの二重出力を修正
- バージョン: 0.3.1 → 0.3.2

## テスト
- 全243テストが通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)