### PR TITLE
fix(packages): package.jsonにrepositoryフィールドを追加

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -48,5 +48,10 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/otolab/moduler-prompt.git",
+    "directory": "packages/driver"
   }
 }

--- a/packages/simple-chat/package.json
+++ b/packages/simple-chat/package.json
@@ -45,5 +45,10 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/otolab/moduler-prompt.git",
+    "directory": "packages/simple-chat"
   }
 }


### PR DESCRIPTION
## 問題

Trusted Publisher使用時の`--provenance`フラグがpackage.jsonの`repository.url`を検証するため、以下のパッケージでnpm publishが失敗していました:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle: 
Failed to validate repository information: package.json: "repository.url" is "", 
expected to match "https://github.com/otolab/moduler-prompt" from provenance
```

## 修正内容

以下のパッケージに`repository`フィールドを追加:
- `@moduler-prompt/driver`
- `@moduler-prompt/simple-chat`

他のパッケージ(core, utils, process)は既に設定済みでした。

## 検証

- [ ] マージ後、release/0.4.1の再実行でnpm publishが成功することを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)