### PR TITLE
fix: tool_call終了タグの正規表現バグを修正

### DIFF
--- a/.changeset/fix-tool-call-format-regex.md
+++ b/.changeset/fix-tool-call-format-regex.md
@@ -1,0 +1,9 @@
+---
+"@modular-prompt/driver": patch
+---
+
+tool_call終了タグの正規表現バグを修正
+
+- `detect_tool_call_format`の終了タグ検出パターンが開始タグにもマッチしていた問題を修正
+- Qwen3.5等の`tool_parser_type`を持たないモデルでツールコールのパースが失敗していた
+- Qwen3.5の改行を含むXML形式出力のテストケースを追加

--- a/packages/driver/src/mlx-ml/python/token_utils.py
+++ b/packages/driver/src/mlx-ml/python/token_utils.py
@@ -245,8 +245,8 @@ def detect_tool_call_format(tokenizer):
     if template:
         # 複数のtool_call関連パターンを順に試行
         tool_call_patterns = [
-            # <tool_call>...</tool_call>, <|tool_call|>...<|/tool_call|>
-            (r'<\|?tool_call\|?>', r'</?\|?tool_call\|?>|<\|?/tool_call\|?>'),
+            # </tool_call>, <|/tool_call|> (終了タグ専用)
+            (r'<\|?tool_call\|?>', r'</tool_call>|<\|/tool_call\|>'),
             # <|tool_call_start|>...<|tool_call_end|>
             (r'<\|tool_call_start\|>', r'<\|tool_call_end\|>'),
             # <start_function_call>...<end_function_call>

--- a/packages/driver/src/mlx-ml/tool-call-parser.test.ts
+++ b/packages/driver/src/mlx-ml/tool-call-parser.test.ts
@@ -395,6 +395,41 @@ describe('parseToolCalls', () => {
       });
     });
 
+    it('should parse Qwen3.5 XML format with tool_call_format (multiline parameters)', () => {
+      // Qwen3.5の実際のruntimeInfo: tool_parser_typeなし、chat_templateから検出
+      const runtimeInfo = {
+        methods: ['chat'],
+        special_tokens: {
+          tool_call_xml: {
+            start: { text: '<tool_call>', id: 248058 },
+            end: { text: '</tool_call>', id: 248059 }
+          }
+        },
+        features: {
+          apply_chat_template: true,
+          chat_template: {
+            supported_roles: ['system', 'user', 'assistant', 'tool'],
+            constraints: {},
+            tool_call_format: {
+              call_start: '<tool_call>',
+              call_end: '</tool_call>',
+              response_start: '<tool_response>',
+              response_end: '</tool_response>'
+            }
+          }
+        }
+      } as MlxRuntimeInfo;
+
+      // Qwen3.5の実際の出力形式（改行を含む）
+      const text = '<tool_call>\n<function=get_weather>\n<parameter=location>\n東京\n</parameter>\n</function>\n</tool_call>';
+      const result = parseToolCalls(text, runtimeInfo);
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].name).toBe('get_weather');
+      expect(result.toolCalls[0].arguments).toEqual({ location: '東京' });
+      expect(result.content).toBe('');
+    });
+
     it('should parse minimax invoke XML format inside delimiters', () => {
       const runtimeInfo = {
         methods: ['chat'],


### PR DESCRIPTION
## Summary
- `detect_tool_call_format`の終了タグ検出パターンが開始タグにもマッチするバグを修正
- Qwen3.5等の`tool_parser_type`を持たないモデルでツールコールのパースが失敗していた
- `call_end`が`<tool_call>`（開始タグ）に誤設定され、`parseWithDelimiters`でマッチ不能になっていた

### 原因
```python
# 修正前: ?により/がオプショナル → <tool_call>にもマッチ
(r'<\|?tool_call\|?>', r'</?\|?tool_call\|?>|<\|?/tool_call\|?>')

# 修正後: 終了タグのみにマッチ
(r'<\|?tool_call\|?>', r'</tool_call>|<\|/tool_call\|>')
```

## Test plan
- [x] 既存36テスト通過
- [x] Qwen3.5の改行を含むXML形式パースのテスト追加
- [ ] Qwen3.5モデルで実際にツールコールが正しくパースされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)