### PR TITLE
fix(driver): ModelSpec.enabled を disabled に変更

### DIFF
--- a/.changeset/modelspec-enabled-to-disabled.md
+++ b/.changeset/modelspec-enabled-to-disabled.md
@@ -1,0 +1,7 @@
+---
+"@modular-prompt/driver": patch
+---
+
+fix(driver): ModelSpec.enabled を disabled に変更し、AIService.selectModels() で無効モデルを除外
+
+ModelSpec.enabled フラグを disabled に変更。デフォルトで有効、明示的に `disabled: true` で無効化するシンプルな設計に統一。AIService.selectModels() に disabled チェックを追加し、無効モデルが選択されない問題を修正。(#88)

--- a/packages/driver/src/driver-registry/ai-service.ts
+++ b/packages/driver/src/driver-registry/ai-service.ts
@@ -71,9 +71,9 @@ export class AIService {
     capabilities: DriverCapability[],
     options?: SelectionOptions
   ): ModelSpec[] {
-    // capability フィルタ
+    // disabled + capability フィルタ
     let models = this.config.models?.filter(m =>
-      capabilities.every(cap => m.capabilities.includes(cap))
+      !m.disabled && capabilities.every(cap => m.capabilities.includes(cap))
     ) || [];
 
     // プロバイダー除外

--- a/packages/driver/src/driver-registry/registry.test.ts
+++ b/packages/driver/src/driver-registry/registry.test.ts
@@ -35,7 +35,7 @@ describe('DriverRegistry', () => {
       expect(result?.model.capabilities).toContain('local');
     });
 
-    it('should set default values for enabled and priority', () => {
+    it('should set default values for priority', () => {
       const spec: ModelSpec = {
         model: 'test-model',
         provider: 'echo',
@@ -46,7 +46,7 @@ describe('DriverRegistry', () => {
 
       const result = registry.selectModel({});
 
-      expect(result?.model.enabled).toBe(true);
+      expect(result?.model.disabled).toBeUndefined();
       expect(result?.model.priority).toBe(0);
     });
   });

--- a/packages/driver/src/driver-registry/registry.ts
+++ b/packages/driver/src/driver-registry/registry.ts
@@ -79,9 +79,6 @@ export class DriverRegistry implements IDriverRegistry {
    */
   registerModel(spec: ModelSpec): void {
     // デフォルト値を設定
-    if (spec.enabled === undefined) {
-      spec.enabled = true;
-    }
     if (spec.priority === undefined) {
       spec.priority = 0;
     }
@@ -99,7 +96,7 @@ export class DriverRegistry implements IDriverRegistry {
 
     for (const [, spec] of this.models) {
       // 無効なモデルはスキップ
-      if (!spec.enabled) {
+      if (spec.disabled) {
         continue;
       }
 

--- a/packages/driver/src/driver-registry/types.ts
+++ b/packages/driver/src/driver-registry/types.ts
@@ -76,8 +76,8 @@ export interface ModelSpec {
   /** 優先度（高いほど優先される） */
   priority?: number;
 
-  /** このモデルが有効かどうか */
-  enabled?: boolean;
+  /** このモデルを無効化する */
+  disabled?: boolean;
 
   /** カスタムメタデータ */
   metadata?: Record<string, unknown>;

--- a/packages/experiment/examples/experiment.yaml
+++ b/packages/experiment/examples/experiment.yaml
@@ -7,7 +7,6 @@ models:
     provider: "mlx"
     capabilities: ["local", "fast", "tools"]
     priority: 20
-    enabled: true
 
   # Vertex AI Gemini - for testing with structuredOutput support
   gemini-vertexai:
@@ -15,7 +14,6 @@ models:
     provider: "vertexai"
     capabilities: ["tools", "fast", "japanese"]
     priority: 10
-    enabled: true
 
   # GoogleGenAI Gemini - alternative for testing
   gemini-googlegenai:
@@ -23,7 +21,7 @@ models:
     provider: "googlegenai"
     capabilities: ["tools", "fast", "japanese"]
     priority: 15
-    enabled: false  # Disabled by default
+    disabled: true  # Disabled by default
 
 drivers:
   mlx: {}

--- a/packages/experiment/src/run-comparison.ts
+++ b/packages/experiment/src/run-comparison.ts
@@ -73,7 +73,7 @@ const models = serverConfig.models;
 
 // Display available models for logging
 const modelEntries = Object.entries(models).filter(([_, spec]: [string, any]) =>
-  spec.enabled !== false && (!spec.role || spec.role === 'test')
+  !spec.disabled && (!spec.role || spec.role === 'test')
 );
 
 if (options.modelFilter) {
@@ -166,7 +166,7 @@ if (options.enableEvaluation) {
   const modelName = evaluationConfig.model;
   const modelSpec = serverConfig.models[modelName];
 
-  if (!modelSpec || modelSpec.enabled === false) {
+  if (!modelSpec || modelSpec.disabled) {
     console.error(`❌ Evaluator model not found or disabled: ${modelName}`);
     console.error('   Please ensure the model is defined in the models section and enabled');
     process.exit(1);

--- a/packages/experiment/src/runner/experiment.ts
+++ b/packages/experiment/src/runner/experiment.ts
@@ -72,7 +72,7 @@ export class ExperimentRunner {
             return { name, spec };
           }).filter(Boolean) as Array<{ name: string; spec: ModelSpec }>
         : Object.entries(this.models)
-            .filter(([_, spec]) => spec.enabled !== false)
+            .filter(([_, spec]) => !spec.disabled)
             .map(([name, spec]) => ({ name, spec }));
 
       if (modelsToTest.length === 0) {

--- a/packages/experiment/test/fixtures/test-config.ts
+++ b/packages/experiment/test/fixtures/test-config.ts
@@ -8,7 +8,6 @@ export default {
       model: 'test-model-ts',
       provider: 'test',
       capabilities: ['test'],
-      enabled: true,
     },
   },
   drivers: {

--- a/packages/experiment/test/fixtures/test-config.yaml
+++ b/packages/experiment/test/fixtures/test-config.yaml
@@ -5,7 +5,6 @@ models:
     model: "test-model"
     provider: "test"
     capabilities: ["test"]
-    enabled: true
 
 drivers:
   test: {}

--- a/packages/simple-chat/src/ai-chat.e2e.test.ts
+++ b/packages/simple-chat/src/ai-chat.e2e.test.ts
@@ -35,8 +35,7 @@ describe('AI Chat E2E Tests', () => {
       registry.registerModel({
         model: 'test-chat',
         provider: 'test' as any,
-        capabilities: ['chat', 'japanese'],
-        enabled: true
+        capabilities: ['chat', 'japanese']
       });
       
       const profile: DialogProfile = {
@@ -79,8 +78,7 @@ describe('AI Chat E2E Tests', () => {
       registry.registerModel({
         model: 'test-chat',
         provider: 'test' as any,
-        capabilities: ['chat'],
-        enabled: true
+        capabilities: ['chat']
       });
       
       const profile: DialogProfile = {
@@ -136,8 +134,7 @@ describe('AI Chat E2E Tests', () => {
       registry.registerModel({
         model: 'echo-text',
         provider: 'echo' as any,
-        capabilities: ['chat'],
-        enabled: true
+        capabilities: ['chat']
       });
       
       const profile: DialogProfile = {
@@ -180,8 +177,7 @@ describe('AI Chat E2E Tests', () => {
       registry.registerModel({
         model: 'echo-messages',
         provider: 'echo' as any,
-        capabilities: ['chat'],
-        enabled: true
+        capabilities: ['chat']
       });
       
       const profile: DialogProfile = {
@@ -235,8 +231,7 @@ describe('AI Chat E2E Tests', () => {
       registry.registerModel({
         model: 'echo-debug',
         provider: 'echo' as any,
-        capabilities: ['chat'],
-        enabled: true
+        capabilities: ['chat']
       });
       
       const profile: DialogProfile = {
@@ -309,8 +304,7 @@ describe('AI Chat E2E Tests', () => {
       registry.registerModel({
         model: 'test-chat',
         provider: 'test' as any,
-        capabilities: ['chat'],
-        enabled: true
+        capabilities: ['chat']
       });
       
       const profile: DialogProfile = {
@@ -372,8 +366,7 @@ describe('AI Chat E2E Tests', () => {
       registry.registerModel({
         model: 'echo-both',
         provider: 'echo' as any,
-        capabilities: ['chat'],
-        enabled: true
+        capabilities: ['chat']
       });
       
       const profile: DialogProfile = {

--- a/packages/simple-chat/src/ai-chat.ts
+++ b/packages/simple-chat/src/ai-chat.ts
@@ -109,7 +109,6 @@ function initializeRegistry(): DriverRegistry {
     model: 'mlx-community/gemma-3-270m-it-qat-4bit',
     provider: 'mlx',
     capabilities: ['local', 'streaming', 'chat'],
-    enabled: true,
     priority: 10
   });
 


### PR DESCRIPTION
## Summary
- `ModelSpec.enabled` を `ModelSpec.disabled` にリネーム（デフォルトで有効、明示的に `disabled: true` で無効化）
- `AIService.selectModels()` に disabled チェックを追加し、無効モデルが選択される問題を修正
- `DriverRegistry.registerModel()` の不要なデフォルト値設定(`enabled = true`)を削除

Closes #88

## Test plan
- [x] 全パッケージのビルド成功確認
- [x] 全パッケージのテスト全件パス確認（core: 79, utils: 71, driver: 317, process: 51, experiment: 4, simple-chat: 13）

🤖 Generated with [Claude Code](https://claude.com/claude-code)