### PR TITLE
release: v0.11.2

### DIFF
--- a/.changeset/fix-stop-on-external-tool-call.md
+++ b/.changeset/fix-stop-on-external-tool-call.md
@@ -1,5 +1,0 @@
----
-"@modular-prompt/process": patch
----
-
-agentic workflow: 外部ツール呼び出し時にタスクループを即停止、タスク指示の改善

--- a/packages/experiment/CHANGELOG.md
+++ b/packages/experiment/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modular-prompt/experiment
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies [5590292]
+  - @modular-prompt/process@0.2.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/experiment/package.json
+++ b/packages/experiment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modular-prompt/experiment",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Experiment framework for comparing and evaluating prompt modules",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/process/CHANGELOG.md
+++ b/packages/process/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modular-prompt/process
 
+## 0.2.2
+
+### Patch Changes
+
+- 5590292: agentic workflow: 外部ツール呼び出し時にタスクループを即停止、タスク指示の改善
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modular-prompt/process",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Process module for modular prompt framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/simple-chat/CHANGELOG.md
+++ b/packages/simple-chat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modular-prompt/simple-chat
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies [5590292]
+  - @modular-prompt/process@0.2.2
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/simple-chat/package.json
+++ b/packages/simple-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modular-prompt/simple-chat",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Sample implementation: Simple chat application using Moduler Prompt with MLX models",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- @modular-prompt/process 0.2.2 (patch)
  - 外部ツール呼び出し時にタスクループを即停止
  - 疑似thinkタグにタスク指示文を記載
  - taskCommon に scope 制限指示を追加
  - planning のタスク指示文ガイダンスを調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)