### PR TITLE
feat: リリースCI/CDワークフローを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build all packages
+      run: npm run build
+
+    - name: Run tests
+      run: npm run test:run
+
+    - name: Run type check
+      run: npm run typecheck
+
+    - name: Run linter
+      run: npm run lint
+
+    - name: Extract version from tag
+      id: version
+      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+    - name: Extract release notes
+      id: release_notes
+      run: |
+        VERSION=${{ steps.version.outputs.VERSION }}
+        if [ -f CHANGELOG.md ]; then
+          # Extract the section for this version from CHANGELOG.md
+          NOTES=$(awk "/## \[${VERSION}\]/,/## \[/" CHANGELOG.md | sed '$d' | tail -n +2)
+          if [ -z "$NOTES" ]; then
+            NOTES="リリース v${VERSION}"
+          fi
+        else
+          NOTES="リリース v${VERSION}"
+        fi
+        echo "NOTES<<EOF" >> $GITHUB_OUTPUT
+        echo "$NOTES" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ github.ref }}
+        name: v${{ steps.version.outputs.VERSION }}
+        body: ${{ steps.release_notes.outputs.NOTES }}
+        draft: false
+        prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
+
+    - name: Publish to npm (with Trusted Publisher)
+      run: npm publish --workspaces --access public --provenance
+      # Note: Using npm Trusted Publisher (OIDC)
+      # No NPM_TOKEN needed - authentication via id-token: write permission
+      # Configure Trusted Publisher on npmjs.com for each package before first release


### PR DESCRIPTION
## 概要

GitHub Actionsによる自動リリースワークフローを導入しました。

## 変更内容

### 新規ファイル
- `.github/workflows/release.yml` - リリース自動化ワークフロー

### 更新ファイル
- `prompts/RELEASE_GUIDE.md` - CI/CDセクションとTrusted Publisher設定手順を追加

## 機能

### 自動リリースワークフロー
- **トリガー**: `v*`形式のタグがpushされた時
- **処理フロー**:
  1. テスト・ビルド・型チェック・Lint実行
  2. CHANGELOG.mdからリリースノートを自動抽出
  3. GitHubリリースを作成
  4. 全ワークスペースパッケージをnpmに公開（provenance付き）

### npm Trusted Publisher (OIDC) 対応
- npmトークン不要で安全に公開
- provenanceが自動生成
- トークン漏洩リスクなし

## リリース手順（CI利用時）

```bash
# 1. バージョン更新とCHANGELOG編集
npm version patch --no-git-tag-version
# CHANGELOG.mdを編集

# 2. PRを作成してマージ
git checkout -b release/v0.x.x
git add .
git commit -m "chore: バージョンを0.x.xに更新"
git push -u origin release/v0.x.x
gh pr create --title "chore: v0.x.xリリース" --body "..."

# 3. タグをpush（CIが自動実行）
git checkout main
git pull origin main
git tag v0.x.x
git push origin v0.x.x
```

## 必要な設定

パッケージのTrusted Publisher設定は完了済みです。

## 確認項目
- [ ] ワークフローファイルの内容確認
- [ ] リリースガイドの記載内容確認
- [ ] Trusted Publisher設定の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)