### PR TITLE
chore: add changeset for GoogleGenAI driver improvements

### DIFF
--- a/.changeset/googlegenai-element-to-parts.md
+++ b/.changeset/googlegenai-element-to-parts.md
@@ -1,0 +1,11 @@
+---
+"@moduler-prompt/driver": patch
+---
+
+GoogleGenAI driver improvements: Element to Parts/Content mapping and model update
+
+- Implement proper Element to Parts/Content conversion for Gemini API
+- Map instructions to systemInstruction (Part[]) and data to contents (Content[])
+- Add role conversion: assistant→model, system→user
+- Add integration tests for Element conversion
+- Update default model from gemini-2.0-flash-exp to gemma-3-27b for better stability


### PR DESCRIPTION
## 概要

GoogleGenAI driverの改善に対するchangesetを追加します。

## 変更内容

- Element to Parts/Content mapping の実装
- systemInstruction と contents の分離
- Role変換 (assistant→model, system→user)
- Integration tests の追加
- デフォルトモデルを gemma-3-27b に変更

## 関連

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)