### PR TITLE
fix(driver): Outputセクションでschema専用descriptionを削除

### DIFF
--- a/packages/driver/docs/mlx-api-selection.md
+++ b/packages/driver/docs/mlx-api-selection.md
@@ -1,0 +1,301 @@
+# MLX Driver API Selection
+
+MLX Driverは、chat APIとcompletion APIの2つのAPIを提供しています。このドキュメントでは、どちらのAPIを使用するかを決定するロジックと、カスタマイズ方法について説明します。
+
+## デフォルトのAPI選択ロジック
+
+`ModelSpecManager.determineApi()`は、以下の順序でAPIを選択します：
+
+### 1. カスタムロジック（最優先）
+
+`customProcessor.determineApi()`が提供されている場合、それが最優先されます。
+
+```typescript
+const driver = new MlxDriver({
+  model: 'some-model',
+  modelSpec: {
+    customProcessor: {
+      determineApi: (context) => {
+        // カスタムロジック
+        if (/* 特定の条件 */) {
+          return 'completion';
+        }
+        // デフォルトロジックに委譲
+        return undefined;
+      }
+    }
+  }
+});
+```
+
+### 2. 強制モード
+
+`apiStrategy`が`'force-chat'`または`'force-completion'`の場合、その設定が優先されます。
+
+```typescript
+modelSpec: {
+  apiStrategy: 'force-completion'  // 常にcompletion APIを使用
+}
+```
+
+### 3. 機能チェック
+
+- `hasApplyChatTemplate: false`の場合: completion APIを使用
+- `supportsCompletion: false`の場合: chat APIを使用
+
+### 4. 優先モード
+
+#### `prefer-chat`
+
+1. メッセージを検証
+2. 有効な場合: chat APIを使用
+3. 無効な場合: completion APIにフォールバック
+
+```typescript
+modelSpec: {
+  apiStrategy: 'prefer-chat',
+  chatRestrictions: {
+    singleSystemAtStart: true,
+    requiresUserLast: true
+  }
+}
+```
+
+#### `prefer-completion`
+
+常にcompletion APIを使用します。
+
+### 5. `auto`モード（デフォルト）
+
+1. メッセージを検証
+2. chat制限に違反している場合: completion APIを使用
+3. chat制限が3個以上の場合: completion APIを使用
+4. それ以外: chat APIを使用
+
+---
+
+## カスタムAPI選択ロジック
+
+`customProcessor.determineApi()`を使用して、独自のロジックを実装できます。
+
+### ApiSelectionContext
+
+カスタムロジックには、以下の情報が提供されます：
+
+```typescript
+interface ApiSelectionContext {
+  messages: MlxMessage[];              // 処理対象のメッセージ
+  validation: ValidationResult;        // メッセージの検証結果
+  capabilities: {                      // モデルの機能情報
+    hasApplyChatTemplate?: boolean;
+    supportsCompletion?: boolean;
+  };
+  chatRestrictions?: ChatRestrictions; // チャット制限
+  apiStrategy: ApiStrategy;            // 設定されたapiStrategy
+}
+```
+
+### 戻り値
+
+- `'chat'`: chat APIを使用
+- `'completion'`: completion APIを使用
+- `undefined`: デフォルトロジックに委譲
+
+---
+
+## ヘルパー関数
+
+### createModulerPromptApiSelector()
+
+moduler-promptの典型的なパターン（system → user → system(cue)）に最適化されたセレクター。
+
+#### 検出するパターン
+
+```typescript
+[
+  { role: 'system', content: 'instructions...' },
+  { role: 'user', content: 'input data...' },
+  { role: 'system', content: 'Please output in JSON format' }  // cue
+]
+```
+
+#### 問題となる制限
+
+- `singleSystemAtStart: true` - systemメッセージは先頭1つのみ
+- `maxSystemMessages: 1` - システムメッセージは1個まで
+
+上記パターンと制限の組み合わせでは、cueメッセージを配置できないため、completion APIを強制します。
+
+#### 使用例
+
+```typescript
+import { createModulerPromptApiSelector } from '@moduler-prompt/driver/mlx-ml/model-spec';
+
+const driver = new MlxDriver({
+  model: 'gemma-2-2b-it-4bit',
+  modelSpec: {
+    customProcessor: {
+      determineApi: createModulerPromptApiSelector()
+    }
+  }
+});
+```
+
+### createSystemMessageBasedSelector(minSystemMessages)
+
+システムメッセージの数に基づくセレクター。
+
+#### パラメータ
+
+- `minSystemMessages`: この数以上のsystemメッセージがある場合に判定（デフォルト: 2）
+
+#### 使用例
+
+```typescript
+import { createSystemMessageBasedSelector } from '@moduler-prompt/driver/mlx-ml/model-spec';
+
+const driver = new MlxDriver({
+  model: 'some-model',
+  modelSpec: {
+    customProcessor: {
+      determineApi: createSystemMessageBasedSelector(3)
+    }
+  }
+});
+```
+
+### combineSelectors(selectors)
+
+複数のセレクターを組み合わせるコンビネーター。
+
+#### 動作
+
+セレクターを順番に実行し、最初に`undefined`以外を返したセレクターの結果を使用します。
+
+#### 使用例
+
+```typescript
+import {
+  combineSelectors,
+  createModulerPromptApiSelector,
+  createSystemMessageBasedSelector
+} from '@moduler-prompt/driver/mlx-ml/model-spec';
+
+const driver = new MlxDriver({
+  model: 'some-model',
+  modelSpec: {
+    customProcessor: {
+      determineApi: combineSelectors([
+        // 1. moduler-promptパターンをチェック
+        createModulerPromptApiSelector(),
+        // 2. システムメッセージ数をチェック
+        createSystemMessageBasedSelector(3),
+        // 3. カスタムロジック
+        (context) => {
+          if (context.messages.length > 100) {
+            return 'completion';
+          }
+          return undefined;
+        }
+      ])
+    }
+  }
+});
+```
+
+---
+
+## ユースケース別の推奨設定
+
+### 1. moduler-promptで使用する場合
+
+```typescript
+import { createModulerPromptApiSelector } from '@moduler-prompt/driver/mlx-ml/model-spec';
+
+const driver = new MlxDriver({
+  model: 'gemma-2-2b-it-4bit',
+  modelSpec: {
+    customProcessor: {
+      determineApi: createModulerPromptApiSelector()
+    }
+  }
+});
+```
+
+### 2. chat APIを優先したいが、制限違反時はフォールバック
+
+```typescript
+const driver = new MlxDriver({
+  model: 'some-model',
+  modelSpec: {
+    apiStrategy: 'prefer-chat'
+  }
+});
+```
+
+### 3. 常にcompletion APIを使用
+
+```typescript
+const driver = new MlxDriver({
+  model: 'some-model',
+  modelSpec: {
+    apiStrategy: 'force-completion'
+  }
+});
+```
+
+### 4. 完全カスタムロジック
+
+```typescript
+const driver = new MlxDriver({
+  model: 'some-model',
+  modelSpec: {
+    customProcessor: {
+      determineApi: (context) => {
+        // 独自のロジック
+        const systemMessages = context.messages.filter(m => m.role === 'system');
+        const hasComplexPattern = systemMessages.length > 2;
+
+        if (hasComplexPattern && context.chatRestrictions?.singleSystemAtStart) {
+          return 'completion';
+        }
+
+        // デフォルトロジックに委譲
+        return undefined;
+      }
+    }
+  }
+});
+```
+
+---
+
+## トラブルシューティング
+
+### chat APIでエラーが発生する
+
+**症状**: 「システムメッセージが複数ある」などのエラー
+
+**原因**: chat制限に違反している
+
+**解決策**:
+1. `apiStrategy: 'force-completion'`を設定
+2. または`createModulerPromptApiSelector()`を使用
+
+### completion APIしか使われない
+
+**症状**: chat APIを使いたいのにcompletion APIが選択される
+
+**原因**: デフォルトロジックがchat制限を厳しいと判断
+
+**解決策**:
+1. `apiStrategy: 'prefer-chat'`を設定
+2. または`chatRestrictions: undefined`で制限をクリア
+
+---
+
+## 関連ドキュメント
+
+- [型定義](../src/mlx-ml/model-spec/types.ts)
+- [ヘルパー関数](../src/mlx-ml/model-spec/helpers.ts)
+- [ModelSpecManager](../src/mlx-ml/model-spec/manager.ts)

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moduler-prompt/driver",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/driver/src/formatter/completion-formatter.ts
+++ b/packages/driver/src/formatter/completion-formatter.ts
@@ -84,11 +84,7 @@ export function formatCompletionPrompt(
   // Format output section with header - always show the section
   if (sections.length > 0) sections.push('');
   sections.push('# Output');
-  // Use different description if outputSchema exists
-  if (prompt.metadata?.outputSchema) {
-    sections.push('');
-    sections.push('Output a JSON string based on the schema defined in the Instructions section above.');
-  } else if (sectionDescriptions?.output) {
+  if (sectionDescriptions?.output) {
     sections.push('');
     sections.push(sectionDescriptions.output);
   }

--- a/packages/driver/src/formatter/converter.ts
+++ b/packages/driver/src/formatter/converter.ts
@@ -85,15 +85,9 @@ export function formatPromptAsMessages(
   
   // Process output section
   if (prompt.output && prompt.output.length > 0) {
-    // Use different description if outputSchema exists
-    let outputHeader: string;
-    if (prompt.metadata?.outputSchema) {
-      outputHeader = '# Output\n\nOutput a JSON string based on the schema defined in the Instructions section above.';
-    } else {
-      outputHeader = sectionDescriptions?.output
-        ? `# Output\n\n${sectionDescriptions.output}`
-        : '# Output';
-    }
+    const outputHeader = sectionDescriptions?.output
+      ? `# Output\n\n${sectionDescriptions.output}`
+      : '# Output';
     messages.push({
       role: 'system',
       content: outputHeader

--- a/packages/driver/test-api-selection.ts
+++ b/packages/driver/test-api-selection.ts
@@ -1,0 +1,26 @@
+import { compile } from '@moduler-prompt/core';
+import { MlxDriver } from './src/index.js';
+
+async function test() {
+  console.log('Testing force-completion API selection...');
+
+  const driver = new MlxDriver({
+    model: 'mlx-community/gemma-2-2b-it-4bit',
+    modelSpec: {
+      apiStrategy: 'force-completion'
+    }
+  });
+
+  const prompt = compile({
+    objective: ['Test'],
+    instructions: ['Say hello in one sentence']
+  });
+
+  console.log('Querying...');
+  const result = await driver.query(prompt);
+  console.log('\nResult:', result.content.substring(0, 100));
+
+  await driver.close();
+}
+
+test().catch(console.error);

--- a/prompts/memos/mlx-api-selection-refactoring.v1.md
+++ b/prompts/memos/mlx-api-selection-refactoring.v1.md
@@ -1,0 +1,244 @@
+# MLX API選択ロジックのリファクタリング
+
+## 経緯
+
+1. **初期バグ修正** (他の人が実装)
+   - `apiStrategy: 'force-completion'`が機能しない3つの独立したバグを修正
+   - すべてのテストがパス
+
+2. **機能追加の検討**
+   - moduler-promptの典型的パターン（system → user → system(cue)）が、厳格なchat制限（`singleSystemAtStart`）により失敗する問題に対処
+   - 外部からAPI選択ロジックをカスタマイズできる機構を追加
+   - `customProcessor.determineApi()`の実装
+   - ヘルパー関数（`createModulerPromptApiSelector()`など）の実装
+   - ドキュメント作成
+
+3. **設計の再検討**
+   - ユーザーからの指摘: capabilitiesが外部で読めるなら、`apiStrategy`を使って調整できるため、カスタムロジック機構は不要
+   - 代わりに`getModelSpec()`を公開する方針に変更
+   - カスタムロジック機構は削除予定
+
+4. **調査フェーズ**
+   - `getCapabilities()`と`getModelSpec()`の棲み分けを整理
+   - model-specの使用範囲を調査
+   - **重要な発見**: `initialize()`が動的検出した`chatRestrictions`をマージしていない
+
+---
+
+## 現状の整理
+
+### ModelSpecの二重定義
+
+**1. MLX専用のModelSpec** (`packages/driver/src/mlx-ml/model-spec/types.ts`)
+```typescript
+export interface ModelSpec {
+  modelName: string;
+  capabilities?: {
+    hasApplyChatTemplate?: boolean;
+    supportsCompletion?: boolean;
+    specialTokens?: Record<string, any>;
+  };
+  apiStrategy?: ApiStrategy;
+  chatRestrictions?: ChatRestrictions;
+  customProcessor?: ModelCustomProcessor;
+  validatedPatterns?: Map<string, ValidationResult>;
+}
+```
+
+- **用途**: MLXドライバー内部でのchat/completion選択制御
+- **範囲**: `packages/driver/src/mlx-ml/`内でのみ使用
+- **特徴**: chat制限、動的検出、API選択戦略など、MLX固有の詳細な仕様
+
+**2. 汎用のModelSpec** (`packages/driver/src/driver-registry/types.ts`)
+```typescript
+export interface ModelSpec {
+  model: string;
+  provider: DriverProvider;
+  capabilities: DriverCapability[];
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+  cost?: { input: number; output: number };
+  // ... その他
+}
+```
+
+- **用途**: ドライバーレジストリでの全ドライバー共通のモデル仕様
+- **範囲**: `packages/driver/src/driver-registry/`で使用
+- **特徴**: ドライバー横断的な情報（token制限、コスト、能力フラグなど）
+
+**結論**: 2つのModelSpecは**完全に別物**。名前は同じだが目的と内容が異なる。
+
+---
+
+### ModelSpecManagerの動作
+
+**コンストラクタ** (`manager.ts:37-64`)
+```typescript
+constructor(modelName: string, process: MlxProcess, customSpec?: Partial<ModelSpec>) {
+  this.modelName = modelName;
+  this.process = process;
+  this.detector = new ModelSpecDetector(process);
+
+  // 1. プリセットを取得
+  const preset = getPresetForModel(modelName);
+
+  // 2. プリセットとカスタムをマージ
+  this.spec = {
+    modelName,
+    ...mergeWithPreset(preset, customSpec)  // ← バグ修正済み
+  };
+}
+```
+
+**initialize()メソッド** (`manager.ts:74-91`)
+```typescript
+async initialize(): Promise<void> {
+  if (this.initialized) return;
+
+  // Pythonプロセスから動的に検出
+  const detectedSpec = await this.detector.detectCapabilities();
+
+  // ❌ 問題: capabilitiesのみマージ
+  this.spec = {
+    ...this.spec,
+    capabilities: {
+      ...this.spec.capabilities,
+      ...detectedSpec.capabilities  // ← capabilitiesだけ
+    }
+    // chatRestrictions、apiStrategyは捨てられる
+  };
+
+  this.initialized = true;
+}
+```
+
+**detectCapabilities()が返す内容** (`detector.ts`)
+```typescript
+async detectCapabilities(): Promise<Partial<ModelSpec>> {
+  const capabilities = await this.process.getCapabilities();
+
+  return {
+    capabilities: {
+      hasApplyChatTemplate: capabilities.features.apply_chat_template,
+      supportsCompletion: true,
+      specialTokens: capabilities.special_tokens
+    },
+    chatRestrictions: await this.detectChatRestrictions(),  // ← 無視される
+    apiStrategy: this.determineApiStrategy(spec)  // ← 無視される
+  };
+}
+```
+
+**問題点**:
+- `detectCapabilities()`は`chatRestrictions`と`apiStrategy`を動的検出
+- しかし`initialize()`は`capabilities`しかマージしない
+- 動的検出した情報の大部分が捨てられている
+- **非合理的**
+
+---
+
+### カスタムロジック機構の現状
+
+**追加した機能**:
+- `ApiSelectionContext`型の定義
+- `ModelCustomProcessor.determineApi()`メソッド
+- `helpers.ts`ファイル（ヘルパー関数群）
+- `helpers.test.ts`ファイル（13テスト）
+- `manager.test.ts`への4テスト追加
+- `docs/mlx-api-selection.md`ドキュメント
+
+**削除予定の理由**:
+- `getModelSpec()`を公開すれば、外部でcapabilitiesとchatRestrictionsを確認できる
+- ユーザーは`apiStrategy`を指定するだけで済む
+- カスタムロジック機構は過剰設計
+
+---
+
+## 発見された問題
+
+### 1. initialize()がchatRestrictionsをマージしない
+
+**現状**:
+```typescript
+this.spec = {
+  ...this.spec,
+  capabilities: {
+    ...this.spec.capabilities,
+    ...detectedSpec.capabilities
+  }
+  // chatRestrictions、apiStrategyを無視
+};
+```
+
+**期待される動作**:
+```typescript
+this.spec = {
+  ...this.spec,
+  capabilities: {
+    ...this.spec.capabilities,
+    ...detectedSpec.capabilities
+  },
+  chatRestrictions: {
+    ...this.spec.chatRestrictions,
+    ...detectedSpec.chatRestrictions  // ← 追加すべき？
+  },
+  apiStrategy: detectedSpec.apiStrategy ?? this.spec.apiStrategy  // ← 追加すべき？
+};
+```
+
+**疑問点**:
+- `chatRestrictions`と`apiStrategy`は動的検出すべきか、それともプリセット/カスタム設定のみか？
+- 動的検出結果とカスタム設定の優先順位は？
+  - 現状: カスタム設定が優先（capabilitiesのみ両方をマージ）
+  - 提案: すべて同様にマージ？それとも完全上書き？
+
+### 2. getModelSpec()が未実装
+
+**現状**: `ModelSpecManager.getSpec()`は存在するが、`MlxDriver`から公開されていない
+
+**必要な実装**:
+```typescript
+// mlx-driver.ts
+public getModelSpec(): Readonly<ModelSpec> {
+  return this.specManager.getSpec();
+}
+```
+
+---
+
+## 残タスク
+
+### 確定している作業
+1. **カスタムロジック機構の削除**
+   - `types.ts`から`ApiSelectionContext`を削除
+   - `ModelCustomProcessor.determineApi`を削除
+   - `helpers.ts`全体を削除
+   - `helpers.test.ts`全体を削除
+   - `manager.test.ts`のカスタムロジックテスト削除
+   - `docs/mlx-api-selection.md`削除
+
+2. **getModelSpec()の追加**
+   - `MlxDriver`に`getModelSpec()`メソッドを追加
+
+### 検討が必要な作業
+3. **initialize()の修正**
+   - `chatRestrictions`を動的検出結果からマージすべきか？
+   - `apiStrategy`を動的検出結果からマージすべきか？
+   - マージロジック（浅いマージ vs 深いマージ vs 完全上書き）
+   - カスタム設定と動的検出の優先順位
+
+---
+
+## 質問事項
+
+1. **initialize()の修正方針**
+   - 動的検出した`chatRestrictions`と`apiStrategy`もマージすべきか？
+   - マージする場合、どのような優先順位で？
+
+2. **作業の順序**
+   - 先にカスタムロジック機構を削除してから`initialize()`を修正？
+   - それとも`initialize()`を先に修正？
+
+3. **動的検出の役割**
+   - `detector.detectChatRestrictions()`と`detector.determineApiStrategy()`は何のために存在するのか？
+   - 現在は検出しても捨てているが、本来の意図は？

--- a/prompts/memos/mlx-driver-force-completion-bug.v1.md
+++ b/prompts/memos/mlx-driver-force-completion-bug.v1.md
@@ -1,0 +1,554 @@
+# MLX Driver force-completion バグ調査レポート
+
+## 問題の概要
+
+### 報告された問題
+- `apiStrategy: 'force-completion'` を設定しているにもかかわらず、chat APIが使用される
+- 「システムメッセージが5個検出」という警告が出る（chat API使用の証拠）
+- パッケージバージョン: `@moduler-prompt/driver@0.2.5`（最新）
+- 対象モデル: `gemma-2-2b-it-4bit`
+
+### 設定内容（問題報告者のコード）
+```typescript
+modelSpec: {
+  apiStrategy: 'force-completion',
+  chatRestrictions: undefined
+}
+```
+
+---
+
+## 根本原因：3つの独立したバグ
+
+### バグ1: ModelSpecManagerのコンストラクタ処理順序の問題 ⭐ **最重要**
+
+**場所**: `packages/driver/src/mlx-ml/model-spec/manager.ts:33-43`
+
+**問題のコード**:
+```typescript
+constructor(modelName, process, customSpec?, customProcessor?) {
+  // プリセットとカスタム設定をマージ
+  const baseSpec = mergeWithPreset(modelName, customSpec);
+
+  // デフォルト値を設定
+  this.spec = {
+    modelName,
+    apiStrategy: 'auto',  // ⚠️ ここでapiStrategy: 'auto'を設定
+    ...baseSpec,          // ⚠️ その後baseSpecで上書き（プリセットのprefer-chatが優先される）
+    customProcessor: customProcessor || baseSpec.customProcessor,
+    validatedPatterns: new Map()
+  };
+}
+```
+
+**問題点**:
+1. `apiStrategy: 'auto'` を先に設定
+2. その後 `...baseSpec` で展開
+3. gemma-2-2b-it-4bitの場合、プリセット（presets.ts:14-25）に `prefer-chat` が設定されている
+4. **結果**: customSpecの `force-completion` がプリセットの `prefer-chat` で上書きされる
+
+**影響**:
+- customSpecで `force-completion` を設定しても、プリセットの `prefer-chat` で上書きされる
+- **これが主要な原因**
+
+**修正方法**:
+```typescript
+this.spec = {
+  modelName,
+  apiStrategy: 'auto',
+  ...baseSpec,
+  ...customSpec,  // ← 追加：customSpecを最後に展開
+  customProcessor: customProcessor || baseSpec.customProcessor,
+  validatedPatterns: new Map()
+};
+```
+
+---
+
+### バグ2: initialize()での2重マージ問題
+
+**場所**: `packages/driver/src/mlx-ml/model-spec/manager.ts:48-68`
+
+**問題のコード**:
+```typescript
+async initialize(): Promise<void> {
+  if (this.initialized) return;
+
+  // 動的に能力を検出
+  const detectedSpec = await this.detector.detectCapabilities();
+
+  // 検出結果をマージ（既存の設定を優先）
+  this.spec = {
+    ...detectedSpec,
+    ...this.spec,  // ← constructor()で既にマージ済みのspecを再度マージ
+    capabilities: {
+      ...detectedSpec.capabilities,
+      ...this.spec.capabilities
+    },
+    chatRestrictions: {
+      ...detectedSpec.chatRestrictions,
+      ...this.spec.chatRestrictions  // ← 既にプリセットの値が入っている
+    }
+  };
+
+  this.initialized = true;
+}
+```
+
+**問題点**:
+1. `constructor()` で既にプリセットとマージ済み
+2. `initialize()` で再度マージすると、chatRestrictionsなどが残る
+3. `chatRestrictions: undefined` を指定しても、プリセットの制限がそのまま残る
+
+**影響**:
+- `chatRestrictions: undefined` で「制限を消したい」という意図が伝わらない
+- プリセットの制限が残り続ける
+
+**修正方法**:
+```typescript
+async initialize(): Promise<void> {
+  if (this.initialized) return;
+
+  const detectedSpec = await this.detector.detectCapabilities();
+
+  // apiStrategyとchatRestrictionsは既存の値を優先（マージしない）
+  this.spec = {
+    ...detectedSpec,
+    ...this.spec,
+    // capabilitiesのみ検出結果を優先してマージ
+    capabilities: {
+      ...this.spec.capabilities,
+      ...detectedSpec.capabilities
+    }
+  };
+
+  this.initialized = true;
+}
+```
+
+---
+
+### バグ3: mergeWithPreset()の深いマージ処理
+
+**場所**: `packages/driver/src/mlx-ml/model-spec/presets.ts:112-138`
+
+**問題のコード**:
+```typescript
+export function mergeWithPreset(
+  modelName: string,
+  customSpec?: Partial<import('./types.js').ModelSpec>
+): Partial<import('./types.js').ModelSpec> {
+  const preset = findPreset(modelName);
+
+  if (!preset) {
+    return customSpec || {};
+  }
+
+  // プリセットとカスタム設定をマージ（カスタムが優先）
+  return {
+    ...preset.spec,
+    ...customSpec,
+    modelName,
+    // chatRestrictionsは深いマージ
+    chatRestrictions: {
+      ...preset.spec.chatRestrictions,  // ← プリセットの制限
+      ...customSpec?.chatRestrictions   // ← undefinedの場合、何も展開されない
+    },
+    // capabilitiesも深いマージ
+    capabilities: {
+      ...preset.spec.capabilities,
+      ...customSpec?.capabilities
+    }
+  };
+}
+```
+
+**問題点**:
+1. `customSpec.chatRestrictions: undefined` を指定した場合
+2. `...undefined` は何も展開されないため、プリセットの制限がそのまま残る
+3. **「制限を消したい」という意図が伝わらない**
+
+**影響**:
+- `chatRestrictions: undefined` を設定しても効果がない
+- プリセットの制限が残り続ける
+
+**修正方法（オプション1）**:
+```typescript
+export function mergeWithPreset(modelName, customSpec?) {
+  const preset = findPreset(modelName);
+
+  if (!preset) {
+    return customSpec || {};
+  }
+
+  return {
+    ...preset.spec,
+    ...customSpec,
+    modelName,
+    // undefinedの場合は空オブジェクトとして扱う
+    chatRestrictions: customSpec?.chatRestrictions !== undefined
+      ? customSpec.chatRestrictions
+      : preset.spec.chatRestrictions,
+    capabilities: customSpec?.capabilities !== undefined
+      ? customSpec.capabilities
+      : preset.spec.capabilities
+  };
+}
+```
+
+**修正方法（オプション2 - より単純）**:
+```typescript
+export function mergeWithPreset(modelName, customSpec?) {
+  const preset = findPreset(modelName);
+
+  if (!preset) {
+    return customSpec || {};
+  }
+
+  return {
+    ...preset.spec,
+    ...customSpec,
+    modelName
+    // 深いマージを削除（customSpecが優先される）
+  };
+}
+```
+
+---
+
+## 問題が発生する具体的なフロー
+
+### 1. ユーザーのコード
+```typescript
+new MlxDriver({
+  model: 'gemma-2-2b-it-4bit',
+  modelSpec: {
+    apiStrategy: 'force-completion',
+    chatRestrictions: undefined
+  }
+});
+```
+
+### 2. MlxDriver → MlxProcess → ModelSpecManager
+```typescript
+// mlx-driver.ts:141
+this.process = new MlxProcess(config.model, config.modelSpec, config.customProcessor);
+
+// process/index.ts:59
+this.specManager = new ModelSpecManager(modelName, this, customSpec, customProcessor);
+```
+
+### 3. ModelSpecManager constructor()
+```typescript
+// manager.ts:33
+const baseSpec = mergeWithPreset('gemma-2-2b-it-4bit', {
+  apiStrategy: 'force-completion',
+  chatRestrictions: undefined
+});
+
+// mergeWithPreset()の結果:
+// {
+//   apiStrategy: 'prefer-chat',  // ← customSpecのforce-completionが上書きされている
+//   chatRestrictions: {
+//     singleSystemAtStart: true,
+//     alternatingTurns: true,
+//     requiresUserLast: true,
+//     maxSystemMessages: 1
+//   }
+// }
+
+// manager.ts:36-43
+this.spec = {
+  modelName: 'gemma-2-2b-it-4bit',
+  apiStrategy: 'auto',
+  ...baseSpec,  // ← prefer-chatで上書き
+  customProcessor: customProcessor || baseSpec.customProcessor,
+  validatedPatterns: new Map()
+};
+
+// 結果:
+// this.spec.apiStrategy = 'prefer-chat'
+```
+
+### 4. initialize()
+```typescript
+// manager.ts:48-68
+const detectedSpec = await this.detector.detectCapabilities();
+
+this.spec = {
+  ...detectedSpec,
+  ...this.spec,  // ← 既にprefer-chatになっている
+  capabilities: { ... },
+  chatRestrictions: { ... }  // ← プリセットの制限が残る
+};
+```
+
+### 5. determineApi()の実行
+```typescript
+// mlx-driver.ts:177
+const api = determineApiSelection(prompt, specManager, this.formatterOptions);
+
+// determineApiSelection → specManager.determineApi()
+// manager.ts:74-121
+determineApi(messages: MlxMessage[]): 'chat' | 'completion' {
+  const strategy = this.spec.apiStrategy;  // 'prefer-chat'
+
+  // 強制モード
+  if (strategy === 'force-chat') return 'chat';
+  if (strategy === 'force-completion') return 'completion';  // ← 到達しない！
+
+  // ...
+
+  // 優先モード
+  if (strategy === 'prefer-chat') {
+    // メッセージが有効かチェック
+    const validation = this.validateMessages(messages);
+    if (validation.valid) {
+      return 'chat';  // ← こちらが実行される
+    }
+    return 'completion';
+  }
+
+  // ...
+}
+```
+
+**結果**: chat APIが使用される
+
+---
+
+## 修正案と作業計画
+
+### 優先度1: 最小限の修正（バグ1のみ）⭐
+
+**目的**: force-completionが機能するようにする
+
+**修正対象**:
+- `packages/driver/src/mlx-ml/model-spec/manager.ts:33-43`
+
+**修正内容**:
+```typescript
+this.spec = {
+  modelName,
+  apiStrategy: 'auto',
+  ...baseSpec,
+  ...customSpec,  // ← この1行を追加
+  customProcessor: customProcessor || baseSpec.customProcessor,
+  validatedPatterns: new Map()
+};
+```
+
+**影響範囲**: 最小
+**リスク**: 低
+**効果**: force-completionが機能するようになる
+
+---
+
+### 優先度2: 包括的な修正（バグ1, 2, 3すべて）
+
+**目的**: 設定マージの挙動を正しくする
+
+**修正対象**:
+1. `packages/driver/src/mlx-ml/model-spec/manager.ts` (バグ1, 2)
+2. `packages/driver/src/mlx-ml/model-spec/presets.ts` (バグ3)
+
+**修正内容**:
+
+#### 1. manager.ts - constructor()
+```typescript
+constructor(
+  modelName: string,
+  process: MlxProcess,
+  customSpec?: Partial<ModelSpec>,
+  customProcessor?: ModelCustomProcessor
+) {
+  this.process = process;
+  this.detector = new ModelCapabilityDetector(process, modelName);
+
+  // プリセットとカスタム設定をマージ
+  const baseSpec = mergeWithPreset(modelName, customSpec);
+
+  // デフォルト値を設定
+  this.spec = {
+    modelName,
+    apiStrategy: 'auto',
+    ...baseSpec,
+    ...customSpec,  // ← 追加：customSpecを最後に展開
+    customProcessor: customProcessor || baseSpec.customProcessor,
+    validatedPatterns: new Map()
+  };
+}
+```
+
+#### 2. manager.ts - initialize()
+```typescript
+async initialize(): Promise<void> {
+  if (this.initialized) return;
+
+  // 動的に能力を検出
+  const detectedSpec = await this.detector.detectCapabilities();
+
+  // apiStrategyとchatRestrictionsは既存の値を優先
+  this.spec = {
+    ...detectedSpec,
+    ...this.spec,
+    // capabilitiesのみ検出結果を優先してマージ
+    capabilities: {
+      ...this.spec.capabilities,
+      ...detectedSpec.capabilities
+    }
+  };
+
+  this.initialized = true;
+}
+```
+
+#### 3. presets.ts - mergeWithPreset() (オプション2を推奨)
+```typescript
+export function mergeWithPreset(
+  modelName: string,
+  customSpec?: Partial<import('./types.js').ModelSpec>
+): Partial<import('./types.js').ModelSpec> {
+  const preset = findPreset(modelName);
+
+  if (!preset) {
+    return customSpec || {};
+  }
+
+  // プリセットとカスタム設定をマージ（カスタムが優先）
+  return {
+    ...preset.spec,
+    ...customSpec,
+    modelName
+  };
+}
+```
+
+**影響範囲**: 中
+**リスク**: 低〜中
+**効果**: すべての設定が意図通りに動作する
+
+---
+
+### 優先度3: テストケースの追加
+
+**目的**: 回帰を防止する
+
+**追加テスト**:
+- `packages/driver/src/mlx-ml/model-spec/manager.test.ts`
+
+```typescript
+describe('ModelSpecManager - apiStrategy override', () => {
+  test('force-completion should override preset prefer-chat', async () => {
+    const process = createMockProcess();
+    const manager = new ModelSpecManager(
+      'gemma-2-2b-it-4bit',
+      process,
+      { apiStrategy: 'force-completion' }
+    );
+
+    await manager.initialize();
+
+    const api = manager.determineApi([
+      { role: 'user', content: 'test' }
+    ]);
+
+    expect(api).toBe('completion');
+  });
+
+  test('chatRestrictions: undefined should clear preset restrictions', async () => {
+    const process = createMockProcess();
+    const manager = new ModelSpecManager(
+      'gemma-2-2b-it-4bit',
+      process,
+      { chatRestrictions: undefined }
+    );
+
+    await manager.initialize();
+
+    const spec = manager.getSpec();
+    expect(spec.chatRestrictions).toBeUndefined();
+  });
+
+  test('custom apiStrategy should not be overwritten by initialize()', async () => {
+    const process = createMockProcess();
+    const manager = new ModelSpecManager(
+      'gemma-2-2b-it-4bit',
+      process,
+      { apiStrategy: 'force-completion' }
+    );
+
+    await manager.initialize();
+
+    const spec = manager.getSpec();
+    expect(spec.apiStrategy).toBe('force-completion');
+  });
+});
+```
+
+---
+
+## 検証方法
+
+### 1. ユニットテストで検証
+```bash
+npm test -- packages/driver/src/mlx-ml/model-spec/manager.test.ts
+```
+
+### 2. 実際のモデルで検証
+```typescript
+const driver = new MlxDriver({
+  model: 'gemma-2-2b-it-4bit',
+  modelSpec: {
+    apiStrategy: 'force-completion',
+    chatRestrictions: undefined
+  }
+});
+
+// システムメッセージが5個あるプロンプトを実行
+// → completion APIが使用され、警告が出ないことを確認
+```
+
+---
+
+## 推奨される実装順序
+
+1. **ステップ1**: バグ1の修正（manager.ts constructor()）
+2. **ステップ2**: テストケースの追加と実行
+3. **ステップ3**: 動作確認（実際のモデルで検証）
+4. **ステップ4**: バグ2, 3の修正（必要に応じて）
+5. **ステップ5**: 追加テストと包括的な検証
+
+---
+
+## 影響範囲の分析
+
+### 影響を受けるモデル
+- **gemma-2-2b-it-4bit**: プリセットで `prefer-chat` が設定されている（最も影響大）
+- **gemma-3シリーズ**: 同様のプリセット
+- **Tanuki-8B**: prefer-chat設定
+- **Phi-3シリーズ**: prefer-chat設定
+- **Qwenシリーズ**: prefer-chat設定
+
+### 影響を受けない設定
+- カスタムモデル（プリセットなし）
+- プリセットが `auto` または `force-completion` のモデル
+- customSpecを指定しない場合
+
+---
+
+## 補足情報
+
+### 関連ファイル
+- `packages/driver/src/mlx-ml/mlx-driver.ts:49-72` - determineApiSelection()
+- `packages/driver/src/mlx-ml/model-spec/manager.ts:74-121` - determineApi()
+- `packages/driver/src/mlx-ml/model-spec/presets.ts:12-100` - MODEL_PRESETS
+- `packages/driver/src/mlx-ml/model-spec/types.ts:56-62` - ApiStrategy型定義
+
+### 参考PR
+- PR #26: ModelSpecManagerの修正（該当する修正は含まれていない）
+
+---
+
+**作成日**: 2025-11-21
+**対象バージョン**: @moduler-prompt/driver@0.2.5

--- a/prompts/memos/mlx-modelspec-rename-plan.v1.md
+++ b/prompts/memos/mlx-modelspec-rename-plan.v1.md
@@ -1,0 +1,355 @@
+# MLX ModelSpec → MlxModelConfig リネーム計画
+
+## リネーム対象の型
+
+### 主要な型
+
+1. **`ModelSpec`** → **`MlxModelConfig`**
+   - `packages/driver/src/mlx-ml/model-spec/types.ts:121`
+   - MLXモデルの設定と動作仕様を定義
+
+2. **`ModelSpecPreset`** → **`MlxModelConfigPreset`**
+   - `packages/driver/src/mlx-ml/model-spec/types.ts:148`
+   - プリセット定義の型
+
+3. **`ModelSpecManager`** → **`MlxModelConfigManager`**
+   - `packages/driver/src/mlx-ml/model-spec/manager.ts:17`
+   - モデル設定の管理クラス
+
+### 関連する型（リネーム不要）
+
+これらは明確にMLX固有なので現状のまま:
+- `ChatRestrictions` - そのまま
+- `ApiStrategy` - そのまま
+- `ApiSelectionContext` - そのまま（削除予定だが）
+- `ModelCustomProcessor` - そのまま
+- `ValidationResult` - そのまま
+- `MlxCapabilities` - 新規作成（capabilities の型を明示化）
+
+### 関連しない型（注意）
+
+**リネームしない**:
+- `ModelSpecificProcessor` (`process/model-specific.ts:11`)
+  - これは「モデル固有の処理」を意味する別の型
+  - ModelSpecとは無関係
+
+## リネーム影響範囲
+
+### ファイル一覧（10ファイル）
+
+1. `packages/driver/src/mlx-ml/model-spec/types.ts` ⭐
+2. `packages/driver/src/mlx-ml/model-spec/manager.ts` ⭐
+3. `packages/driver/src/mlx-ml/model-spec/manager.test.ts` ⭐
+4. `packages/driver/src/mlx-ml/model-spec/presets.ts` ⭐
+5. `packages/driver/src/mlx-ml/model-spec/detector.ts` ⭐
+6. `packages/driver/src/mlx-ml/process/index.ts` ⭐
+7. `packages/driver/src/mlx-ml/mlx-driver.ts` ⭐
+8. `packages/driver/src/mlx-ml/process/model-specific.ts`
+9. `packages/driver/src/mlx-ml/process/model-specific.test.ts`
+10. `packages/driver/src/mlx-ml/process/completion-prompt-formatting.test.ts`
+
+⭐ = 主要な修正が必要
+
+## 詳細な修正内容
+
+### 1. types.ts
+
+**変更前**:
+```typescript
+export interface ModelSpec {
+  modelName: string;
+  capabilities?: {
+    hasApplyChatTemplate?: boolean;
+    supportsCompletion?: boolean;
+    specialTokens?: Record<string, any>;
+  };
+  // ...
+}
+
+export interface ModelSpecPreset {
+  pattern: RegExp;
+  spec: Partial<ModelSpec>;
+}
+```
+
+**変更後**:
+```typescript
+// capabilities の型を明示化
+export interface MlxCapabilities {
+  hasApplyChatTemplate?: boolean;
+  supportsCompletion?: boolean;
+  specialTokens?: Record<string, any>;
+}
+
+export interface MlxModelConfig {
+  modelName: string;
+  capabilities?: MlxCapabilities;
+  apiStrategy?: ApiStrategy;
+  chatRestrictions?: ChatRestrictions;
+  customProcessor?: ModelCustomProcessor;
+  validatedPatterns?: Map<string, ValidationResult>;
+}
+
+export interface MlxModelConfigPreset {
+  pattern: RegExp;
+  config: Partial<MlxModelConfig>;  // spec → config
+}
+
+// 後方互換性のための型エイリアス（非推奨）
+/** @deprecated Use MlxModelConfig instead */
+export type ModelSpec = MlxModelConfig;
+
+/** @deprecated Use MlxModelConfigPreset instead */
+export type ModelSpecPreset = MlxModelConfigPreset;
+```
+
+### 2. manager.ts
+
+**クラス名**: `ModelSpecManager` → `MlxModelConfigManager`
+
+**主要な変更**:
+```typescript
+// 変更前
+export class ModelSpecManager {
+  private spec: ModelSpec;
+
+  constructor(
+    modelName: string,
+    process: MlxProcess,
+    customSpec?: Partial<ModelSpec>
+  ) { }
+
+  getSpec(): Readonly<ModelSpec> { }
+}
+
+// 変更後
+export class MlxModelConfigManager {
+  private config: MlxModelConfig;  // spec → config
+
+  constructor(
+    modelName: string,
+    process: MlxProcess,
+    customConfig?: Partial<MlxModelConfig>  // customSpec → customConfig
+  ) { }
+
+  getConfig(): Readonly<MlxModelConfig> { }  // getSpec → getConfig
+}
+
+// 後方互換性のための型エイリアス（非推奨）
+/** @deprecated Use MlxModelConfigManager instead */
+export const ModelSpecManager = MlxModelConfigManager;
+```
+
+### 3. presets.ts
+
+**変数名とシグネチャ**:
+```typescript
+// 変更前
+import type { ModelSpecPreset } from './types.js';
+
+export const MODEL_PRESETS: ModelSpecPreset[] = [ /* ... */ ];
+
+export function findPreset(modelName: string): ModelSpecPreset | undefined { }
+
+// 変更後
+import type { MlxModelConfigPreset } from './types.js';
+
+export const MODEL_CONFIG_PRESETS: MlxModelConfigPreset[] = [ /* ... */ ];
+
+export function findPreset(modelName: string): MlxModelConfigPreset | undefined { }
+
+// 後方互換性
+/** @deprecated Use MODEL_CONFIG_PRESETS instead */
+export const MODEL_PRESETS = MODEL_CONFIG_PRESETS;
+```
+
+**プリセット内容**:
+```typescript
+// 変更前
+{
+  pattern: /^gemma-2-2b-it/,
+  spec: {
+    apiStrategy: 'prefer-chat',
+    // ...
+  }
+}
+
+// 変更後
+{
+  pattern: /^gemma-2-2b-it/,
+  config: {  // spec → config
+    apiStrategy: 'prefer-chat',
+    // ...
+  }
+}
+```
+
+### 4. detector.ts
+
+```typescript
+// 変更前
+async detectCapabilities(): Promise<Partial<ModelSpec>> { }
+
+// 変更後
+async detectCapabilities(): Promise<Partial<MlxModelConfig>> { }
+```
+
+### 5. process/index.ts
+
+```typescript
+// 変更前
+import type { ModelSpec, ModelCustomProcessor } from '../model-spec/types.js';
+import { ModelSpecManager } from '../model-spec/manager.js';
+
+export class MlxProcess {
+  private specManager: ModelSpecManager;
+
+  constructor(
+    options: MlxProcessOptions,
+    customSpec?: Partial<ModelSpec>,
+    customProcessor?: ModelCustomProcessor
+  ) {
+    this.specManager = new ModelSpecManager(modelName, this, customSpec, customProcessor);
+  }
+
+  getSpecManager(): ModelSpecManager { }
+}
+
+// 変更後
+import type { MlxModelConfig, ModelCustomProcessor } from '../model-spec/types.js';
+import { MlxModelConfigManager } from '../model-spec/manager.js';
+
+export class MlxProcess {
+  private configManager: MlxModelConfigManager;  // specManager → configManager
+
+  constructor(
+    options: MlxProcessOptions,
+    customConfig?: Partial<MlxModelConfig>,  // customSpec → customConfig
+    customProcessor?: ModelCustomProcessor
+  ) {
+    this.configManager = new MlxModelConfigManager(modelName, this, customConfig, customProcessor);
+  }
+
+  getConfigManager(): MlxModelConfigManager { }  // getSpecManager → getConfigManager
+}
+```
+
+### 6. mlx-driver.ts
+
+```typescript
+// 変更前
+import type { ModelSpec, ModelCustomProcessor } from './model-spec/types.js';
+
+export interface MlxDriverOptions {
+  model: string;
+  modelSpec?: Partial<ModelSpec>;
+  customProcessor?: ModelCustomProcessor;
+  // ...
+}
+
+// 変更後
+import type { MlxModelConfig, ModelCustomProcessor } from './model-spec/types.js';
+
+export interface MlxDriverOptions {
+  model: string;
+  modelConfig?: Partial<MlxModelConfig>;  // modelSpec → modelConfig
+  customProcessor?: ModelCustomProcessor;
+  // ...
+}
+```
+
+### 7. テストファイル
+
+**manager.test.ts**:
+- `ModelSpecManager` → `MlxModelConfigManager`
+- `const spec: Partial<ModelSpec>` → `const config: Partial<MlxModelConfig>`
+
+**その他のテスト**:
+- import文の更新
+- 型アノテーションの更新
+
+## 作業手順
+
+### フェーズ1: 型定義の更新
+1. `types.ts`の更新
+   - `MlxCapabilities`インターフェース追加
+   - `MlxModelConfig`インターフェース追加
+   - `MlxModelConfigPreset`インターフェース追加
+   - 後方互換性エイリアス追加
+
+### フェーズ2: コア実装の更新
+2. `manager.ts`の更新
+   - クラス名変更
+   - プロパティ名変更（spec → config）
+   - メソッド名変更（getSpec → getConfig）
+   - 後方互換性エイリアス追加
+
+3. `presets.ts`の更新
+   - 定数名変更
+   - プリセット構造更新（spec → config）
+
+4. `detector.ts`の更新
+   - 戻り値型の更新
+
+### フェーズ3: 使用側の更新
+5. `process/index.ts`の更新
+   - プロパティ名変更（specManager → configManager）
+   - メソッド名変更
+
+6. `mlx-driver.ts`の更新
+   - オプション型の更新（modelSpec → modelConfig）
+
+### フェーズ4: テストの更新
+7. すべてのテストファイルの更新
+   - import文
+   - 型アノテーション
+   - 変数名
+
+### フェーズ5: 検証
+8. 型チェック: `npm run typecheck`
+9. テスト実行: `npm test`
+10. ビルド確認: `npm run build`
+
+### フェーズ6: クリーンアップ（後日）
+11. 後方互換性エイリアスの削除
+12. ドキュメントの更新
+
+## 後方互換性
+
+### 一時的な型エイリアス（非推奨マーク付き）
+
+```typescript
+/** @deprecated Use MlxModelConfig instead */
+export type ModelSpec = MlxModelConfig;
+
+/** @deprecated Use MlxModelConfigManager instead */
+export const ModelSpecManager = MlxModelConfigManager;
+
+/** @deprecated Use MODEL_CONFIG_PRESETS instead */
+export const MODEL_PRESETS = MODEL_CONFIG_PRESETS;
+```
+
+### 削除タイミング
+
+次のメジャーバージョン（v1.0.0など）でエイリアスを削除
+
+## 確認事項
+
+- [ ] すべてのファイルが修正された
+- [ ] 型チェックが通る
+- [ ] すべてのテストがパスする
+- [ ] ビルドが成功する
+- [ ] ドキュメント更新（docs/mlx-api-selection.md など）
+
+## 注意点
+
+1. **ModelSpecificProcessor は変更しない**
+   - これは別の概念（モデル固有の処理）
+   - `process/model-specific.ts`で定義
+
+2. **driver-registry の ModelSpec は無関係**
+   - 別の型定義なので影響なし
+
+3. **段階的な移行**
+   - 一時的に両方の名前が共存
+   - @deprecated マークで移行を促す

--- a/prompts/memos/modelspec-comparison.v1.md
+++ b/prompts/memos/modelspec-comparison.v1.md
@@ -1,0 +1,340 @@
+# ModelSpec 比較分析
+
+## 概要
+
+2つの`ModelSpec`型が存在し、同名だが目的と内容が異なる。
+
+---
+
+## 1. MLX専用ModelSpec
+
+**ファイル**: `packages/driver/src/mlx-ml/model-spec/types.ts`
+
+**目的**: MLXドライバー内部でのchat/completion API選択制御
+
+### 保持項目
+
+| 項目 | 型 | 説明 | データソース |
+|------|-----|------|------------|
+| `modelName` | `string` | モデル名/ID | 必須、ユーザー指定 |
+| `capabilities` | `object` | 機能情報 | Pythonランタイムから動的取得 |
+| `capabilities.hasApplyChatTemplate` | `boolean?` | chat template利用可能か | Python |
+| `capabilities.supportsCompletion` | `boolean?` | completion API対応か | Python |
+| `capabilities.specialTokens` | `Record<string, any>?` | 特殊トークン情報 | Python |
+| `apiStrategy` | `ApiStrategy?` | API選択戦略 | プリセット/カスタム設定 |
+| `chatRestrictions` | `ChatRestrictions?` | chat制限 | プリセット/カスタム設定 |
+| `customProcessor` | `ModelCustomProcessor?` | カスタム処理 | カスタム設定のみ |
+| `validatedPatterns` | `Map?` | 検証済みパターンキャッシュ | 実行時生成 |
+
+### ApiStrategy（5種類）
+- `auto` - 自動判定
+- `prefer-chat` - chat優先
+- `prefer-completion` - completion優先
+- `force-chat` - 常にchat
+- `force-completion` - 常にcompletion
+
+### ChatRestrictions（5項目）
+- `singleSystemAtStart` - systemメッセージは先頭に1つだけ
+- `alternatingTurns` - user/assistant交互
+- `requiresUserLast` - 最後はuser
+- `maxSystemMessages` - systemメッセージ最大数
+- `allowEmptyMessages` - 空メッセージ許可
+
+### ModelCustomProcessor（4メソッド）
+- `preprocessMessages` - メッセージ前処理
+- `preprocessCompletion` - completionプロンプト前処理
+- `validateMessages` - メッセージ検証
+- `determineApi` - カスタムAPI選択ロジック（削除予定）
+
+### 特徴
+- **MLX固有**: chat/completion選択に特化
+- **動的検出**: Pythonプロセスから実行時に機能を取得
+- **制約管理**: 各モデルのchat制限を詳細に管理
+- **プリセット**: よく知られたモデルの設定を事前定義
+- **実行時最適化**: メッセージパターンに基づいて最適なAPIを選択
+
+---
+
+## 2. 汎用ModelSpec（ドライバーレジストリ）
+
+**ファイル**: `packages/driver/src/driver-registry/types.ts`
+
+**目的**: 全ドライバー横断的なモデル選択・管理
+
+### 保持項目
+
+| 項目 | 型 | 説明 | データソース |
+|------|-----|------|------------|
+| `model` | `string` | モデル識別子 | 必須、設定ファイル |
+| `provider` | `DriverProvider` | プロバイダー名 | 必須、設定ファイル |
+| `capabilities` | `DriverCapability[]` | 能力フラグ配列 | 設定ファイル |
+| `maxInputTokens` | `number?` | 最大入力トークン数 | 設定ファイル |
+| `maxOutputTokens` | `number?` | 最大出力トークン数 | 設定ファイル |
+| `maxTotalTokens` | `number?` | 合計最大トークン数 | 設定ファイル |
+| `tokensPerMinute` | `number?` | TPM制限 | 設定ファイル |
+| `requestsPerMinute` | `number?` | RPM制限 | 設定ファイル |
+| `cost.input` | `number?` | 入力コスト（$/1Kトークン） | 設定ファイル |
+| `cost.output` | `number?` | 出力コスト（$/1Kトークン） | 設定ファイル |
+| `priority` | `number?` | 優先度 | 設定ファイル |
+| `enabled` | `boolean?` | 有効/無効 | 設定ファイル |
+| `metadata` | `Record<string, unknown>?` | カスタムメタデータ | 設定ファイル |
+
+### DriverCapability（15種類）
+- `streaming` - ストリーミング対応
+- `local` - ローカル実行可能
+- `fast` - 高速応答
+- `large-context` - 大規模コンテキスト
+- `multilingual` - 多言語対応
+- `japanese` - 日本語特化
+- `coding` - コーディング特化
+- `reasoning` - 推論・思考特化
+- `chat` - チャット特化
+- `tools` - ツール使用可能
+- `vision` - 画像認識可能
+- `audio` - 音声処理可能
+- `structured` - 構造化出力対応
+- `json` - JSON出力対応
+- `function-calling` - 関数呼び出し対応
+
+### DriverProvider（7種類）
+- `openai`
+- `anthropic`
+- `vertexai`
+- `mlx`
+- `ollama`
+- `echo`（テスト用）
+- `test`（ユニットテスト用）
+
+### 特徴
+- **ドライバー横断**: 全プロバイダー共通の情報
+- **静的定義**: 設定ファイルで事前定義
+- **リソース管理**: token制限、コスト、レート制限
+- **モデル選択**: 条件に基づいて最適なモデルを選択
+- **ビジネスロジック**: コスト最適化、優先度管理
+
+---
+
+## 比較表
+
+| 観点 | MLX専用ModelSpec | 汎用ModelSpec |
+|------|------------------|--------------|
+| **スコープ** | MLXドライバー内部のみ | 全ドライバー横断 |
+| **目的** | API選択制御（chat vs completion） | モデル選択・管理 |
+| **データソース** | 動的検出（Python）+ プリセット | 静的設定（設定ファイル） |
+| **更新頻度** | 実行時に動的変化 | 基本的に静的 |
+| **管理対象** | 技術的制約（chat制限など） | ビジネス的属性（コスト、制限など） |
+| **詳細度** | 実行時の詳細な挙動 | モデルの一般的特性 |
+| **粒度** | モデル実装レベル | モデル選択レベル |
+
+---
+
+## 項目の重複/類似性
+
+### 重複している概念
+
+1. **モデル識別子**
+   - MLX: `modelName: string`
+   - 汎用: `model: string`
+   - **内容**: 同じ（モデルのID）
+
+2. **capabilities（能力）**
+   - MLX: `capabilities: { hasApplyChatTemplate?, supportsCompletion?, ... }`
+   - 汎用: `capabilities: DriverCapability[]`
+   - **内容**: 異なる
+     - MLX: 技術的な機能有無（boolean）
+     - 汎用: 高レベルな能力フラグ（文字列配列）
+
+### 独自の項目
+
+**MLX専用のみ**:
+- `apiStrategy` - API選択戦略
+- `chatRestrictions` - chat制限の詳細
+- `customProcessor` - カスタム処理
+- `validatedPatterns` - キャッシュ
+- `capabilities.specialTokens` - 特殊トークン
+
+**汎用のみ**:
+- `provider` - プロバイダー名
+- `maxInputTokens / maxOutputTokens` - トークン制限
+- `tokensPerMinute / requestsPerMinute` - レート制限
+- `cost` - コスト情報
+- `priority` - 優先度
+- `enabled` - 有効/無効フラグ
+- `metadata` - カスタムメタデータ
+
+---
+
+## 使用コンテキスト
+
+### MLX専用ModelSpec
+
+**生成タイミング**:
+1. `MlxDriver`のコンストラクタ
+2. プリセットとカスタム設定をマージ
+3. `initialize()`で動的検出結果をマージ
+
+**使用箇所**:
+- `ModelSpecManager` - API選択の判断
+- `MlxProcess` - メッセージ検証
+- `createModelSpecificProcessor()` - モデル固有処理
+
+**ライフサイクル**: ドライバーインスタンスのライフタイム
+
+### 汎用ModelSpec
+
+**生成タイミング**:
+- 設定ファイル読み込み時
+- プログラマティックな登録時
+
+**使用箇所**:
+- `DriverRegistry` - モデル登録・選択
+- `DriverFactory` - ドライバー生成の引数
+- `selectModel()` - 条件に基づくモデル選択
+
+**ライフサイクル**: アプリケーション全体（通常は静的）
+
+---
+
+## 統一 vs 名前変更の検討
+
+### オプション1: 統一する
+
+**メリット**:
+- 型の一貫性
+- インターフェースの統一
+- 理解しやすい
+
+**デメリット**:
+- 用途が異なる情報を1つの型に混在させる
+- MLX固有の詳細情報が他のドライバーには不要
+- 動的vs静的の性質の違いを無視することになる
+
+**実現方法**:
+```typescript
+// 統一されたModelSpec
+export interface ModelSpec {
+  // 共通項目
+  model: string;
+  provider?: DriverProvider;
+
+  // 汎用ドライバー情報
+  capabilities?: DriverCapability[];
+  maxInputTokens?: number;
+  cost?: { input: number; output: number };
+  // ...
+
+  // MLX固有情報（mlxの場合のみ使用）
+  mlxConfig?: {
+    apiStrategy?: ApiStrategy;
+    chatRestrictions?: ChatRestrictions;
+    // ...
+  };
+}
+```
+
+### オプション2: 名前を変更する
+
+**メリット**:
+- 用途が明確
+- 責務の分離
+- それぞれ独立して進化可能
+
+**デメリット**:
+- 名前の選定が必要
+- 既存コードの修正が必要
+
+**候補案**:
+
+1. **役割ベース命名**
+   - MLX: `MlxRuntimeConfig` または `MlxBehaviorSpec`
+   - 汎用: `ModelSpec`（そのまま）
+
+2. **レイヤーベース命名**
+   - MLX: `ModelRuntimeSpec` または `ModelExecutionSpec`
+   - 汎用: `ModelRegistrySpec` または `ModelCatalogSpec`
+
+3. **スコープベース命名**
+   - MLX: `MlxModelSpec`
+   - 汎用: `DriverModelSpec`
+
+---
+
+## 推奨案
+
+### 推奨: **オプション2 - 名前変更**
+
+**理由**:
+1. **関心の分離**: 2つは全く異なる目的を持つ
+   - MLX: 実行時のAPI選択制御
+   - 汎用: モデルカタログ管理
+
+2. **データソースの違い**:
+   - MLX: 動的検出（実行時に変化）
+   - 汎用: 静的設定（変化しない）
+
+3. **スコープの違い**:
+   - MLX: ドライバー内部実装の詳細
+   - 汎用: ドライバー横断的な抽象
+
+4. **将来性**: 他のドライバーも同様の実行時設定が必要になる可能性は低い
+
+### 具体的な提案
+
+**MLX専用**:
+```typescript
+// packages/driver/src/mlx-ml/model-spec/types.ts
+export interface MlxModelConfig {  // ModelSpec → MlxModelConfig
+  modelName: string;
+  capabilities?: MlxCapabilities;  // より具体的な名前
+  apiStrategy?: ApiStrategy;
+  chatRestrictions?: ChatRestrictions;
+  customProcessor?: ModelCustomProcessor;
+  validatedPatterns?: Map<string, ValidationResult>;
+}
+
+export interface MlxCapabilities {  // 新規: capabilitiesの型を明示
+  hasApplyChatTemplate?: boolean;
+  supportsCompletion?: boolean;
+  specialTokens?: Record<string, any>;
+}
+```
+
+**汎用**:
+```typescript
+// packages/driver/src/driver-registry/types.ts
+export interface ModelSpec {  // そのまま
+  model: string;
+  provider: DriverProvider;
+  capabilities: DriverCapability[];
+  // ... 現状維持
+}
+```
+
+### リネーム影響範囲
+
+**MLX内部のみ**:
+- `packages/driver/src/mlx-ml/model-spec/` 配下
+- `packages/driver/src/mlx-ml/process/` 配下
+- `packages/driver/src/mlx-ml/mlx-driver.ts`
+
+**driver-registry**: 影響なし
+
+---
+
+## まとめ
+
+### 結論
+- **2つのModelSpecは統一すべきではない**
+- **MLX専用を`MlxModelConfig`にリネームすることを推奨**
+
+### 次のステップ
+1. リネームの承認を得る
+2. リネーム実施計画の策定
+3. 段階的な移行（型エイリアスで互換性維持）
+
+### 理由
+1. 用途・目的が根本的に異なる
+2. データソース・ライフサイクルが異なる
+3. スコープ・責務が異なる
+4. 統一すると両方の型が肥大化・複雑化する
+5. 独立した進化が可能になる


### PR DESCRIPTION
## 概要
Outputセクションでschema専用のdescriptionを削除し、デフォルトのdescriptionを使用するように変更しました。

## 背景
- JSONフォーマットがあってもreasoningを出力したい場合がある
- ```json{...}```を抽出してstructuredOutputを得る機構があるため、reasoning + JSONの方が精度が高くなる可能性がある
- 「JSON文字列を出せ」という指示が邪魔になってしまう
- Instructionsセクションですでにスキーマに従うように指示しているため、Outputセクションでの重複指示は不要

## 変更内容
- `completion-formatter.ts`: Output sectionの条件分岐を削除し、デフォルトdescriptionを使用
- `converter.ts`: Output sectionの条件分岐を簡素化し、デフォルトdescriptionを使用
- デフォルトdescription: "This section is where you write your response."

## テスト
- All 243 tests passed

## バージョン
- 0.3.4 → 0.3.5