### PR TITLE
fix(utils): loggerのJSONLファイル書き込み順序を修正

### DIFF
--- a/.changeset/fix-logger-write-order.md
+++ b/.changeset/fix-logger-write-order.md
@@ -1,0 +1,7 @@
+---
+"@modular-prompt/utils": patch
+---
+
+fix(utils): loggerのJSONLファイル書き込み順序を修正
+
+flushToFileの並列書き込みを逐次書き込みに変更し、エントリの書き込み順序を保証。

--- a/packages/utils/src/logger/logger.test.ts
+++ b/packages/utils/src/logger/logger.test.ts
@@ -25,6 +25,7 @@ describe('Logger', () => {
       logFile: undefined,
     });
     logger.clearLogEntries();
+    Logger.clearFileQueue();
 
     // 既存のテストログファイルを削除
     if (existsSync(testLogFile)) {


### PR DESCRIPTION
## Summary

- `flushToFile`で`Promise.allSettled`による並列書き込みを`for...of` + `await`の逐次書き込みに変更し、JONLエントリの書き込み順序を保証
- テストの`beforeEach`でファイルキューをクリアする`clearFileQueue()`を追加

## Test plan

- [x] 全71テストパス（`pnpm test --filter @modular-prompt/utils`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)