### PR TITLE
feat: QueryResult にログ・エラー情報フィールドを追加

### DIFF
--- a/.changeset/query-result-error-logging.md
+++ b/.changeset/query-result-error-logging.md
@@ -1,0 +1,11 @@
+---
+"@modular-prompt/driver": minor
+"@modular-prompt/utils": patch
+---
+
+QueryResult に `logEntries` / `errors` フィールドを追加し、クエリ実行中のログ・エラー情報を構造化して caller に返却するよう変更。
+
+- `QueryLogger` ヘルパーを新規追加（クエリスコープのログ収集）
+- 全ドライバー（OpenAI, Anthropic, VertexAI, GoogleGenAI, MLX, vLLM）で Logger を統一
+- `console.error` / `console.warn` の直接使用を全廃止
+- `@modular-prompt/utils` から `LogEntry` 型をエクスポート

--- a/docs/DRIVER_API.md
+++ b/docs/DRIVER_API.md
@@ -113,12 +113,14 @@ interface QueryOptions {
 interface QueryResult {
   content: string;                     // テキストレスポンス
   structuredOutput?: unknown;          // 構造化出力（スキーマ指定時）
-  finishReason?: 'stop' | 'length' | 'error';
+  finishReason?: 'stop' | 'length' | 'error' | 'tool_calls';
   usage?: {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
   };
+  logEntries?: LogEntry[];             // クエリ実行中のログエントリ
+  errors?: LogEntry[];                 // エラーレベルのログエントリ
 }
 ```
 
@@ -195,16 +197,53 @@ type DriverProvider =
 const result = await driver.query(prompt);
 
 if (result.finishReason === 'error') {
-  // エラー発生
-  console.error('Query failed');
+  // エラー発生 — errors フィールドで詳細を確認
+  if (result.errors) {
+    for (const entry of result.errors) {
+      console.error(`[${entry.prefix}] ${entry.message}`);
+    }
+  }
 } else if (result.finishReason === 'length') {
   // トークン数制限により切り詰め
   console.warn('Response was truncated');
 } else if (result.finishReason === 'stop') {
   // 正常終了
-  console.log('Success');
+}
+
+// logEntries で全レベルのログを確認可能
+if (result.logEntries) {
+  console.log(`Query produced ${result.logEntries.length} log entries`);
 }
 ```
+
+### ドライバー実装者向けログ規約
+
+ドライバー実装では `QueryLogger` を使用してクエリスコープのログを記録する。`console.error` / `console.warn` の直接使用は禁止。
+
+```typescript
+import { QueryLogger } from '../query-logger.js';
+
+class MyDriver implements AIDriver {
+  private queryLogger = new QueryLogger('MyDriver');
+
+  async streamQuery(prompt, options) {
+    this.queryLogger.mark();  // 各クエリの先頭で呼ぶ
+    try {
+      // ... API呼び出し
+      const result = { content, finishReason, usage };
+      return { stream, result: Promise.resolve({ ...result, ...this.queryLogger.collect() }) };
+    } catch (error) {
+      this.queryLogger.log.error('Query error:', error instanceof Error ? error.message : String(error));
+      return {
+        stream: (async function* () {})(),
+        result: Promise.resolve({ content: '', finishReason: 'error', ...this.queryLogger.collect() })
+      };
+    }
+  }
+}
+```
+
+**prefix 命名規則**: ドライバー名を使用（`OpenAI`, `Anthropic`, `VertexAI`, `GoogleGenAI`, `MLX`, `vLLM`）。詳細は [UTILITIES.md](./UTILITIES.md) の Logger セクションを参照。
 
 ## 関連ドキュメント
 

--- a/packages/driver/src/anthropic/anthropic-driver.ts
+++ b/packages/driver/src/anthropic/anthropic-driver.ts
@@ -6,6 +6,7 @@ import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolCall, ToolC
 import { extractJSON } from '@modular-prompt/utils';
 import { hasToolCalls, isToolResult } from '../types.js';
 import { contentToString } from '../content-utils.js';
+import { QueryLogger } from '../query-logger.js';
 
 /**
  * VertexAI経由でのClaude利用設定
@@ -81,6 +82,7 @@ export class AnthropicDriver implements AIDriver {
   private client: Anthropic | AnthropicVertex;
   private defaultModel: string;
   private _defaultOptions: Partial<AnthropicQueryOptions>;
+  private queryLogger = new QueryLogger('Anthropic');
 
   get defaultOptions(): Partial<AnthropicQueryOptions> {
     return this._defaultOptions;
@@ -304,6 +306,8 @@ export class AnthropicDriver implements AIDriver {
    * Stream query implementation
    */
   async streamQuery(prompt: CompiledPrompt, options?: QueryOptions): Promise<StreamResult> {
+    this.queryLogger.mark();
+    try {
     const anthropicOptions = options as AnthropicQueryOptions || {};
     const mergedOptions = { ...this.defaultOptions, ...anthropicOptions };
 
@@ -353,6 +357,7 @@ export class AnthropicDriver implements AIDriver {
 
     // Process the stream
     const processStream = async () => {
+      try {
       for await (const chunk of anthropicStream) {
         if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
           const content = chunk.delta.text;
@@ -392,6 +397,10 @@ export class AnthropicDriver implements AIDriver {
             }
           }
         }
+      }
+      } catch (error) {
+        this.queryLogger.log.error('Stream error:', error instanceof Error ? error.message : String(error));
+        finishReason = 'error';
       }
       streamConsumed = true;
     };
@@ -453,7 +462,8 @@ export class AnthropicDriver implements AIDriver {
         structuredOutput,
         usage,
         toolCalls,
-        finishReason
+        finishReason,
+        ...this.queryLogger.collect()
       };
     });
 
@@ -461,6 +471,17 @@ export class AnthropicDriver implements AIDriver {
       stream: streamGenerator(),
       result: resultPromise
     };
+    } catch (error) {
+      this.queryLogger.log.error('Query error:', error instanceof Error ? error.message : String(error));
+      return {
+        stream: (async function* () {})(),
+        result: Promise.resolve({
+          content: '',
+          finishReason: 'error' as const,
+          ...this.queryLogger.collect()
+        })
+      };
+    }
   }
 
   /**

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -4,6 +4,7 @@ import type { CompiledPrompt, Element } from '@modular-prompt/core';
 import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolDefinition, ToolChoice, ToolCall, ChatMessage } from '../types.js';
 import { hasToolCalls, isToolResult } from '../types.js';
 import { contentToString } from '../content-utils.js';
+import { QueryLogger } from '../query-logger.js';
 
 /**
  * GoogleGenAI driver configuration
@@ -56,6 +57,7 @@ export class GoogleGenAIDriver implements AIDriver {
   private defaultModel: string;
   private defaultTemperature: number;
   private _defaultOptions: Partial<GoogleGenAIQueryOptions>;
+  private queryLogger = new QueryLogger('GoogleGenAI');
 
   get defaultOptions(): Partial<GoogleGenAIQueryOptions> {
     return this._defaultOptions;
@@ -315,6 +317,7 @@ export class GoogleGenAIDriver implements AIDriver {
     prompt: CompiledPrompt,
     options: GoogleGenAIQueryOptions = {}
   ): Promise<QueryResult> {
+    this.queryLogger.mark();
     try {
       // Merge options with defaults
       const mergedOptions = { ...this.defaultOptions, ...options };
@@ -416,17 +419,15 @@ export class GoogleGenAIDriver implements AIDriver {
           promptTokens: response.usageMetadata.promptTokenCount || 0,
           completionTokens: response.usageMetadata.candidatesTokenCount || 0,
           totalTokens: response.usageMetadata.totalTokenCount || 0
-        } : undefined
+        } : undefined,
+        ...this.queryLogger.collect()
       };
     } catch (error) {
-      console.error('[GoogleGenAIDriver] Query error:', error);
-      if (error instanceof Error) {
-        console.error('[GoogleGenAIDriver] Error message:', error.message);
-        console.error('[GoogleGenAIDriver] Error stack:', error.stack);
-      }
+      this.queryLogger.log.error('Query error:', error instanceof Error ? error.message : String(error));
       return {
         content: '',
-        finishReason: 'error'
+        finishReason: 'error',
+        ...this.queryLogger.collect()
       };
     }
   }
@@ -438,6 +439,7 @@ export class GoogleGenAIDriver implements AIDriver {
     prompt: CompiledPrompt,
     options?: GoogleGenAIQueryOptions
   ): Promise<StreamResult> {
+    this.queryLogger.mark();
     const mergedOptions = { ...this.defaultOptions, ...options };
 
     // Convert prompt to GoogleGenAI format
@@ -546,7 +548,8 @@ export class GoogleGenAIDriver implements AIDriver {
             };
           }
         }
-      } catch {
+      } catch (error) {
+        this.queryLogger.log.error('Stream error:', error instanceof Error ? error.message : String(error));
         finishReason = 'error';
       }
 
@@ -593,7 +596,8 @@ export class GoogleGenAIDriver implements AIDriver {
         structuredOutput,
         toolCalls: accumulatedToolCalls.length > 0 ? accumulatedToolCalls : undefined,
         usage,
-        finishReason
+        finishReason,
+        ...this.queryLogger.collect()
       };
     })();
 

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -18,6 +18,9 @@ export type {
 
 export { hasToolCalls, isToolResult } from './types.js';
 
+// Query Logger
+export { QueryLogger } from './query-logger.js';
+
 // Test driver
 export {
   TestDriver,

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -8,11 +8,10 @@ import type { MlxMessage, MlxMlModelOptions, MlxModelCapabilities, MlxContentPar
 import type { MlxRuntimeInfo, MlxToolDefinition } from './process/types.js';
 import { createModelSpecificProcessor, selectApi } from './process/model-specific.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
-import { extractJSON, Logger } from '@modular-prompt/utils';
+import { extractJSON } from '@modular-prompt/utils';
 import { parseToolCalls, formatToolDefinitionsAsText } from './tool-call-parser.js';
 import { contentToString, extractImagePaths } from '../content-utils.js';
-
-const logger = new Logger({ prefix: 'MLX', context: 'driver' });
+import { QueryLogger } from '../query-logger.js';
 
 // ========================================================================
 // Utility Functions (exported for testing)
@@ -137,6 +136,7 @@ export class MlxDriver implements AIDriver {
   private modelProcessor;
   private formatterOptions: FormatterOptions;
   private maxImageSize: number;
+  private queryLogger = new QueryLogger('MLX');
 
   get defaultOptions(): Partial<MlxMlModelOptions> {
     return this._defaultOptions;
@@ -178,7 +178,7 @@ export class MlxDriver implements AIDriver {
           modelKind: this.runtimeInfo.model_kind,
         });
       } catch (error) {
-        logger.error('Failed to get MLX runtime info:', error);
+        this.queryLogger.log.error('Failed to get MLX runtime info:', error instanceof Error ? error.message : String(error));
       }
     }
   }
@@ -320,6 +320,7 @@ export class MlxDriver implements AIDriver {
     prompt: CompiledPrompt,
     options?: QueryOptions
   ): Promise<StreamResult> {
+    this.queryLogger.mark();
     await this.ensureInitialized();
 
     // Merge options (only override if explicitly provided)
@@ -338,8 +339,9 @@ export class MlxDriver implements AIDriver {
 
     // Create result promise that waits for stream completion
     const resultPromise = completion.then(({ content, error }) => {
-      // If there was an error, throw it
+      // If there was an error, log and throw it
       if (error) {
+        this.queryLogger.log.error('Stream error:', error.message);
         throw error;
       }
 
@@ -368,7 +370,8 @@ export class MlxDriver implements AIDriver {
         content: finalContent,
         structuredOutput,
         toolCalls,
-        finishReason
+        finishReason,
+        ...this.queryLogger.collect()
       };
     });
 

--- a/packages/driver/src/openai/openai-driver.ts
+++ b/packages/driver/src/openai/openai-driver.ts
@@ -3,6 +3,7 @@ import type { CompiledPrompt, Element } from '@modular-prompt/core';
 import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolCall, ToolDefinition, ToolChoice, ChatMessage } from '../types.js';
 import { hasToolCalls, isToolResult } from '../types.js';
 import { contentToString } from '../content-utils.js';
+import { QueryLogger } from '../query-logger.js';
 import type {
   ChatCompletionCreateParams,
   ChatCompletionMessageParam
@@ -48,6 +49,7 @@ export class OpenAIDriver implements AIDriver {
   private client: OpenAI;
   private defaultModel: string;
   private _defaultOptions: Partial<OpenAIQueryOptions>;
+  private queryLogger = new QueryLogger('OpenAI');
 
   get defaultOptions(): Partial<OpenAIQueryOptions> {
     return this._defaultOptions;
@@ -233,6 +235,7 @@ export class OpenAIDriver implements AIDriver {
    * Stream query implementation with both stream and result
    */
   async streamQuery(prompt: CompiledPrompt, options?: QueryOptions): Promise<StreamResult> {
+    this.queryLogger.mark();
     try {
       const openaiOptions = options as OpenAIQueryOptions || {};
       const mergedOptions = { ...this.defaultOptions, ...openaiOptions };
@@ -355,7 +358,8 @@ export class OpenAIDriver implements AIDriver {
               };
             }
           }
-        } catch {
+        } catch (error) {
+          this.queryLogger.log.error('Stream error:', error instanceof Error ? error.message : String(error));
           finishReason = 'error';
         }
         streamConsumed = true;
@@ -414,7 +418,8 @@ export class OpenAIDriver implements AIDriver {
           structuredOutput,
           usage,
           toolCalls,
-          finishReason
+          finishReason,
+          ...this.queryLogger.collect()
         };
       });
 
@@ -422,15 +427,16 @@ export class OpenAIDriver implements AIDriver {
         stream: streamGenerator(),
         result: resultPromise
       };
-    } catch {
-      // Return error state
+    } catch (error) {
+      this.queryLogger.log.error('Query error:', error instanceof Error ? error.message : String(error));
       return {
         stream: (async function* () {
           // Empty stream
         })(),
         result: Promise.resolve({
           content: '',
-          finishReason: 'error' as const
+          finishReason: 'error' as const,
+          ...this.queryLogger.collect()
         })
       };
     }

--- a/packages/driver/src/query-logger.test.ts
+++ b/packages/driver/src/query-logger.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Logger } from '@modular-prompt/utils';
+import { QueryLogger } from './query-logger.js';
+
+describe('QueryLogger', () => {
+  let ql: QueryLogger;
+
+  beforeEach(() => {
+    // 静的 logEntries をクリアして前テストの残留を防ぐ
+    new Logger().clearLogEntries();
+    ql = new QueryLogger('Test', 'query-logger-test');
+  });
+
+  it('should collect log entries after mark()', () => {
+    ql.mark();
+    ql.log.info('test message');
+    const { logEntries, errors } = ql.collect();
+
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries![0].message).toBe('test message');
+    expect(logEntries![0].level).toBe('info');
+    expect(errors).toBeUndefined();
+  });
+
+  it('should separate errors from logEntries', () => {
+    ql.mark();
+    ql.log.info('info message');
+    ql.log.error('error message');
+    const { logEntries, errors } = ql.collect();
+
+    expect(logEntries).toHaveLength(2);
+    expect(errors).toHaveLength(1);
+    expect(errors![0].message).toBe('error message');
+    expect(errors![0].level).toBe('error');
+  });
+
+  it('should return undefined for empty collections', () => {
+    ql.mark();
+    const { logEntries, errors } = ql.collect();
+
+    expect(logEntries).toBeUndefined();
+    expect(errors).toBeUndefined();
+  });
+
+  it('should scope entries by mark() timing', async () => {
+    ql.log.info('before mark');
+    await new Promise(r => setTimeout(r, 10));
+
+    ql.mark();
+    ql.log.info('after mark');
+    const { logEntries } = ql.collect();
+
+    expect(logEntries).toHaveLength(1);
+    expect(logEntries![0].message).toBe('after mark');
+  });
+
+  it('should not include warn in errors', () => {
+    ql.mark();
+    ql.log.warn('warning message');
+    const { logEntries, errors } = ql.collect();
+
+    expect(logEntries).toHaveLength(1);
+    expect(errors).toBeUndefined();
+  });
+});

--- a/packages/driver/src/query-logger.ts
+++ b/packages/driver/src/query-logger.ts
@@ -1,0 +1,61 @@
+import { Logger, type LogEntry } from '@modular-prompt/utils';
+
+/**
+ * クエリ実行中のログを収集し、QueryResult に付与するためのヘルパー。
+ *
+ * 各ドライバーの query/streamQuery の冒頭で mark() を呼び、
+ * 結果返却前に collect() で logEntries/errors を取得する。
+ *
+ * @example
+ * ```typescript
+ * const ql = new QueryLogger('OpenAI');
+ *
+ * async streamQuery(prompt, options) {
+ *   ql.mark();
+ *   try {
+ *     // ... API呼び出し
+ *     return { stream, result: resultPromise.then(r => ({ ...r, ...ql.collect() })) };
+ *   } catch (error) {
+ *     ql.log.error('Query error:', error);
+ *     return { stream: emptyStream(), result: Promise.resolve({ content: '', finishReason: 'error', ...ql.collect() }) };
+ *   }
+ * }
+ * ```
+ */
+export class QueryLogger {
+  private readonly logger: Logger;
+  private startTime: Date;
+
+  constructor(prefix: string, context: string = 'driver') {
+    this.logger = new Logger({
+      prefix,
+      context,
+      accumulate: true,
+    });
+    this.startTime = new Date();
+  }
+
+  /** ログ収集の開始時刻をリセット（各 query 呼び出しの冒頭で呼ぶ） */
+  mark(): void {
+    this.startTime = new Date();
+  }
+
+  /** Logger インスタンスへのアクセス */
+  get log(): Logger {
+    return this.logger;
+  }
+
+  /** クエリスコープのログエントリを収集し、QueryResult にスプレッドできる形で返す */
+  collect(): { logEntries?: LogEntry[]; errors?: LogEntry[] } {
+    const logEntries = this.logger.getLogEntries({
+      since: this.startTime,
+      filterByContext: true,
+    });
+    const errors = logEntries.filter(e => e.level === 'error');
+
+    return {
+      logEntries: logEntries.length > 0 ? logEntries : undefined,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  }
+}

--- a/packages/driver/src/types.ts
+++ b/packages/driver/src/types.ts
@@ -1,4 +1,5 @@
 import type { Attachment, ToolCall, ToolResultKind } from '@modular-prompt/core';
+import type { LogEntry } from '@modular-prompt/utils';
 
 // Re-export from core for convenience
 export type { Attachment, CompiledPrompt, ToolCall, ToolResultKind } from '@modular-prompt/core';
@@ -109,6 +110,12 @@ export interface QueryResult {
   toolCalls?: ToolCall[];
 
   finishReason?: FinishReason;
+
+  /** Log entries recorded during query execution */
+  logEntries?: LogEntry[];
+
+  /** Error-level log entries recorded during query execution */
+  errors?: LogEntry[];
 }
 
 /**

--- a/packages/driver/src/vertexai/vertexai-driver.ts
+++ b/packages/driver/src/vertexai/vertexai-driver.ts
@@ -17,6 +17,7 @@ import { hasToolCalls, isToolResult } from '../types.js';
 import { contentToString } from '../content-utils.js';
 import { OpenAIDriver } from '../openai/openai-driver.js';
 import type { OpenAIQueryOptions } from '../openai/openai-driver.js';
+import { QueryLogger } from '../query-logger.js';
 
 /**
  * VertexAI driver configuration
@@ -71,6 +72,7 @@ export class VertexAIDriver implements AIDriver {
   private googleAuth: GoogleAuth;
   private openaiDriver?: OpenAIDriver;
   private lastToken?: string;
+  private queryLogger = new QueryLogger('VertexAI');
 
   get defaultOptions(): Partial<VertexAIQueryOptions> {
     return this._defaultOptions;
@@ -353,7 +355,7 @@ export class VertexAIDriver implements AIDriver {
 
       for (const key of Object.keys(s)) {
         if (!VertexAIDriver.SUPPORTED_SCHEMA_FIELDS.has(key)) {
-          console.warn(`[VertexAIDriver] Unsupported JSON Schema field "${key}" removed from schema`);
+          this.queryLogger.log.warn(`Unsupported JSON Schema field "${key}" removed from schema`);
           continue;
         }
         result[key] = s[key];
@@ -532,6 +534,7 @@ export class VertexAIDriver implements AIDriver {
       return route.driver.query(prompt, { ...mergedOptions, model: route.modelName } as OpenAIQueryOptions);
     }
 
+    this.queryLogger.mark();
     try {
       // Convert prompt to VertexAI format
       const request = this.compiledPromptToVertexAI(prompt);
@@ -568,11 +571,13 @@ export class VertexAIDriver implements AIDriver {
       // Extract response
       const response = result.response;
       const candidate = response.candidates?.[0];
-      
+
       if (!candidate || !candidate.content) {
+        this.queryLogger.log.error('Empty response: no candidate or content');
         return {
           content: '',
-          finishReason: 'error'
+          finishReason: 'error',
+          ...this.queryLogger.collect()
         };
       }
       
@@ -609,17 +614,15 @@ export class VertexAIDriver implements AIDriver {
           promptTokens: response.usageMetadata.promptTokenCount || 0,
           completionTokens: response.usageMetadata.candidatesTokenCount || 0,
           totalTokens: response.usageMetadata.totalTokenCount || 0
-        } : undefined
+        } : undefined,
+        ...this.queryLogger.collect()
       };
     } catch (error) {
-      console.error('[VertexAIDriver] Query error:', error);
-      if (error instanceof Error) {
-        console.error('[VertexAIDriver] Error message:', error.message);
-        console.error('[VertexAIDriver] Error stack:', error.stack);
-      }
+      this.queryLogger.log.error('Query error:', error instanceof Error ? error.message : String(error));
       return {
         content: '',
-        finishReason: 'error'
+        finishReason: 'error',
+        ...this.queryLogger.collect()
       };
     }
   }
@@ -639,6 +642,8 @@ export class VertexAIDriver implements AIDriver {
     if (route) {
       return route.driver.streamQuery(prompt, { ...mergedOptions, model: route.modelName } as OpenAIQueryOptions);
     }
+
+    this.queryLogger.mark();
 
     // Convert prompt to VertexAI format
     const request = this.compiledPromptToVertexAI(prompt);
@@ -686,9 +691,11 @@ export class VertexAIDriver implements AIDriver {
       const candidate = response.candidates?.[0];
 
       if (!candidate || !candidate.content) {
+        this.queryLogger.log.error('Empty response: no candidate or content');
         return {
           content: '',
-          finishReason: 'error'
+          finishReason: 'error',
+          ...this.queryLogger.collect()
         };
       }
 
@@ -725,7 +732,8 @@ export class VertexAIDriver implements AIDriver {
           promptTokens: response.usageMetadata.promptTokenCount || 0,
           completionTokens: response.usageMetadata.candidatesTokenCount || 0,
           totalTokens: response.usageMetadata.totalTokenCount || 0
-        } : undefined
+        } : undefined,
+        ...this.queryLogger.collect()
       };
     })();
 

--- a/packages/driver/src/vllm/vllm-driver.ts
+++ b/packages/driver/src/vllm/vllm-driver.ts
@@ -18,12 +18,11 @@ import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolCall, Finis
 import type { FormatterOptions } from '../formatter/types.js';
 import { formatPromptAsMessages } from '../formatter/converter.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
-import { extractJSON, Logger } from '@modular-prompt/utils';
+import { extractJSON } from '@modular-prompt/utils';
 import { contentToString } from '../content-utils.js';
 import { VllmProcess, type VllmCapabilities } from './vllm-process.js';
 import { Readable } from 'stream';
-
-const logger = new Logger({ prefix: 'vLLM', context: 'driver' });
+import { QueryLogger } from '../query-logger.js';
 
 /**
  * vLLM driver configuration
@@ -113,6 +112,7 @@ export class VllmDriver implements AIDriver {
   private defaultOptions: VllmDriverConfig['defaultOptions'];
   private capabilities: VllmCapabilities | null = null;
   private formatterOptions: FormatterOptions;
+  private queryLogger = new QueryLogger('vLLM');
 
   constructor(config: VllmDriverConfig) {
     this.defaultOptions = config.defaultOptions || {};
@@ -124,9 +124,9 @@ export class VllmDriver implements AIDriver {
     if (!this.capabilities) {
       try {
         this.capabilities = await this.process.getCapabilities();
-        logger.info('Model capabilities:', this.capabilities);
+        this.queryLogger.log.info('Model capabilities:', this.capabilities);
       } catch (error) {
-        logger.error('Failed to get capabilities:', error);
+        this.queryLogger.log.error('Failed to get capabilities:', error instanceof Error ? error.message : String(error));
       }
     }
   }
@@ -171,6 +171,7 @@ export class VllmDriver implements AIDriver {
   }
 
   async streamQuery(prompt: CompiledPrompt, options?: QueryOptions): Promise<StreamResult> {
+    this.queryLogger.mark();
     await this.ensureInitialized();
 
     const opts = mapOptions(this.defaultOptions, options);
@@ -179,7 +180,10 @@ export class VllmDriver implements AIDriver {
     const { iterable, completion } = createStreamIterable(stream);
 
     const resultPromise = completion.then(({ content, error }) => {
-      if (error) throw error;
+      if (error) {
+        this.queryLogger.log.error('Stream error:', error.message);
+        throw error;
+      }
 
       let structuredOutput: unknown | undefined;
       if (prompt.metadata?.outputSchema && content) {
@@ -189,7 +193,7 @@ export class VllmDriver implements AIDriver {
         }
       }
 
-      return { content, finishReason: 'stop' as FinishReason, structuredOutput };
+      return { content, finishReason: 'stop' as FinishReason, structuredOutput, ...this.queryLogger.collect() };
     });
 
     return { stream: iterable, result: resultPromise };

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -5,7 +5,8 @@ export {
 } from './logger/index.js';
 
 export type {
-  LogLevel
+  LogLevel,
+  LogEntry
 } from './logger/index.js';
 
 // JSON Extractor exports


### PR DESCRIPTION
## Summary

- `QueryResult` に `logEntries` / `errors` フィールドを追加し、クエリ実行中のエラー詳細を構造化して caller に返却
- `QueryLogger` ヘルパーを新規追加（クエリスコープのログ収集ユーティリティ）
- 全ドライバー（OpenAI, Anthropic, VertexAI, GoogleGenAI, MLX, vLLM）で Logger を統一し、`console.error` / `console.warn` の直接使用を全廃止

## 背景

従来、ドライバーのエラー情報は `finishReason: 'error'` のみで、エラーの詳細（メッセージ、原因）が caller に伝わらなかった。また、ドライバーごとにエラーハンドリング戦略（throw vs 吸収、console.error vs Logger vs 無出力）がバラバラだった。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `packages/driver/src/types.ts` | `QueryResult` に `logEntries?`, `errors?` フィールド追加 |
| `packages/driver/src/query-logger.ts` | `QueryLogger` クラス新規作成 |
| `packages/driver/src/query-logger.test.ts` | テスト（5件） |
| `packages/driver/src/openai/openai-driver.ts` | QueryLogger 導入 |
| `packages/driver/src/anthropic/anthropic-driver.ts` | QueryLogger 導入 + try-catch 追加 |
| `packages/driver/src/vertexai/vertexai-driver.ts` | console.error/warn → QueryLogger |
| `packages/driver/src/google-genai/google-genai-driver.ts` | console.error → QueryLogger |
| `packages/driver/src/mlx-ml/mlx-driver.ts` | 既存 Logger → QueryLogger |
| `packages/driver/src/vllm/vllm-driver.ts` | 既存 Logger → QueryLogger |
| `packages/utils/src/index.ts` | `LogEntry` 型エクスポート追加 |
| `docs/DRIVER_API.md` | エラーハンドリングセクション更新 |

## Test plan

- [x] `npx tsc --build` ビルド成功
- [x] ドライバーテスト 394件全パス
- [x] process/utils テスト 130件全パス
- [x] QueryLogger テスト 5件全パス
- [x] 全ドライバーから `console.error`/`console.warn` が除去されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)