### PR TITLE
feat: add defaultOptions getter/setter to all drivers

### DIFF
--- a/.changeset/mutable-defaultoptions.md
+++ b/.changeset/mutable-defaultoptions.md
@@ -1,0 +1,7 @@
+---
+"@modular-prompt/driver": minor
+---
+
+ドライバーのdefaultOptionsを動的に変更可能にするgetter/setterを追加
+
+全てのドライバー（OpenAI、Anthropic、VertexAI、GoogleGenAI、MLX）でdefaultOptionsプロパティにgetter/setterを実装し、ドライバーインスタンス生成後に設定を動的に変更できるようにしました。これにより、ModelSpec.maxOutputTokensを使用してdefaultOptions.maxTokensを設定するなどのユースケースが可能になります。

--- a/packages/driver/src/anthropic/anthropic-driver.ts
+++ b/packages/driver/src/anthropic/anthropic-driver.ts
@@ -30,7 +30,15 @@ export interface AnthropicQueryOptions extends QueryOptions {
 export class AnthropicDriver implements AIDriver {
   private client: Anthropic;
   private defaultModel: string;
-  private defaultOptions: Partial<AnthropicQueryOptions>;
+  private _defaultOptions: Partial<AnthropicQueryOptions>;
+
+  get defaultOptions(): Partial<AnthropicQueryOptions> {
+    return this._defaultOptions;
+  }
+
+  set defaultOptions(value: Partial<AnthropicQueryOptions>) {
+    this._defaultOptions = value;
+  }
 
   constructor(config: AnthropicDriverConfig = {}) {
     this.client = new Anthropic({
@@ -38,7 +46,7 @@ export class AnthropicDriver implements AIDriver {
     });
 
     this.defaultModel = config.model || 'claude-3-5-sonnet-20241022';
-    this.defaultOptions = config.defaultOptions || {};
+    this._defaultOptions = config.defaultOptions || {};
   }
 
   /**

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -53,7 +53,15 @@ export class GoogleGenAIDriver implements AIDriver {
   private client: GoogleGenAI;
   private defaultModel: string;
   private defaultTemperature: number;
-  private defaultOptions: Partial<GoogleGenAIQueryOptions>;
+  private _defaultOptions: Partial<GoogleGenAIQueryOptions>;
+
+  get defaultOptions(): Partial<GoogleGenAIQueryOptions> {
+    return this._defaultOptions;
+  }
+
+  set defaultOptions(value: Partial<GoogleGenAIQueryOptions>) {
+    this._defaultOptions = value;
+  }
 
   constructor(config: GoogleGenAIDriverConfig = {}) {
     const apiKey = config.apiKey || process.env.GOOGLE_GENAI_API_KEY;
@@ -65,7 +73,7 @@ export class GoogleGenAIDriver implements AIDriver {
     this.client = new GoogleGenAI({ apiKey });
     this.defaultModel = config.model || 'gemma-3-27b';
     this.defaultTemperature = config.temperature ?? 0.7;
-    this.defaultOptions = config.defaultOptions || {};
+    this._defaultOptions = config.defaultOptions || {};
   }
 
   /**

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -96,15 +96,22 @@ function createStreamIterable(stream: Readable): {
 export class MlxDriver implements AIDriver {
   private process: MlxProcess;
   private model: string;
-  private defaultOptions: Partial<MlxMlModelOptions>;
+  private _defaultOptions: Partial<MlxMlModelOptions>;
   private runtimeInfo: MlxRuntimeInfo | null = null;
   private modelProcessor;
   private formatterOptions: FormatterOptions;
-  
-  
+
+  get defaultOptions(): Partial<MlxMlModelOptions> {
+    return this._defaultOptions;
+  }
+
+  set defaultOptions(value: Partial<MlxMlModelOptions>) {
+    this._defaultOptions = value;
+  }
+
   constructor(config: MlxDriverConfig) {
     this.model = config.model;
-    this.defaultOptions = config.defaultOptions || {};
+    this._defaultOptions = config.defaultOptions || {};
     this.formatterOptions = config.formatterOptions || {};
     this.process = new MlxProcess(config.model);
     this.modelProcessor = createModelSpecificProcessor(config.model);

--- a/packages/driver/src/openai/openai-driver.ts
+++ b/packages/driver/src/openai/openai-driver.ts
@@ -50,7 +50,15 @@ export interface OpenAIQueryOptions extends QueryOptions {
 export class OpenAIDriver implements AIDriver {
   private client: OpenAI;
   private defaultModel: string;
-  private defaultOptions: Partial<OpenAIQueryOptions>;
+  private _defaultOptions: Partial<OpenAIQueryOptions>;
+
+  get defaultOptions(): Partial<OpenAIQueryOptions> {
+    return this._defaultOptions;
+  }
+
+  set defaultOptions(value: Partial<OpenAIQueryOptions>) {
+    this._defaultOptions = value;
+  }
 
   constructor(config: OpenAIDriverConfig = {}) {
     this.client = new OpenAI({
@@ -60,7 +68,7 @@ export class OpenAIDriver implements AIDriver {
     });
 
     this.defaultModel = config.model || 'gpt-4o-mini';
-    this.defaultOptions = config.defaultOptions || {};
+    this._defaultOptions = config.defaultOptions || {};
   }
 
   /**

--- a/packages/driver/src/vertexai/vertexai-driver.ts
+++ b/packages/driver/src/vertexai/vertexai-driver.ts
@@ -58,8 +58,16 @@ export class VertexAIDriver implements AIDriver {
   private vertexAI: VertexAI;
   private defaultModel: string;
   private defaultTemperature: number;
-  private defaultOptions: Partial<VertexAIQueryOptions>;
-  
+  private _defaultOptions: Partial<VertexAIQueryOptions>;
+
+  get defaultOptions(): Partial<VertexAIQueryOptions> {
+    return this._defaultOptions;
+  }
+
+  set defaultOptions(value: Partial<VertexAIQueryOptions>) {
+    this._defaultOptions = value;
+  }
+
   constructor(config: VertexAIDriverConfig = {}) {
     const project = config.project || process.env.GOOGLE_CLOUD_PROJECT || process.env.ANTHROPIC_VERTEX_PROJECT_ID;
     const location = config.location || process.env.GOOGLE_CLOUD_REGION || process.env.CLOUD_ML_REGION || 'us-central1';
@@ -71,7 +79,7 @@ export class VertexAIDriver implements AIDriver {
     this.vertexAI = new VertexAI({ project, location });
     this.defaultModel = config.model || 'gemini-2.0-flash-001';
     this.defaultTemperature = config.temperature ?? 0.05;
-    this.defaultOptions = config.defaultOptions || {};
+    this._defaultOptions = config.defaultOptions || {};
   }
   
   /**


### PR DESCRIPTION
## 概要

ドライバーインスタンス生成後に`defaultOptions`を動的に変更できるようにgetter/setterを実装しました。

## 変更内容

全てのドライバーで`defaultOptions`プロパティをgetter/setterパターンに変更：

- ✅ OpenAIDriver
- ✅ AnthropicDriver
- ✅ VertexAIDriver
- ✅ GoogleGenAIDriver
- ✅ MlxDriver
- ✅ OllamaDriver（OpenAIDriverを継承、自動対応）

## 実装パターン

```typescript
// 変更前
private defaultOptions: Partial<XxxQueryOptions>;

// 変更後
private _defaultOptions: Partial<XxxQueryOptions>;

get defaultOptions(): Partial<XxxQueryOptions> {
  return this._defaultOptions;
}

set defaultOptions(value: Partial<XxxQueryOptions>) {
  this._defaultOptions = value;
}
```

## ユースケース

```typescript
const specs = aiService.selectModels(['fast']);
const driver = await aiService.createDriver(specs[0]);

// 生成後に設定を更新
driver.defaultOptions = {
  ...driver.defaultOptions,
  maxTokens: specs[0].maxOutputTokens
};
```

## テスト結果

- ✅ ビルド成功
- ✅ 型チェック成功
- ✅ テスト成功（254テスト）

Closes #83