### PR TITLE
fix: VertexAI parts undefined ガード + queryWithTools リトライ不整合修正

### DIFF
--- a/.changeset/fix-query-retry-mismatch.md
+++ b/.changeset/fix-query-retry-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@modular-prompt/process': patch
+---
+
+fix: queryWithTools で外部ツール混在時の function call/response 数不一致を修正

--- a/.changeset/fix-vertexai-parts-guard.md
+++ b/.changeset/fix-vertexai-parts-guard.md
@@ -1,0 +1,5 @@
+---
+'@modular-prompt/driver': patch
+---
+
+fix: VertexAI ドライバで candidate.content.parts が undefined の場合のクラッシュを修正

--- a/packages/driver/src/vertexai/vertexai-driver.ts
+++ b/packages/driver/src/vertexai/vertexai-driver.ts
@@ -580,14 +580,15 @@ export class VertexAIDriver implements AIDriver {
           ...this.queryLogger.collect()
         };
       }
-      
-      // Extract text content
-      const content = candidate.content.parts
+
+      // Extract text content (parts may be undefined)
+      const parts = candidate.content.parts || [];
+      const content = parts
         .map(part => part.text || '')
         .join('');
 
       // Extract tool calls
-      const toolCalls = this.extractToolCalls(candidate.content.parts as Part[]);
+      const toolCalls = this.extractToolCalls(parts as Part[]);
 
       // Map finish reason
       let finishReason = finishReasonMap[candidate.finishReason || 'error'];
@@ -699,13 +700,14 @@ export class VertexAIDriver implements AIDriver {
         };
       }
 
-      // Extract text content
-      const content = candidate.content.parts
+      // Extract text content (parts may be undefined)
+      const parts = candidate.content.parts || [];
+      const content = parts
         .map(part => part.text || '')
         .join('');
 
       // Extract tool calls
-      const toolCalls = this.extractToolCalls(candidate.content.parts as Part[]);
+      const toolCalls = this.extractToolCalls(parts as Part[]);
 
       // Map finish reason
       let finishReason = finishReasonMap[candidate.finishReason || 'error'];

--- a/packages/process/src/workflows/agentic-workflow/process/query-with-tools.ts
+++ b/packages/process/src/workflows/agentic-workflow/process/query-with-tools.ts
@@ -182,20 +182,21 @@ export async function queryWithTools(
     const hasInvalidCalls = invalidCalls.length > 0;
     const hasErrors = hasBuiltinErrors || hasInvalidCalls;
 
-    // No errors: return normally
+    // External tool calls exist → return them as pending (regardless of errors).
+    // Retrying with external calls would cause function call/response count mismatch
+    // because external results are not available yet.
+    if (validExternalCalls.length > 0) {
+      return buildResult(content, queryResult, { pendingToolCalls: validExternalCalls });
+    }
+
+    // No external calls, no errors → return normally
     if (!hasErrors) {
-      if (validExternalCalls.length > 0) {
-        return buildResult(content, queryResult, { pendingToolCalls: validExternalCalls });
-      }
       return buildResult(content, queryResult);
     }
 
     // Errors exist but no retries left → return what we have
     if (retryCount >= maxRetries) {
       qLogger.info('[retry:exhausted]', `gave up after ${maxRetries} retries`);
-      if (validExternalCalls.length > 0) {
-        return buildResult(content, queryResult, { pendingToolCalls: validExternalCalls });
-      }
       return buildResult(content, queryResult);
     }
 


### PR DESCRIPTION
## Summary

- **VertexAI ドライバ**: `candidate.content.parts` が undefined の場合に `.map()` でクラッシュする問題を修正（query / streamQuery 両方）
- **queryWithTools**: 外部ツール呼び出しが混在するターンでリトライすると、function call/response 数が不一致になり Gemini API が 400 エラーを返す問題を修正

## 変更内容

### VertexAI ドライバ (`packages/driver/src/vertexai/vertexai-driver.ts`)
- `candidate.content.parts` を `|| []` でガード（`extractToolCalls` は既に対応済みだったが、テキスト抽出側が未対応だった）

### queryWithTools (`packages/process/src/workflows/agentic-workflow/process/query-with-tools.ts`)
- 外部ツール呼び出しが存在する場合は、エラーの有無に関わらずリトライせず `pendingToolCalls` として返すように変更
- リトライは外部ツールがない場合（builtin/invalid エラーのみ）に限定

## Test plan

- [x] `npx vitest run packages/process/` — 78 tests passed
- [x] `npx tsc --build` — 型チェックパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)