### PR TITLE
feat: toolAgentProcess ワークフローを追加

### DIFF
--- a/.changeset/tool-agent-workflow.md
+++ b/.changeset/tool-agent-workflow.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/process": minor
+---
+
+toolAgentProcess ワークフローを追加。外部からツール（定義+ハンドラー）を渡してエージェントループを実行するシンプルなワークフロー。ToolSpec/ToolCallLog 型を共有型に移動。

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -204,6 +204,71 @@ const answers = await answerMultipleQuestions([
 console.log('回答:\n', answers);
 ```
 
+### ツールを使ったエージェント処理
+
+toolAgentProcessワークフローを使って、AIモデルにツールを渡し、自律的にツール呼び出し→結果取得→判断を繰り返させる：
+
+```typescript
+import { toolAgentProcess } from '@modular-prompt/process';
+import type { ToolSpec } from '@modular-prompt/process';
+
+// ツール定義（AIに渡す定義 + 実行ハンドラー）
+const tools: ToolSpec[] = [
+  {
+    definition: {
+      name: 'search',
+      description: 'ドキュメントを検索する',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: '検索クエリ' },
+        },
+        required: ['query'],
+      },
+    },
+    handler: async (args) => {
+      const results = await mySearchAPI.search(args.query as string);
+      return results;
+    },
+  },
+  {
+    definition: {
+      name: 'get_document',
+      description: 'ドキュメントの全文を取得する',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'ドキュメントID' },
+        },
+        required: ['id'],
+      },
+    },
+    handler: async (args) => {
+      return await mySearchAPI.getDocument(args.id as string);
+    },
+  },
+];
+
+const agentModule = {
+  objective: ['質問に関連するドキュメントを検索し、回答を生成する'],
+  instructions: [
+    '質問を分析し、必要な情報を特定する',
+    'ツールを使って情報を収集する',
+    '収集した情報をもとに回答を生成する',
+  ],
+};
+
+const result = await toolAgentProcess(driver, agentModule, {}, {
+  tools,
+  maxTurns: 10,   // ツール呼び出しループの最大ターン数
+});
+
+console.log(result.output);
+console.log(result.metadata?.toolCallLog); // ツール呼び出し履歴
+```
+
+agenticProcessとの違い：agenticProcessはplanning→タスクシーケンス→outputの多段ワークフローだが、toolAgentProcessは単一モデル+ツールループのみのシンプルな構成。
+
 ### 資料を使った処理
 
 ```typescript

--- a/docs/PROCESS_MODULE_GUIDE.md
+++ b/docs/PROCESS_MODULE_GUIDE.md
@@ -357,6 +357,7 @@ interface WorkflowResult<TContext> {
 | dialogueProcess | two-pass合計 / single | 最終パスのusage |
 | summarizeProcess | analysis+summary合計 | 最終バッチのusage |
 | agenticProcess | 全タスク合計（リトライ含む） | 最終タスクのusage |
+| toolAgentProcess | 全ターン合計（ツール実行ループ含む） | 最終ターンのusage |
 
 ### ステップ5: 使用例
 

--- a/packages/process/src/workflows/agentic-workflow/types.ts
+++ b/packages/process/src/workflows/agentic-workflow/types.ts
@@ -3,26 +3,9 @@ import type { ResolvedModule } from '@modular-prompt/core';
 import type { LogEntry } from '@modular-prompt/utils';
 import type { ModelRole } from '../driver-input.js';
 
-// ---------------------------------------------------------------------------
-// Tool specification
-// ---------------------------------------------------------------------------
-
-/**
- * Tool specification: definition for AI + handler for execution
- */
-export interface ToolSpec {
-  definition: ToolDefinition;
-  handler: (args: Record<string, unknown>) => Promise<unknown>;
-}
-
-/**
- * Tool call log entry (builtin tool execution record)
- */
-export interface ToolCallLog {
-  name: string;
-  arguments: Record<string, unknown>;
-  result: unknown;
-}
+// Import shared tool types (re-exported below for backward compatibility)
+import type { ToolSpec, ToolCallLog } from '../types.js';
+export type { ToolSpec, ToolCallLog };
 
 // ---------------------------------------------------------------------------
 // Task types

--- a/packages/process/src/workflows/index.ts
+++ b/packages/process/src/workflows/index.ts
@@ -48,6 +48,10 @@ export type {
   TaskTypeConfig
 } from './agentic-workflow/index.js';
 
+// Tool agent workflow
+export { toolAgentProcess } from './tool-agent-workflow.js';
+export type { ToolAgentOptions } from './tool-agent-workflow.js';
+
 // Default workflow
 export { defaultProcess } from './default-workflow.js';
 export type { DefaultProcessOptions } from './default-workflow.js';

--- a/packages/process/src/workflows/tool-agent-workflow.ts
+++ b/packages/process/src/workflows/tool-agent-workflow.ts
@@ -1,0 +1,180 @@
+/**
+ * Tool agent workflow
+ *
+ * A simple agent loop: query the model with tools, execute tool calls,
+ * feed results back, and repeat until the model produces a final output
+ * or the turn limit is reached.
+ *
+ * All tools are executed internally — there is no builtin/external distinction.
+ */
+
+import { compile } from '@modular-prompt/core';
+import type { PromptModule } from '@modular-prompt/core';
+import type { ToolResultMessageElement, StandardMessageElement } from '@modular-prompt/core';
+import type { ToolChoice, QueryResult } from '@modular-prompt/driver';
+import { Logger } from '@modular-prompt/utils';
+import type { LogEntry } from '@modular-prompt/utils';
+import { WorkflowExecutionError, type WorkflowResult, type ToolSpec, type ToolCallLog } from './types.js';
+import { type DriverInput, type ModelRole, resolveDriver } from './driver-input.js';
+import { aggregateUsage, aggregateLogEntries } from './usage-utils.js';
+
+const logger = new Logger({ prefix: 'process', context: 'tool-agent' });
+
+/**
+ * Options for tool agent workflow
+ */
+export interface ToolAgentOptions {
+  /** Tools available to the agent (definition + handler) */
+  tools?: ToolSpec[];
+  /** Maximum number of query-execute turns (default: 10) */
+  maxTurns?: number;
+  /** Maximum output tokens per query */
+  maxTokens?: number;
+  /** Tool usage strategy */
+  toolChoice?: ToolChoice;
+  /** Driver role to use from DriverSet (default: 'default') */
+  driverRole?: ModelRole;
+}
+
+/**
+ * Tool agent workflow — runs a model with tools in a loop.
+ *
+ * The model is queried with tool definitions. When it produces tool calls,
+ * they are executed and the results are fed back. This continues until
+ * the model produces output without tool calls or maxTurns is reached.
+ */
+export async function toolAgentProcess<TContext extends Record<string, any>>(
+  driver: DriverInput,
+  module: PromptModule<TContext>,
+  context: TContext,
+  options: ToolAgentOptions = {}
+): Promise<WorkflowResult<TContext>> {
+  const {
+    tools = [],
+    maxTurns = 10,
+    driverRole = 'default',
+  } = options;
+
+  const resolvedDriver = resolveDriver(driver, driverRole);
+  const toolDefs = tools.map(t => t.definition);
+  const toolMap = new Map(tools.map(t => [t.definition.name, t]));
+
+  try {
+    logger.info('[start] tool-agent workflow');
+    const prompt = compile(module, context);
+    const queryOptions = {
+      tools: toolDefs.length > 0 ? toolDefs : undefined,
+      toolChoice: options.toolChoice ?? 'auto' as ToolChoice,
+      ...(options.maxTokens ? { maxTokens: options.maxTokens } : {}),
+    };
+
+    const toolCallLog: ToolCallLog[] = [];
+    const allUsages: (QueryResult['usage'] | undefined)[] = [];
+    const allLogEntries: (LogEntry[] | undefined)[] = [];
+    const allErrors: (LogEntry[] | undefined)[] = [];
+    let turn = 0;
+
+    while (turn < maxTurns) {
+      turn++;
+      logger.info(`[turn ${turn}/${maxTurns}]`);
+
+      const result = await resolvedDriver.query(prompt, queryOptions);
+      const content = result.content || '';
+      logger.verbose('[output]', content);
+
+      // No tool calls → done
+      if (!result.toolCalls || result.toolCalls.length === 0) {
+        allUsages.push(result.usage);
+        allLogEntries.push(result.logEntries);
+        allErrors.push(result.errors);
+
+        logger.info(`[end] ${turn} turn(s)`);
+        return {
+          output: content,
+          context,
+          consumedUsage: aggregateUsage(allUsages),
+          responseUsage: result.usage,
+          logEntries: aggregateLogEntries(allLogEntries),
+          errors: aggregateLogEntries(allErrors),
+          metadata: {
+            iterations: turn,
+            toolCallLog,
+            finishReason: result.finishReason,
+          },
+        };
+      }
+
+      // Execute tool calls
+      for (const tc of result.toolCalls) {
+        logger.info('[tool:call]', tc.name, JSON.stringify(tc.arguments));
+      }
+
+      const toolResults: ToolResultMessageElement[] = [];
+      for (const tc of result.toolCalls) {
+        const spec = toolMap.get(tc.name);
+        if (!spec) {
+          const errValue = `Unknown tool: "${tc.name}". Available tools: ${toolDefs.map(d => d.name).join(', ')}`;
+          logger.warn('[tool:error]', tc.name, errValue);
+          toolResults.push({
+            type: 'message', role: 'tool', toolCallId: tc.id, name: tc.name,
+            kind: 'error', value: errValue,
+          });
+          toolCallLog.push({ name: tc.name, arguments: tc.arguments, result: `Error: unknown tool` });
+          continue;
+        }
+        try {
+          const toolResult = await spec.handler(tc.arguments);
+          logger.info('[tool:result]', tc.name, toolResult);
+          toolResults.push({
+            type: 'message', role: 'tool', toolCallId: tc.id, name: tc.name,
+            kind: typeof toolResult === 'string' ? 'text' : 'data', value: toolResult,
+          });
+          toolCallLog.push({ name: tc.name, arguments: tc.arguments, result: toolResult });
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          logger.warn('[tool:error]', tc.name, errorMsg);
+          toolResults.push({
+            type: 'message', role: 'tool', toolCallId: tc.id, name: tc.name,
+            kind: 'error', value: errorMsg,
+          });
+          toolCallLog.push({ name: tc.name, arguments: tc.arguments, result: `Error: ${errorMsg}` });
+        }
+      }
+
+      // Accumulate usage from this turn
+      allUsages.push(result.usage);
+      allLogEntries.push(result.logEntries);
+      allErrors.push(result.errors);
+
+      // Append assistant + tool results for next turn
+      const assistantMessage: StandardMessageElement = {
+        type: 'message', role: 'assistant', content,
+        toolCalls: result.toolCalls,
+      };
+      prompt.output.push(assistantMessage, ...toolResults);
+
+      // After first turn, ensure toolChoice is auto
+      queryOptions.toolChoice = 'auto';
+    }
+
+    // maxTurns exhausted — return last content
+    logger.info(`[end] max turns (${maxTurns}) reached`);
+    return {
+      output: '',
+      context,
+      consumedUsage: aggregateUsage(allUsages),
+      logEntries: aggregateLogEntries(allLogEntries),
+      errors: aggregateLogEntries(allErrors),
+      metadata: {
+        iterations: turn,
+        toolCallLog,
+      },
+    };
+  } catch (error) {
+    throw new WorkflowExecutionError(
+      error instanceof Error ? error : new Error(String(error)),
+      context,
+      { phase: 'tool-agent-loop' }
+    );
+  }
+}

--- a/packages/process/src/workflows/types.ts
+++ b/packages/process/src/workflows/types.ts
@@ -1,7 +1,28 @@
 // Re-export types from driver package
 export type { AIDriver, QueryResult, FinishReason } from '@modular-prompt/driver';
-import type { FinishReason } from '@modular-prompt/driver';
+import type { FinishReason, ToolDefinition } from '@modular-prompt/driver';
 import type { LogEntry } from '@modular-prompt/utils';
+
+// ---------------------------------------------------------------------------
+// Tool types (shared across workflows)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tool specification: definition for AI + handler for execution
+ */
+export interface ToolSpec {
+  definition: ToolDefinition;
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+/**
+ * Tool call log entry
+ */
+export interface ToolCallLog {
+  name: string;
+  arguments: Record<string, unknown>;
+  result: unknown;
+}
 
 /**
  * Result of workflow execution


### PR DESCRIPTION
## Summary
- 外部からツール（定義+ハンドラー）を渡してエージェントループを実行するシンプルなワークフロー `toolAgentProcess` を追加
- `ToolSpec` / `ToolCallLog` 型を `workflows/types.ts` に共有化（agentic-workflow側はre-export）
- GETTING_STARTED.md, PROCESS_MODULE_GUIDE.md にドキュメント追加

## Motivation
agenticProcess はplanning→タスクシーケンス→outputの多段構成で、「単一モデル+ツールループ」のユースケースには大きすぎる。search-docsプロジェクトのContext-1エージェントのように、ツールを渡してループを回すだけのシンプルなワークフローが必要。

## Test plan
- [x] `pnpm run build` でビルド確認
- [x] `pnpm run typecheck` で型チェック通過
- [x] `pnpm test` で既存テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)