### PR TITLE
docs: OllamaDriverの構造化出力対応をドキュメントに反映

### DIFF
--- a/docs/DRIVER_API.md
+++ b/docs/DRIVER_API.md
@@ -65,7 +65,7 @@ close(): Promise<void>
 
 | ドライバー | プロバイダー | Structured Outputs | 用途 |
 |----------|------------|-------------------|------|
-| OllamaDriver | Ollama | ❌ 未対応 | ローカルLLM（OpenAI互換） |
+| OllamaDriver | Ollama | ✅ ネイティブ（継承） | ローカルLLM（OpenAI互換） |
 | MlxDriver | MLX | ✅ JSON抽出 | Apple Silicon最適化 |
 
 ### テスト用

--- a/docs/STRUCTURED_OUTPUTS.md
+++ b/docs/STRUCTURED_OUTPUTS.md
@@ -70,9 +70,11 @@ APIレベルでstructured outputsをサポート：
 - **MlxDriver**: JSON抽出ユーティリティを使用
 - **TestDriver / EchoDriver**: JSON抽出（詳細は[TEST_DRIVERS.md](./TEST_DRIVERS.md)）
 
-### 3. 未対応
+### 3. OpenAI互換型
 
-- **OllamaDriver**: 実装可能（OpenAI互換）
+OpenAIDriverを継承し、OpenAI互換APIを使用：
+
+- **OllamaDriver**: `response_format` APIパラメータを使用（OpenAIDriver継承）
 
 ## 使用方法
 
@@ -188,7 +190,7 @@ const data = result.structuredOutput ||
 | TestDriver | ✅ 対応済み | JSON抽出 | v0.2.1〜 |
 | EchoDriver | ✅ 対応済み | JSON抽出 | v0.2.1〜 |
 | MlxDriver | ✅ 対応済み | JSON抽出 | v0.2.0〜 |
-| OllamaDriver | ❌ 未対応 | - | 実装可能（OpenAI互換） |
+| OllamaDriver | ✅ 対応済み | response_format API（OpenAIDriver継承） | コード変更なし、OpenAI互換APIを利用 |
 
 ## トラブルシューティング
 


### PR DESCRIPTION
## Summary
- OllamaDriverはOpenAIDriverを継承しており、`response_format` APIによる構造化出力がそのまま動作するため、ドキュメントの対応状況を更新
- `docs/STRUCTURED_OUTPUTS.md`: 「未対応」→「OpenAI互換型」セクション追加、対応状況テーブル更新
- `docs/DRIVER_API.md`: `❌ 未対応` → `✅ ネイティブ（継承）` に変更

Closes #19

## Test plan
- [ ] ドキュメントの記載内容が正確であることを確認
- [ ] 他のドキュメントとの整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)