### PR TITLE
fix: VLMモデルで画像なしリクエスト時のエラーを修正

### DIFF
--- a/.changeset/fix-vlm-no-image.md
+++ b/.changeset/fix-vlm-no-image.md
@@ -1,0 +1,8 @@
+---
+"@modular-prompt/driver": patch
+---
+
+VLMモデルで画像なしリクエスト時のmake_samplerエラーを修正
+
+- VLMモデルでも画像なしの場合に常にVLM用生成パスを使用するよう修正
+- 画像が空の場合はimage=Noneを渡すよう修正

--- a/packages/driver/src/mlx-ml/python/__main__.py
+++ b/packages/driver/src/mlx-ml/python/__main__.py
@@ -271,7 +271,7 @@ def generate_text_vlm(prompt, images, options):
 
     for response in vlm_stream_generate(
         model, processor, prompt,
-        image=images,
+        image=images if images else None,
         max_tokens=max_tokens,
         temperature=temperature,
     ):
@@ -358,7 +358,7 @@ def main():
                 tools = req.get('tools')
                 images = req.get('images', [])
 
-                if model_kind == "vlm" and images:
+                if model_kind == "vlm":
                     max_image_size = req.get('maxImageSize', 768)
                     handle_chat_vlm(messages, images, options, max_image_size)
                 else:


### PR DESCRIPTION
## Summary
- VLMモデルに画像なしでリクエストした場合、LM用の未インポート関数`make_sampler`が呼ばれ`NameError`になるバグを修正
- VLMモデルなら画像の有無に関わらずVLM用生成パスを通すよう条件を変更
- 画像が空の場合は`image=None`を渡すよう修正

## Test plan
- [ ] VLMモデルで画像なしのテキストリクエストがエラーなく動作すること
- [ ] VLMモデルで画像ありのリクエストが従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)