### PR TITLE
feat: defaultProcess追加とexperimentのPromptModule対応

### DIFF
--- a/packages/experiment/examples/tools-experiment.yaml
+++ b/packages/experiment/examples/tools-experiment.yaml
@@ -12,6 +12,7 @@ models:
     provider: "mlx"
     capabilities: ["local", "tools"]
     priority: 20
+    disabled: true
   lfm2.5-jp:
     model: LiquidAI/LFM2.5-1.2B-JP-MLX-8bit
     provider: "mlx"
@@ -26,12 +27,37 @@ models:
   lfm2.5-thinking:
     model: LiquidAI/LFM2.5-1.2B-Thinking-MLX-8bit
     provider: "mlx"
-    capabilities: ["local", "fast", "japanese"]
+    capabilities: ["local", "thinking", "japanese"]
     priority: 20
-    disabled: true
+    # disabled: true
 
 drivers:
   mlx: {}
+
+# 共通定義
+_shared:
+  tools: &tools_def
+    - name: get_weather
+      description: "指定された場所の現在の天気を取得する"
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+            description: "天気を取得する場所（都市名）"
+        required:
+          - location
+  queryOptions:
+    weather: &tool_weather
+      temperature: 0.3
+      maxTokens: 512
+      tools: *tools_def
+      toolChoice: auto
+    math: &tool_math
+      temperature: 0.3
+      maxTokens: 1024
+      tools: *tools_def
+      toolChoice: auto
 
 modules:
   - name: tools-test
@@ -40,66 +66,54 @@ modules:
 
 testCases:
   # --- gemma3-12b ---
-  - name: "[gemma3] 天気ツール呼び出し"
-    description: "get_weatherツールを呼び出すことを期待"
-    models: ["gemma3-12b"]
-    input:
-      question: "東京の天気を教えてください。"
-    queryOptions: &tool_weather
-      temperature: 0.3
-      maxTokens: 512
-      tools: &tools_def
-        - name: get_weather
-          description: "指定された場所の現在の天気を取得する"
-          parameters:
-            type: object
-            properties:
-              location:
-                type: string
-                description: "天気を取得する場所（都市名）"
-            required:
-              - location
-      toolChoice: auto
-
-  - name: "[gemma3] ツール不要の質問"
-    description: "ツールを呼び出さずにテキストで回答することを期待"
-    models: ["gemma3-12b"]
-    input:
-      question: "1 + 1 は何ですか？"
-    queryOptions: &tool_math
-      temperature: 0.3
-      maxTokens: 1024
-      tools: *tools_def
-      toolChoice: auto
-
-  # # --- qwen3-4b ---
-  # - name: "[qwen3] 天気ツール呼び出し"
+  # - name: "[gemma3] 天気ツール呼び出し"
   #   description: "get_weatherツールを呼び出すことを期待"
-  #   models: ["qwen3-4b"]
+  #   models: ["gemma3-12b"]
   #   input:
   #     question: "東京の天気を教えてください。"
   #   queryOptions: *tool_weather
 
-  # - name: "[qwen3] ツール不要の質問"
+  # - name: "[gemma3] ツール不要の質問"
   #   description: "ツールを呼び出さずにテキストで回答することを期待"
-  #   models: ["qwen3-4b"]
+  #   models: ["gemma3-12b"]
   #   input:
   #     question: "1 + 1 は何ですか？"
   #   queryOptions: *tool_math
 
+  # --- qwen3-4b ---
+  - name: "[qwen3] 天気ツール呼び出し"
+    description: "get_weatherツールを呼び出すことを期待"
+    models: ["qwen3-4b"]
+    input:
+      question: "東京の天気を教えてください。"
+    queryOptions: *tool_weather
+
+  - name: "[qwen3] ツール不要の質問"
+    description: "ツールを呼び出さずにテキストで回答することを期待"
+    models: ["qwen3-4b"]
+    input:
+      question: "1 + 1 は何ですか？"
+    queryOptions: *tool_math
+
   # --- lfm2.5 jp ---
   - name: "[lfm2.5] 天気ツール呼び出し"
-    description: "get_weatherツールを呼び出すことを期待"
-    models: ["lfm2.5-instruct"]
+    description: "get_weatherツールを呼び出しコード生成を期待"
+    models: ["lfm2.5-jp"]
     input:
       question: "東京の天気を教えてください。"
     queryOptions: *tool_weather
 
   - name: "[lfm2.5] ツール不要の質問"
     description: "ツールを呼び出さずにテキストで回答することを期待"
-    models: ["lfm2.5-instruct"]
+    models: ["lfm2.5-jp"]
     input:
       question: "1 + 1 は何ですか？"
     queryOptions: *tool_math
 
-evaluators: []
+evaluators:
+  - name: llm-requirement-fulfillment
+
+evaluation:
+  enabled: true
+  provider: mlx
+  model: lfm2.5-thinking

--- a/packages/experiment/examples/tools-test-module.mjs
+++ b/packages/experiment/examples/tools-test-module.mjs
@@ -2,28 +2,22 @@
  * Tools実験用モジュール
  */
 
-import { compile } from '@modular-prompt/core';
-
-export default {
-  name: 'tools-test',
-  description: 'ツール呼び出し実験用モジュール',
-  compile: (context) => {
-    return compile({
-      objective: [
-        '- あなたは利用者からの質問に答えるアシスタントです。',
-      ],
-      instructions: [
-        '- 質問の内容に応じて、適切なツールを使ってください。',
-        '  - ツールの結果が返ってくるまで、推測で答えないでください。',
-        '- 必要がない場合は通常の応答を返します。',
-      ],
-      messages: [
-        {
-          type: 'message',
-          role: 'user',
-          content: context.question || 'Hello',
-        },
-      ],
-    });
-  },
+const module = {
+  objective: [
+    '- あなたは利用者からの質問に答えるアシスタントです。',
+  ],
+  instructions: [
+    '- 質問の内容に応じて、適切なツールを使ってください。',
+    '  - ツールの結果が返ってくるまで、推測で答えないでください。',
+    '- 必要がない場合は通常の応答を返します。',
+  ],
+  messages: [
+    (ctx) => ({
+      type: 'message',
+      role: 'user',
+      content: ctx.question || 'Hello',
+    }),
+  ],
 };
+
+export default module;

--- a/packages/experiment/examples/tools-test-module.ts
+++ b/packages/experiment/examples/tools-test-module.ts
@@ -2,28 +2,24 @@
  * Tools実験用モジュール
  */
 
-import { compile } from '@modular-prompt/core';
+import type { PromptModule } from '@modular-prompt/core';
 
-export default {
-  name: 'tools-test',
-  description: 'ツール呼び出し実験用モジュール',
-  compile: (context: any) => {
-    return compile({
-      objective: [
-        'あなたはツールを使って質問に答えるアシスタントです。',
-        '必要に応じてツールを呼び出してください。',
-      ],
-      instructions: [
-        '質問の内容に応じて、適切なツールを使ってください。',
-        'ツールの結果が返ってくるまで、推測で答えないでください。',
-      ],
-      messages: [
-        {
-          type: 'message' as const,
-          role: 'user' as const,
-          content: context.question || 'Hello',
-        },
-      ],
-    });
-  },
+const module: PromptModule<{ question?: string }> = {
+  objective: [
+    'あなたはツールを使って質問に答えるアシスタントです。',
+    '必要に応じてツールを呼び出してください。',
+  ],
+  instructions: [
+    '質問の内容に応じて、適切なツールを使ってください。',
+    'ツールの結果が返ってくるまで、推測で答えないでください。',
+  ],
+  messages: [
+    (ctx) => ({
+      type: 'message' as const,
+      role: 'user' as const,
+      content: ctx.question || 'Hello',
+    }),
+  ],
 };
+
+export default module;

--- a/packages/experiment/package.json
+++ b/packages/experiment/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@modular-prompt/core": "workspace:*",
     "@modular-prompt/driver": "workspace:*",
+    "@modular-prompt/process": "workspace:*",
     "@modular-prompt/utils": "workspace:*",
     "commander": "^12.0.0",
     "jiti": "^2.4.2",

--- a/packages/experiment/src/config/dynamic-loader.ts
+++ b/packages/experiment/src/config/dynamic-loader.ts
@@ -143,8 +143,8 @@ export async function loadModules(
 
     modules.push({
       name: ref.name,
-      description: ref.description || module.description || '',
-      compile: module.compile,
+      description: ref.description || '',
+      module: module,
     });
   }
 

--- a/packages/experiment/src/types.ts
+++ b/packages/experiment/src/types.ts
@@ -60,7 +60,7 @@ export interface ExperimentOptions {
 export interface ModuleDefinition {
   name: string;
   description: string;
-  compile: (context: any) => any;
+  module: PromptModule<any>;
 }
 
 /**

--- a/packages/experiment/test/config-loader.test.ts
+++ b/packages/experiment/test/config-loader.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { compile } from '@modular-prompt/core';
 import { loadExperimentConfig } from '../src/config/loader.js';
 import { loadModules } from '../src/config/dynamic-loader.js';
 
@@ -53,10 +54,10 @@ describe('Config Loader', () => {
     expect(modules).toHaveLength(1);
     expect(modules[0].name).toBe('test-module');
     expect(modules[0].description).toBe('Test module');
-    expect(modules[0].compile).toBeDefined();
+    expect(modules[0].module).toBeDefined();
 
-    // モジュールのcompileが動作することを確認
-    const compiled = modules[0].compile({ input: 'hello world' });
+    // モジュールがコンパイルできることを確認
+    const compiled = compile(modules[0].module, { input: 'hello world' });
     expect(compiled).toBeDefined();
     expect(compiled.instructions).toBeDefined();
   });

--- a/packages/experiment/test/fixtures/test-module.ts
+++ b/packages/experiment/test/fixtures/test-module.ts
@@ -2,16 +2,14 @@
  * Test module for experiment
  */
 
-import { compile } from '@modular-prompt/core';
+import type { PromptModule } from '@modular-prompt/core';
 
-export default {
-  name: 'Test Module',
-  description: 'Simple test module',
-  compile: (context: any) => {
-    return compile({
-      objective: ['Test objective'],
-      instructions: ['Test instruction'],
-      inputs: [context.input || 'default input'],
-    });
-  },
+const module: PromptModule<{ input?: string }> = {
+  objective: ['Test objective'],
+  instructions: ['Test instruction'],
+  inputs: [
+    (ctx) => ctx.input || 'default input',
+  ],
 };
+
+export default module;

--- a/packages/process/src/workflows/default-workflow.test.ts
+++ b/packages/process/src/workflows/default-workflow.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { defaultProcess } from './default-workflow.js';
+import type { PromptModule } from '@modular-prompt/core';
+import type { AIDriver, QueryResult } from '@modular-prompt/driver';
+
+// テスト用モックドライバー
+function createMockDriver(result: Partial<QueryResult> = {}): AIDriver {
+  return {
+    query: vi.fn().mockResolvedValue({
+      content: 'test response',
+      usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+      finishReason: 'stop',
+      ...result,
+    }),
+    streamQuery: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+describe('defaultProcess', () => {
+  it('should compile module and query driver', async () => {
+    const driver = createMockDriver();
+    const module: PromptModule<{ question: string }> = {
+      objective: ['Answer the question'],
+      messages: [
+        (ctx) => ({ type: 'message' as const, role: 'user' as const, content: ctx.question }),
+      ],
+    };
+    const context = { question: 'Hello' };
+
+    const result = await defaultProcess(driver, module, context);
+
+    expect(result.output).toBe('test response');
+    expect(result.context).toBe(context);
+    expect(result.metadata?.iterations).toBe(1);
+    expect(result.metadata?.tokensUsed).toBe(30);
+    expect(driver.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass queryOptions to driver', async () => {
+    const driver = createMockDriver();
+    const module: PromptModule<any> = {
+      objective: ['Test'],
+    };
+
+    await defaultProcess(driver, module, {}, {
+      queryOptions: { temperature: 0.3, maxTokens: 512 },
+    });
+
+    expect(driver.query).toHaveBeenCalledWith(
+      expect.anything(),
+      { temperature: 0.3, maxTokens: 512 }
+    );
+  });
+
+  it('should include toolCalls in metadata when present', async () => {
+    const toolCalls = [{ id: '1', name: 'get_weather', arguments: { location: 'Tokyo' } }];
+    const driver = createMockDriver({
+      toolCalls,
+      finishReason: 'tool_calls',
+    });
+    const module: PromptModule<any> = { objective: ['Test'] };
+
+    const result = await defaultProcess(driver, module, {});
+
+    expect(result.metadata?.toolCalls).toEqual(toolCalls);
+    expect(result.metadata?.finishReason).toBe('tool_calls');
+  });
+
+  it('should throw WorkflowExecutionError on failure', async () => {
+    const driver: AIDriver = {
+      query: vi.fn().mockRejectedValue(new Error('API error')),
+      streamQuery: vi.fn(),
+      close: vi.fn(),
+    };
+    const module: PromptModule<any> = { objective: ['Test'] };
+    const context = { key: 'value' };
+
+    await expect(defaultProcess(driver, module, context)).rejects.toThrow('API error');
+
+    try {
+      await defaultProcess(driver, module, context);
+    } catch (error: any) {
+      expect(error.name).toBe('WorkflowExecutionError');
+      expect(error.context).toBe(context);
+      expect(error.phase).toBe('query');
+    }
+  });
+});

--- a/packages/process/src/workflows/default-workflow.ts
+++ b/packages/process/src/workflows/default-workflow.ts
@@ -1,0 +1,45 @@
+import { compile } from '@modular-prompt/core';
+import type { PromptModule } from '@modular-prompt/core';
+import type { QueryOptions } from '@modular-prompt/driver';
+import { WorkflowExecutionError, type AIDriver, type WorkflowResult } from './types.js';
+
+/**
+ * Options for default workflow
+ */
+export interface DefaultProcessOptions {
+  queryOptions?: Partial<QueryOptions>;
+}
+
+/**
+ * Default workflow - compiles a module with context and queries the driver.
+ * This is the simplest process, wrapping compile + driver.query().
+ */
+export async function defaultProcess<TContext extends Record<string, any>>(
+  driver: AIDriver,
+  module: PromptModule<TContext>,
+  context: TContext,
+  options: DefaultProcessOptions = {}
+): Promise<WorkflowResult<TContext>> {
+  try {
+    const compiled = compile(module, context);
+    const result = await driver.query(compiled, options.queryOptions);
+
+    return {
+      output: result.content,
+      context,
+      metadata: {
+        iterations: 1,
+        tokensUsed: result.usage?.totalTokens,
+        toolCalls: result.toolCalls,
+        finishReason: result.finishReason,
+        usage: result.usage,
+      },
+    };
+  } catch (error) {
+    throw new WorkflowExecutionError(
+      error instanceof Error ? error : new Error(String(error)),
+      context,
+      { phase: 'query' }
+    );
+  }
+}

--- a/packages/process/src/workflows/index.ts
+++ b/packages/process/src/workflows/index.ts
@@ -46,3 +46,7 @@ export type {
   AgentWorkflowOptions,
   AgentWorkflowActionHandler
 } from './agent-workflow.js';
+
+// Default workflow
+export { defaultProcess } from './default-workflow.js';
+export type { DefaultProcessOptions } from './default-workflow.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@modular-prompt/driver':
         specifier: workspace:*
         version: link:../driver
+      '@modular-prompt/process':
+        specifier: workspace:*
+        version: link:../process
       '@modular-prompt/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Summary

- `@modular-prompt/process` に `defaultProcess` ワークフローを追加（compile + driver.query()の最小プロセス）
- `@modular-prompt/experiment` のモジュール定義を `compile()` 関数ラッパーから `PromptModule` 直接保持に変更
- experiment runner が `defaultProcess` 経由で実行するように移行
- サンプルモジュール・テストフィクスチャを PromptModule 形式に更新

## 変更の背景

driver.query() を直接呼び出す代わりに process を通じた実行に統一する方針。
defaultProcess は全 process の基本形として、将来的な composedProcess（thinking→instruct→chat パイプライン）等の土台になる。

## 破壊的変更

- `ModuleDefinition.compile` → `ModuleDefinition.module: PromptModule<any>` に変更
- experiment のモジュールファイルは PromptModule を直接 default export する形式に変更
- `comparePrompts` メソッドを削除

## Test plan

- [x] process パッケージ: 55テスト通過（defaultProcess の4テスト含む）
- [x] experiment パッケージ: 4テスト通過
- [x] 両パッケージの型チェック通過
- [x] 両パッケージのビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)