### PR TITLE
fix: Fix version comparison in release workflow using semver package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,13 @@ jobs:
         LATEST_VERSION=${LATEST_TAG#v}
         echo "Latest version: $LATEST_VERSION"
 
-        # semverの比較（npx semver使用）
-        if ! npx semver "$VERSION" -r ">$LATEST_VERSION" >/dev/null 2>&1; then
+        # semverの比較（Node.jsスクリプトを使用）
+        COMPARISON=$(node -p "
+          const semver = require('semver');
+          semver.gt('$VERSION', '$LATEST_VERSION') ? 'true' : 'false'
+        ")
+
+        if [ "$COMPARISON" != "true" ]; then
           echo "❌ Version $VERSION is not greater than $LATEST_VERSION"
           echo "New version must be greater than the latest version"
           exit 1

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@changesets/cli": "^2.29.8",
     "@types/node": "^20.0.0",
     "@vitest/ui": "^3.2.4",
+    "semver": "^7.7.3",
     "typescript": "^5.0.0",
     "vitest": "^3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
+      semver:
+        specifier: ^7.7.3
+        version: 7.7.3
       typescript:
         specifier: ^5.0.0
         version: 5.9.3


### PR DESCRIPTION
## 問題

リリースワークフローのバージョン比較が失敗していました。

### 原因
- `npx semver`コマンドがCI環境で失敗
- semverパッケージがプロジェクトの依存関係に含まれていなかった

## 解決策

1. **semverをdevDependenciesに追加**
   - `semver ^7.7.3`を追加

2. **バージョン比較ロジックを修正**
   - `npx semver`の代わりにNode.jsスクリプトで実装
   - `require('semver')`でパッケージを読み込み、`semver.gt()`で比較

## 変更内容

- `package.json`: semverを追加
- `.github/workflows/release.yml`: バージョン比較ロジックを修正

## テスト

ローカルで動作確認済み：
```bash
$ node -p "const semver = require('semver'); semver.gt('0.6.0', '0.5.0') ? 'true' : 'false'"
true
```