### PR TITLE
fix: Add fetch-depth to get all tags for version validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # 全履歴を取得（タグ比較に必要）
 
     - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## 問題

PR #77でバージョンチェックが失敗:
- `git describe --tags --abbrev=0` がタグを見つけられない
- `fetch-tags: false` と `--no-tags` のため、タグが取得されていない

## 修正

`release.yml` の checkout に `fetch-depth: 0` を追加:
- 全履歴とタグを取得
- バージョン順序性チェックが正常に動作

## 確認

この修正をマージ後、PR #77を再実行してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>