### PR TITLE
fix: AnthropicDriver VertexAI対応を@anthropic-ai/vertex-sdkに切り替え

### DIFF
--- a/.changeset/anthropic-vertex-adc.md
+++ b/.changeset/anthropic-vertex-adc.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/driver": patch
+---
+
+AnthropicDriverのVertexAI対応を@anthropic-ai/vertex-sdkに切り替え、ADCによるトークン自動取得をサポート

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.61.0",
+    "@anthropic-ai/vertex-sdk": "^0.14.4",
     "@google-cloud/vertexai": "^1.10.0",
     "@google/genai": "^1.34.0",
     "@modular-prompt/core": "workspace:*",

--- a/packages/driver/src/anthropic/anthropic-driver.ts
+++ b/packages/driver/src/anthropic/anthropic-driver.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { AnthropicVertex } from '@anthropic-ai/vertex-sdk';
 import type { MessageCreateParamsStreaming } from '@anthropic-ai/sdk/resources/messages';
 import type { CompiledPrompt, Element } from '@modular-prompt/core';
 import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolCall, ToolChoice, ToolDefinition, ChatMessage } from '../types.js';
@@ -14,7 +15,7 @@ export interface AnthropicVertexConfig {
   project: string;
   /** GCPリージョン（デフォルト: 'us-east5'） */
   location?: string;
-  /** GCPアクセストークン。未指定時は ANTHROPIC_AUTH_TOKEN 環境変数を使用 */
+  /** GCPアクセストークン。未指定時はADC（Application Default Credentials）から自動取得 */
   accessToken?: string;
 }
 
@@ -77,7 +78,7 @@ function convertToolChoice(toolChoice: ToolChoice): MessageCreateParamsStreaming
 }
 
 export class AnthropicDriver implements AIDriver {
-  private client: Anthropic;
+  private client: Anthropic | AnthropicVertex;
   private defaultModel: string;
   private _defaultOptions: Partial<AnthropicQueryOptions>;
 
@@ -91,13 +92,10 @@ export class AnthropicDriver implements AIDriver {
 
   constructor(config: AnthropicDriverConfig = {}) {
     if (config.vertex) {
-      const location = config.vertex.location || 'us-east5';
-      const project = config.vertex.project;
-      const baseURL = `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`;
-      this.client = new Anthropic({
-        baseURL,
-        apiKey: null,
-        authToken: config.vertex.accessToken || process.env.ANTHROPIC_AUTH_TOKEN,
+      this.client = new AnthropicVertex({
+        projectId: config.vertex.project,
+        region: config.vertex.location || 'us-east5',
+        accessToken: config.vertex.accessToken || null,
       });
     } else {
       this.client = new Anthropic({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.61.0
         version: 0.61.0
+      '@anthropic-ai/vertex-sdk':
+        specifier: ^0.14.4
+        version: 0.14.4
       '@google-cloud/vertexai':
         specifier: ^1.10.0
         version: 1.10.0
@@ -292,6 +295,9 @@ packages:
   '@anthropic-ai/sdk@0.61.0':
     resolution: {integrity: sha512-GnlOXrPxow0uoaVB3DGNh9EJBU1MyagCBCLpU+bwDVlj/oOPYIwoiasMWlykkfYcQOrDP2x/zHnRD0xN7PeZPw==}
     hasBin: true
+
+  '@anthropic-ai/vertex-sdk@0.14.4':
+    resolution: {integrity: sha512-BZUPRWghZxfSFtAxU563wH+jfWBPoedAwsVxG35FhmNsjeV8tyfN+lFriWhCpcZApxA4NdT6Soov+PzfnxxD5g==}
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
@@ -1845,6 +1851,14 @@ packages:
 snapshots:
 
   '@anthropic-ai/sdk@0.61.0': {}
+
+  '@anthropic-ai/vertex-sdk@0.14.4':
+    dependencies:
+      '@anthropic-ai/sdk': 0.61.0
+      google-auth-library: 9.15.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@babel/runtime@7.28.4': {}
 


### PR DESCRIPTION
## Summary

- `baseURL` 手動構築ではエンドポイントパスの不整合（404エラー）が発生していたため、公式の `@anthropic-ai/vertex-sdk` を使用する方式に変更
- ADC（Application Default Credentials）によるトークン自動取得をサポート
- `gcloud auth application-default login` 済みなら `accessToken` の手動設定不要

Ref #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)