### PR TITLE
refactor: Move version validation from Release to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,67 @@ jobs:
         path: |
           packages/*/coverage/
         retention-days: 7
+
+  validate-release-version:
+    # release/*ブランチからのPRの場合のみ実行
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # 全履歴を取得（タグ比較に必要）
+
+    - uses: pnpm/action-setup@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Extract version from package.json
+      id: version
+      run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+    - name: Validate version
+      run: |
+        VERSION="${{ steps.version.outputs.VERSION }}"
+
+        # 1. 形式チェック: セマンティックバージョニング形式か（X.Y.Z）
+        if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "❌ Invalid version format: $VERSION"
+          echo "Version must follow semantic versioning (e.g., 1.2.3)"
+          exit 1
+        fi
+        echo "✅ Version format is valid: $VERSION"
+
+        # 2. タグ重複チェック: 既存のタグと重複していないか
+        if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+          echo "❌ Tag v$VERSION already exists"
+          echo "Please use a different version number"
+          exit 1
+        fi
+        echo "✅ Tag v$VERSION does not exist"
+
+        # 3. バージョン順序性チェック: 最新のタグより大きいバージョンか
+        LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+        LATEST_VERSION=${LATEST_TAG#v}
+        echo "Latest version: $LATEST_VERSION"
+
+        # semverの比較（Node.jsスクリプトを使用）
+        COMPARISON=$(node -p "
+          const semver = require('semver');
+          semver.gt('$VERSION', '$LATEST_VERSION') ? 'true' : 'false'
+        ")
+
+        if [ "$COMPARISON" != "true" ]; then
+          echo "❌ Version $VERSION is not greater than $LATEST_VERSION"
+          echo "New version must be greater than the latest version"
+          exit 1
+        fi
+        echo "✅ Version $VERSION is greater than $LATEST_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # 全履歴を取得（タグ比較に必要）
 
     - uses: pnpm/action-setup@v4
 
@@ -52,44 +50,6 @@ jobs:
     - name: Extract version from package.json
       id: version
       run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-    - name: Validate version
-      run: |
-        VERSION="${{ steps.version.outputs.VERSION }}"
-
-        # 1. 形式チェック: セマンティックバージョニング形式か（X.Y.Z）
-        if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "❌ Invalid version format: $VERSION"
-          echo "Version must follow semantic versioning (e.g., 1.2.3)"
-          exit 1
-        fi
-        echo "✅ Version format is valid: $VERSION"
-
-        # 2. タグ重複チェック: 既存のタグと重複していないか
-        if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-          echo "❌ Tag v$VERSION already exists"
-          echo "Please use a different version number"
-          exit 1
-        fi
-        echo "✅ Tag v$VERSION does not exist"
-
-        # 3. バージョン順序性チェック: 最新のタグより大きいバージョンか
-        LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-        LATEST_VERSION=${LATEST_TAG#v}
-        echo "Latest version: $LATEST_VERSION"
-
-        # semverの比較（Node.jsスクリプトを使用）
-        COMPARISON=$(node -p "
-          const semver = require('semver');
-          semver.gt('$VERSION', '$LATEST_VERSION') ? 'true' : 'false'
-        ")
-
-        if [ "$COMPARISON" != "true" ]; then
-          echo "❌ Version $VERSION is not greater than $LATEST_VERSION"
-          echo "New version must be greater than the latest version"
-          exit 1
-        fi
-        echo "✅ Version $VERSION is greater than $LATEST_VERSION"
 
     - name: Extract release notes
       id: release_notes


### PR DESCRIPTION
## 問題

現在のリリースフローでは、release/*ブランチのPRをマージ**後**にバージョン検証が実行されます。検証が失敗した場合、既にマージ済みなので修正が困難です。

## 解決策

バージョン検証をPR作成時（CIワークフロー）に移動しました。

### 変更前
```
1. release/0.6.0ブランチをpush
2. PRを作成
3. PRをマージ
4. ❌ Releaseワークフローでバージョン検証 → 失敗したら手遅れ
```

### 変更後
```
1. release/0.6.0ブランチをpush
2. PRを作成
3. ✅ CIワークフローでバージョン検証 → 失敗したらマージ前に修正可能
4. PRをマージ
5. Releaseワークフローで公開（検証済みなので安全）
```

## 変更内容

### CIワークフロー (`.github/workflows/ci.yml`)
- **新規ジョブ追加**: `validate-release-version`
  - release/*ブランチからのPRの場合のみ実行
  - バージョン形式チェック（セマンティックバージョニング）
  - タグ重複チェック
  - バージョン順序性チェック（最新タグより大きいか）

### Releaseワークフロー (`.github/workflows/release.yml`)
- **削除**: バージョン検証ステップ（CI側でチェック済み）
- **削除**: 不要な`fetch-depth: 0`（タグ比較不要）

## メリット

✅ PRマージ前に不正なバージョンを検出
✅ 検証失敗時の修正が容易（マージ前）
✅ Releaseワークフローがシンプルに
✅ 安全性の向上（マージ = リリース可能なことが保証される）