### PR TITLE
docs: WorkflowResult 可観測性フィールドのドキュメント追加

### DIFF
--- a/docs/PROCESS_MODULE_GUIDE.md
+++ b/docs/PROCESS_MODULE_GUIDE.md
@@ -286,8 +286,12 @@ export async function processWorkflow(
   return {
     output: result.content,
     context: updatedContext,
+    consumedUsage: result.usage,        // 全クエリの合計（単一クエリの場合は同値）
+    responseUsage: result.usage,        // 最終応答のusage
+    logEntries: result.logEntries,      // クエリ実行中のログエントリ
+    errors: result.errors,              // エラーレベルのログエントリ
     metadata: {
-      usage: result.usage
+      // 追加のメタデータがあればここに配置
     }
   };
 }
@@ -302,7 +306,59 @@ export async function processWorkflow(
 
 役割に応じたドライバーを解決するには、`resolveDriver(input, role)` ヘルパーを使用します。未指定の役割は自動的に `default` にフォールバックします。
 
-### ステップ4: 使用例
+### ステップ4: WorkflowResultの構造
+
+ワークフロー関数は以下の構造を持つ `WorkflowResult<TContext>` を返します：
+
+```typescript
+interface WorkflowResult<TContext> {
+  output: string;              // 最終的な出力テキスト
+  context: TContext;           // 更新されたContext（継続可能な状態）
+  
+  // Usage情報（v0.13.0以降）
+  consumedUsage?: {            // 全query()呼び出しの合計（リトライ含む）= 実コスト
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  responseUsage?: {            // 最終応答のusage = メッセージサイズの目安
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  
+  // ログ情報（v0.13.0以降）
+  logEntries?: LogEntry[];     // ワークフロー実行中の全ログエントリ
+  errors?: LogEntry[];         // エラーレベルのログエントリ
+  
+  // その他のメタデータ
+  metadata?: {
+    iterations?: number;       // イテレーション数（streamProcessなど）
+    [key: string]: any;        // ワークフロー固有のメタデータ
+  };
+}
+```
+
+**usageの2分類**:
+- `consumedUsage`: 全query()呼び出しの合計（リトライ含む）。実際のコスト把握に使用。
+- `responseUsage`: 最終応答のusage。メッセージサイズの目安として使用。
+
+**ログ情報**:
+- `logEntries`: クエリ実行中に記録されたすべてのログエントリ（info, warn, error等）
+- `errors`: エラーレベルのログエントリのみ抽出したもの
+
+各ワークフローでのusageの扱い:
+
+| ワークフロー | consumedUsage | responseUsage |
+|---|---|---|
+| defaultProcess | 単一クエリ（responseUsageと同値） | 単一クエリのusage |
+| streamProcess | 全イテレーション合計 | 最終イテレーションのusage |
+| concatProcess | 全チャンク合計 | 最終チャンクのusage |
+| dialogueProcess | two-pass合計 / single | 最終パスのusage |
+| summarizeProcess | analysis+summary合計 | 最終バッチのusage |
+| agenticProcess | 全タスク合計（リトライ含む） | 最終タスクのusage |
+
+### ステップ5: 使用例
 
 ```typescript
 import { merge, createContext } from '@modular-prompt/core';

--- a/docs/UTILITIES.md
+++ b/docs/UTILITIES.md
@@ -730,7 +730,67 @@ setInterval(() => logger.flush(), 5000);
   - `packages/experiment/src/run-comparison.ts` - 実験フレームワーク
   - `packages/simple-chat/src/cli.ts` - チャットCLI
 
+## Usage集計ユーティリティ
+
+`@modular-prompt/process` パッケージは、複数のクエリやタスクのusage情報を集計するためのユーティリティ関数を提供します。
+
+### aggregateUsage()
+
+複数の usage オブジェクトを合算します。リトライや複数タスクのusageを集計する際に使用します。
+
+```typescript
+import { aggregateUsage } from '@modular-prompt/process/workflows/usage-utils';
+
+const usage1 = { promptTokens: 100, completionTokens: 50, totalTokens: 150 };
+const usage2 = { promptTokens: 200, completionTokens: 80, totalTokens: 280 };
+
+const total = aggregateUsage([usage1, usage2]);
+// { promptTokens: 300, completionTokens: 130, totalTokens: 430 }
+
+// undefined は無視される
+const partialTotal = aggregateUsage([usage1, undefined, usage2]);
+// { promptTokens: 300, completionTokens: 130, totalTokens: 430 }
+
+// すべて undefined の場合は undefined を返す
+const noUsage = aggregateUsage([undefined, undefined]);
+// undefined
+```
+
+### aggregateLogEntries()
+
+複数の LogEntry 配列をフラット化します。全タスク・全クエリのログを1つの配列にまとめる際に使用します。
+
+```typescript
+import { aggregateLogEntries } from '@modular-prompt/process/workflows/usage-utils';
+
+const logs1 = [
+  { level: 'info', message: 'Task 1 started', timestamp: '...' },
+  { level: 'info', message: 'Task 1 completed', timestamp: '...' }
+];
+const logs2 = [
+  { level: 'info', message: 'Task 2 started', timestamp: '...' }
+];
+
+const allLogs = aggregateLogEntries([logs1, logs2]);
+// [
+//   { level: 'info', message: 'Task 1 started', ... },
+//   { level: 'info', message: 'Task 1 completed', ... },
+//   { level: 'info', message: 'Task 2 started', ... }
+// ]
+
+// undefined は無視される
+const partialLogs = aggregateLogEntries([logs1, undefined]);
+// logs1 のコピー
+
+// すべて undefined の場合は undefined を返す
+const noLogs = aggregateLogEntries([undefined, undefined]);
+// undefined
+```
+
+**実装ファイル**: `packages/process/src/workflows/usage-utils.ts`
+
 ## 関連ドキュメント
 
 - [Architecture](./ARCHITECTURE.md) - システム全体のアーキテクチャ
 - [Driver API](./DRIVER_API.md) - ドライバAPIの詳細
+- [Process Module Guide](./PROCESS_MODULE_GUIDE.md) - WorkflowResultの詳細

--- a/packages/process/README.md
+++ b/packages/process/README.md
@@ -67,6 +67,8 @@ const result = await defaultProcess(
 );
 
 console.log(result.output);  // AIの応答
+console.log(result.consumedUsage);  // 実際に消費したトークン数（コスト把握用）
+console.log(result.responseUsage);  // 最終応答のトークン数（メッセージサイズ目安）
 ```
 
 ### チャンク処理
@@ -138,7 +140,9 @@ const result = await agenticProcess(driver, userModule, context, {
 });
 
 console.log(result.output);  // 最終的な献立提案
-console.log(result.metadata); // { planTasks, executedTasks, toolCallsUsed, finishReason }
+console.log(result.metadata); // { planTasks, executedTasks, toolCallsUsed, finishReason, iterations }
+console.log(result.consumedUsage); // 全タスク実行の合計usage（リトライ含む）
+console.log(result.responseUsage); // 最終タスクのusage
 ```
 
 ### 外部ツールの使用
@@ -180,6 +184,41 @@ if (result.metadata.finishReason === 'tool_calls') {
   console.log(result.context.executionLog);
 }
 ```
+
+## WorkflowResult型
+
+すべてのワークフロー関数は以下の型を返します：
+
+```typescript
+interface WorkflowResult<TContext> {
+  output: string;              // 最終的な出力テキスト
+  context: TContext;           // 更新されたContext（継続可能な状態）
+  
+  // Usage情報
+  consumedUsage?: {            // 全query()呼び出しの合計（リトライ含む）= 実コスト
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  responseUsage?: {            // 最終応答のusage = メッセージサイズの目安
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  
+  // ログ情報
+  logEntries?: LogEntry[];     // ワークフロー実行中の全ログエントリ
+  errors?: LogEntry[];         // エラーレベルのログエントリ
+  
+  // その他のメタデータ
+  metadata?: {
+    iterations?: number;       // イテレーション数（streamProcessなど）
+    [key: string]: any;        // ワークフロー固有のメタデータ
+  };
+}
+```
+
+詳細は [プロセスモジュールガイド](../docs/PROCESS_MODULE_GUIDE.md) を参照してください。
 
 ## 開発者向けドキュメント
 


### PR DESCRIPTION
## Summary

- PROCESS_MODULE_GUIDE.md に WorkflowResult の新フィールド（consumedUsage/responseUsage/logEntries/errors）と各ワークフローの usage 一覧表を追加
- packages/process/README.md に使用例と WorkflowResult 型セクションを追加
- UTILITIES.md に aggregateUsage / aggregateLogEntries ユーティリティのドキュメントを追加

PR #192 の補足ドキュメントです。

## Test plan

- [x] ドキュメントのみの変更（コード変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)