### PR TITLE
chore: mlx-vlm を 0.4.4 に更新

### DIFF
--- a/packages/driver/src/mlx-ml/python/pyproject.toml
+++ b/packages/driver/src/mlx-ml/python/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "jinja2==3.1.6",
     "mlx==0.31.1",
     "mlx-lm==0.31.1",
-    "mlx-vlm==0.4.3",
+    "mlx-vlm==0.4.4",
     "tokenizers==0.22.2",
     "torch==2.9.1",
     "torchvision==0.24.1",

--- a/packages/driver/src/mlx-ml/python/uv.lock
+++ b/packages/driver/src/mlx-ml/python/uv.lock
@@ -791,7 +791,7 @@ requires-dist = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "mlx", specifier = "==0.31.1" },
     { name = "mlx-lm", specifier = "==0.31.1" },
-    { name = "mlx-vlm", specifier = "==0.4.3" },
+    { name = "mlx-vlm", specifier = "==0.4.4" },
     { name = "tokenizers", specifier = "==0.22.2" },
     { name = "torch", specifier = "==2.9.1" },
     { name = "torchvision", specifier = "==0.24.1" },
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "mlx-vlm"
-version = "0.4.3"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasets" },
@@ -846,9 +846,9 @@ dependencies = [
     { name = "transformers" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/d2/cc80916001d73d7f877360054c2fcb5ca54a07fcfee8a325e6d121b3d98b/mlx_vlm-0.4.3.tar.gz", hash = "sha256:70c020edbc629ec6091f530a93d913b328b2c74f83da661322ba6e1bcbdf5035", size = 816749, upload-time = "2026-04-02T21:15:14.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/ec/108aec30efb159940ea29d133d5d8ec14840edbec914869b46eaafac5552/mlx_vlm-0.4.4.tar.gz", hash = "sha256:3197e277c1be9ed1712ea04624df029e486f7747ad93e40e7bd1c9c771f8b179", size = 836370, upload-time = "2026-04-04T15:19:01.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/49/1815a7a74070e923140a065c81de5737e007f525fcd9f8d922a3584e301e/mlx_vlm-0.4.3-py3-none-any.whl", hash = "sha256:225d1b6b5467c15cce92e681f54c3f3c58bbcc180fc0aeefa35386f2db56bb08", size = 995733, upload-time = "2026-04-02T21:15:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/81/235518176c3c8230e5274e91346ecf940591f653e73b0daeb505fb37eea9/mlx_vlm-0.4.4-py3-none-any.whl", hash = "sha256:3ff86ea738ab1914dc1b07e4fa5d4cc34bec5909e540692cfad0af808af13c11", size = 1014936, upload-time = "2026-04-04T15:18:59.328Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- mlx-vlm を 0.4.3 → 0.4.4 に更新
- uv.lock を同期

## Test plan
- [ ] mlx-vlm を使った VLM モデルの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)