### PR TITLE
feat: Improve release workflow with validation and order fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,39 @@ jobs:
       id: version
       run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+    - name: Validate version
+      run: |
+        VERSION="${{ steps.version.outputs.VERSION }}"
+
+        # 1. 形式チェック: セマンティックバージョニング形式か（X.Y.Z）
+        if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "❌ Invalid version format: $VERSION"
+          echo "Version must follow semantic versioning (e.g., 1.2.3)"
+          exit 1
+        fi
+        echo "✅ Version format is valid: $VERSION"
+
+        # 2. タグ重複チェック: 既存のタグと重複していないか
+        if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+          echo "❌ Tag v$VERSION already exists"
+          echo "Please use a different version number"
+          exit 1
+        fi
+        echo "✅ Tag v$VERSION does not exist"
+
+        # 3. バージョン順序性チェック: 最新のタグより大きいバージョンか
+        LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+        LATEST_VERSION=${LATEST_TAG#v}
+        echo "Latest version: $LATEST_VERSION"
+
+        # semverの比較（npx semver使用）
+        if ! npx semver "$VERSION" -r ">$LATEST_VERSION" >/dev/null 2>&1; then
+          echo "❌ Version $VERSION is not greater than $LATEST_VERSION"
+          echo "New version must be greater than the latest version"
+          exit 1
+        fi
+        echo "✅ Version $VERSION is greater than $LATEST_VERSION"
+
     - name: Extract release notes
       id: release_notes
       run: |
@@ -67,22 +100,6 @@ jobs:
         echo "NOTES<<EOF" >> $GITHUB_OUTPUT
         echo "$NOTES" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
-
-    - name: Create git tag
-      run: |
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git config --global user.name "github-actions[bot]"
-        git tag -a "v${{ steps.version.outputs.VERSION }}" -m "Release v${{ steps.version.outputs.VERSION }}"
-        git push origin "v${{ steps.version.outputs.VERSION }}"
-
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: v${{ steps.version.outputs.VERSION }}
-        name: v${{ steps.version.outputs.VERSION }}
-        body: ${{ steps.release_notes.outputs.NOTES }}
-        draft: false
-        prerelease: ${{ contains(steps.version.outputs.VERSION, 'alpha') || contains(steps.version.outputs.VERSION, 'beta') }}
 
     - name: Publish changed packages to npm
       run: |
@@ -117,3 +134,19 @@ jobs:
       # Note: Using npm Trusted Publisher (OIDC)
       # Authentication via id-token: write permission (no NODE_AUTH_TOKEN needed)
       # Configure Trusted Publisher on npmjs.com for each package before first release
+
+    - name: Create git tag
+      run: |
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+        git tag -a "v${{ steps.version.outputs.VERSION }}" -m "Release v${{ steps.version.outputs.VERSION }}"
+        git push origin "v${{ steps.version.outputs.VERSION }}"
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: v${{ steps.version.outputs.VERSION }}
+        name: v${{ steps.version.outputs.VERSION }}
+        body: ${{ steps.release_notes.outputs.NOTES }}
+        draft: false
+        prerelease: ${{ contains(steps.version.outputs.VERSION, 'alpha') || contains(steps.version.outputs.VERSION, 'beta') }}

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -32,9 +32,17 @@ jobs:
     - name: Check for changesets
       id: changesets
       run: |
-        if [ -n "$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
+        # コミットメッセージに [skip-changeset] が含まれている場合はスキップ
+        COMMIT_MSG=$(git log -1 --pretty=%B)
+        if [[ "$COMMIT_MSG" =~ \[skip-changeset\] ]]; then
+          echo "skip_changeset=true" >> $GITHUB_OUTPUT
+          echo "has_changesets=false" >> $GITHUB_OUTPUT
+          echo "ℹ️ Skipping changeset check (found [skip-changeset] in commit message)"
+        elif [ -n "$(ls -A .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
+          echo "skip_changeset=false" >> $GITHUB_OUTPUT
           echo "has_changesets=true" >> $GITHUB_OUTPUT
         else
+          echo "skip_changeset=false" >> $GITHUB_OUTPUT
           echo "has_changesets=false" >> $GITHUB_OUTPUT
         fi
 
@@ -70,24 +78,66 @@ jobs:
           git push
         fi
 
+    - name: Update root version only (when skipping changeset)
+      if: steps.changesets.outputs.skip_changeset == 'true'
+      run: |
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+
+        # ブランチ名からバージョンを抽出してrootを更新
+        BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+        if [[ "$BRANCH_NAME" =~ ^release/v?([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+          VERSION="${BASH_REMATCH[1]}"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "Updated root package.json to version $VERSION (changeset skipped)"
+
+          # 変更をコミット・push
+          if [ -n "$(git status --porcelain)" ]; then
+            git add package.json
+            git commit -m "chore: update root version to $VERSION [skip-changeset]"
+            git push
+          fi
+        else
+          echo "⚠️ Invalid branch name format: $BRANCH_NAME"
+          exit 1
+        fi
+
     - name: Create or update PR
-      if: steps.changesets.outputs.has_changesets == 'true'
+      if: steps.changesets.outputs.has_changesets == 'true' || steps.changesets.outputs.skip_changeset == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         VERSION=$(node -p "require('./package.json').version")
         BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+        SKIP_CHANGESET="${{ steps.changesets.outputs.skip_changeset }}"
 
         # PRが既に存在するか確認
         PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --json number -q '.[0].number')
 
         if [ -z "$PR_NUMBER" ]; then
-          # 新規PR作成
-          gh pr create \
-            --base main \
-            --head "$BRANCH_NAME" \
-            --title "Release v$VERSION" \
-            --body "## 🚀 Release v$VERSION
+          # PRボディを生成
+          if [ "$SKIP_CHANGESET" = "true" ]; then
+            PR_BODY="## 🚀 Release v$VERSION
+
+        このPRはrelease/$VERSIONブランチからの自動生成です。
+
+        ### 変更内容
+        - ルートパッケージバージョンの更新のみ
+        - ⚠️ changesetスキップモード
+
+        ### マージ後の動作
+        - mainブランチへのマージ時に自動的にnpmへ公開されます
+
+        ### 確認事項
+        - [ ] バージョン番号が正しいか
+        - [ ] すべてのテストがパスしているか"
+          else
+            PR_BODY="## 🚀 Release v$VERSION
 
         このPRはrelease/$VERSIONブランチからの自動生成です。
 
@@ -102,13 +152,22 @@ jobs:
         - [ ] CHANGELOGの内容が正しいか
         - [ ] バージョン番号が正しいか
         - [ ] すべてのテストがパスしているか"
+          fi
+
+          # 新規PR作成
+          gh pr create \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "Release v$VERSION" \
+            --body "$PR_BODY"
         else
           echo "PR #$PR_NUMBER already exists for $BRANCH_NAME"
         fi
 
     - name: No changesets found
-      if: steps.changesets.outputs.has_changesets == 'false'
+      if: steps.changesets.outputs.has_changesets == 'false' && steps.changesets.outputs.skip_changeset == 'false'
       run: |
         echo "⚠️ .changesetディレクトリにchangesetファイルが見つかりません"
         echo "リリース前に 'npx changeset' で変更内容を記録してください"
+        echo "または、コミットメッセージに [skip-changeset] を含めてchangesetをスキップしてください"
         exit 1


### PR DESCRIPTION
## 概要

リリースワークフローを改善し、v0.2.0で発生した問題を防ぐための修正です。

## 主な変更

### 1. changesetスキップオプション追加 (version-update.yml)

コミットメッセージに `[skip-changeset]` を含めることで、changesetなしでリリース可能に。

**使用例:**
```bash
git commit -m "chore: prepare release [skip-changeset]"
```

### 2. バージョン妥当性チェック追加 (release.yml)

リリース前に以下をチェック:
- ✅ セマンティックバージョニング形式 (X.Y.Z)
- ✅ タグ重複チェック（既存タグとの重複を防ぐ）
- ✅ バージョン順序性（最新タグより大きいバージョンか）

**今回のv0.2.0問題を防げます**

### 3. 処理順序の変更 (release.yml)

**変更前:**
1. Gitタグ作成 ← 先
2. GitHubリリース作成
3. npm publish ← 後

**変更後:**
1. npm publish ← 先
2. Gitタグ作成
3. GitHubリリース作成 ← 後

**メリット:**
- publishが失敗してもタグは作られない
- タグの存在 = npm公開完了を保証
- リカバリーが容易

## 確認事項

- [ ] CI/CDワークフローの修正内容が正しい
- [ ] changesetスキップ機能が適切に動作する
- [ ] バージョンチェックが適切に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>