### PR TITLE
release: v0.11.2

### DIFF
--- a/.changeset/driver-default-options-mode.md
+++ b/.changeset/driver-default-options-mode.md
@@ -1,5 +1,0 @@
----
-"@modular-prompt/driver": patch
----
-
-ApplicationConfig.defaultOptions と ModelSpec に mode (QueryMode) を追加。MLX/vLLM の defaultOptions 型も統一。MLX Python 依存を更新 (mlx 0.31.1, mlx-lm 0.31.1, mlx-vlm 0.4.3)。

--- a/packages/driver/CHANGELOG.md
+++ b/packages/driver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modular-prompt/driver
 
+## 0.11.2
+
+### Patch Changes
+
+- 0f874ea: ApplicationConfig.defaultOptions と ModelSpec に mode (QueryMode) を追加。MLX/vLLM の defaultOptions 型も統一。MLX Python 依存を更新 (mlx 0.31.1, mlx-lm 0.31.1, mlx-vlm 0.4.3)。
+
 ## 0.11.1
 
 ### Patch Changes

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modular-prompt/driver",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/experiment/CHANGELOG.md
+++ b/packages/experiment/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modular-prompt/experiment
 
+## 0.4.15
+
+### Patch Changes
+
+- Updated dependencies [0f874ea]
+  - @modular-prompt/driver@0.11.2
+  - @modular-prompt/process@0.4.2
+
 ## 0.4.14
 
 ### Patch Changes

--- a/packages/experiment/package.json
+++ b/packages/experiment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modular-prompt/experiment",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Experiment framework for comparing and evaluating prompt modules",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/process/CHANGELOG.md
+++ b/packages/process/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modular-prompt/process
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies [0f874ea]
+  - @modular-prompt/driver@0.11.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modular-prompt/process",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Process module for modular prompt framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/simple-chat/CHANGELOG.md
+++ b/packages/simple-chat/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @modular-prompt/simple-chat
 
+## 0.2.21
+
+### Patch Changes
+
+- Updated dependencies [0f874ea]
+  - @modular-prompt/driver@0.11.2
+  - @modular-prompt/process@0.4.2
+
 ## 0.2.20
 
 ### Patch Changes

--- a/packages/simple-chat/package.json
+++ b/packages/simple-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modular-prompt/simple-chat",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "type": "module",
   "description": "Sample implementation: Simple chat application using Moduler Prompt with MLX models",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- `@modular-prompt/driver` 0.11.2
  - ApplicationConfig.defaultOptions と ModelSpec に mode (QueryMode) を追加
  - MLX/vLLM の defaultOptions 型統一
  - MLX Python 依存更新 (mlx 0.31.1, mlx-lm 0.31.1, mlx-vlm 0.4.3)
  - QueryLogger でクエリオプションをログ出力
- `@modular-prompt/process` 0.4.2 (依存更新)
- `@modular-prompt/experiment` 0.4.15 (依存更新)
- `@modular-prompt/simple-chat` 0.2.21 (依存更新)

## Test plan
- [x] ビルド確認
- [x] テスト確認（MLX統合テストのタイムアウト1件は既知・無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)