### PR TITLE
fix: version-update.ymlでvの有無に対応

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -47,9 +47,9 @@ jobs:
         # 1. changesetでパッケージのバージョンとCHANGELOGを更新
         pnpm changeset version
 
-        # 2. ブランチ名からバージョンを抽出してrootを更新
+        # 2. ブランチ名からバージョンを抽出してrootを更新（vの有無に対応）
         BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-        if [[ "$BRANCH_NAME" =~ ^release/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+        if [[ "$BRANCH_NAME" =~ ^release/v?([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
           VERSION="${BASH_REMATCH[1]}"
           node -e "
             const fs = require('fs');


### PR DESCRIPTION
## 修正内容

release/ブランチ名のバージョン抽出正規表現を修正しました。

**変更前**: `^release/([0-9]+\.[0-9]+\.[0-9]+)$`
**変更後**: `^release/v?([0-9]+\.[0-9]+\.[0-9]+)$`

これにより、以下の両方に対応します：
- `release/0.5.0`
- `release/v0.5.0`

## 目的

リリースブランチ名の柔軟性向上