### PR TITLE
feat: AnthropicDriverにVertexAI経由のClaudeサポートを追加

### DIFF
--- a/.changeset/anthropic-vertex-support.md
+++ b/.changeset/anthropic-vertex-support.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/driver": patch
+---
+
+AnthropicDriverにVertexAI経由でのClaude利用をサポートするvertexオプションを追加

--- a/packages/driver/src/anthropic/anthropic-driver.ts
+++ b/packages/driver/src/anthropic/anthropic-driver.ts
@@ -7,12 +7,26 @@ import { hasToolCalls, isToolResult } from '../types.js';
 import { contentToString } from '../content-utils.js';
 
 /**
+ * VertexAI経由でのClaude利用設定
+ */
+export interface AnthropicVertexConfig {
+  /** GCPプロジェクトID */
+  project: string;
+  /** GCPリージョン（デフォルト: 'us-east5'） */
+  location?: string;
+  /** GCPアクセストークン。未指定時は ANTHROPIC_AUTH_TOKEN 環境変数を使用 */
+  accessToken?: string;
+}
+
+/**
  * Anthropic driver configuration
  */
 export interface AnthropicDriverConfig {
   apiKey?: string;
   model?: string;
   defaultOptions?: Partial<AnthropicQueryOptions>;
+  /** VertexAI経由で接続する場合の設定。指定時は apiKey は不要 */
+  vertex?: AnthropicVertexConfig;
 }
 
 /**
@@ -76,9 +90,20 @@ export class AnthropicDriver implements AIDriver {
   }
 
   constructor(config: AnthropicDriverConfig = {}) {
-    this.client = new Anthropic({
-      apiKey: config.apiKey || process.env.ANTHROPIC_API_KEY
-    });
+    if (config.vertex) {
+      const location = config.vertex.location || 'us-east5';
+      const project = config.vertex.project;
+      const baseURL = `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`;
+      this.client = new Anthropic({
+        baseURL,
+        apiKey: null,
+        authToken: config.vertex.accessToken || process.env.ANTHROPIC_AUTH_TOKEN,
+      });
+    } else {
+      this.client = new Anthropic({
+        apiKey: config.apiKey || process.env.ANTHROPIC_API_KEY
+      });
+    }
 
     this.defaultModel = config.model || 'claude-3-5-sonnet-20241022';
     this._defaultOptions = config.defaultOptions || {};

--- a/packages/driver/src/driver-registry/config-based-factory.ts
+++ b/packages/driver/src/driver-registry/config-based-factory.ts
@@ -37,6 +37,12 @@ export interface ApplicationConfig {
     anthropic?: {
       apiKey?: string;
       baseURL?: string;
+      /** VertexAI経由で接続する場合の設定 */
+      vertex?: {
+        project: string;
+        location?: string;
+        accessToken?: string;
+      };
     };
     /** VertexAI設定 */
     vertexai?: {
@@ -112,7 +118,8 @@ export function registerFactories(
     return new AnthropicDriver({
       apiKey: anthropicConfig?.apiKey || process.env.ANTHROPIC_API_KEY,
       model: spec.model,
-      defaultOptions: config.defaultOptions
+      defaultOptions: config.defaultOptions,
+      vertex: anthropicConfig?.vertex,
     });
   });
 

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -58,6 +58,7 @@ export {
 export {
   AnthropicDriver,
   type AnthropicDriverConfig,
+  type AnthropicVertexConfig,
   type AnthropicQueryOptions
 } from './anthropic/anthropic-driver.js';
 


### PR DESCRIPTION
## Summary

- AnthropicDriverConfig に `vertex` オプションを追加し、VertexAI経由でClaudeモデルにアクセス可能にした
- `vertex` 指定時は `baseURL` と `authToken` ベースの認証に切り替え
- ApplicationConfig にも vertex 設定を追加

## 使い方

```typescript
new AnthropicDriver({
  model: 'claude-sonnet-4-20250514',
  vertex: {
    project: 'my-gcp-project',
    location: 'us-east5',  // デフォルト
    // accessToken 未指定時は ANTHROPIC_AUTH_TOKEN 環境変数を使用
  }
});
```

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)