### PR TITLE
fix: context-1 の tool_call_end 単体トークン検出対応

### DIFF
--- a/.changeset/fix-context1-tool-call-end.md
+++ b/.changeset/fix-context1-tool-call-end.md
@@ -1,0 +1,9 @@
+---
+"@modular-prompt/driver": patch
+---
+
+fix: context-1 モデルの tool_call_end 単体トークンによる tool call 検出対応
+
+- `hasNativeToolSupport()` で `tool_call_end` 単体トークンも認識するように修正
+- `get_tool_stop_token_ids()` で `special_tokens.tool_call_end` へのフォールバックを追加
+- `parseToolCalls()` で `tool_call_end` 特殊トークンから context-1 パーサーを起動するように修正

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -232,6 +232,10 @@ export class MlxDriver implements AIDriver {
       if (tokens['tool_calls_marker']) {
         return true;
       }
+      // context-1型の単体終了トークン
+      if (tokens['tool_call_end']) {
+        return true;
+      }
     }
 
     return false;

--- a/packages/driver/src/mlx-ml/python/__main__.py
+++ b/packages/driver/src/mlx-ml/python/__main__.py
@@ -332,9 +332,14 @@ def generate_text_vlm(prompt, images, options, stop_token_ids=None):
 
 
 def get_tool_stop_token_ids():
-    """tool_call_format.call_end を stop token ID に変換（汎用）"""
+    """tool_call_format.call_end または special_tokens.tool_call_end を stop token ID に変換（汎用）"""
     tcf = capabilities.get('features', {}).get('chat_template', {}).get('tool_call_format')
     call_end = tcf.get('call_end') if tcf else None
+    # フォールバック: special_tokens の tool_call_end 単体トークン
+    if not call_end:
+        tce = capabilities.get('special_tokens', {}).get('tool_call_end')
+        if tce and isinstance(tce, dict) and 'text' in tce:
+            call_end = tce['text']
     if not call_end:
         return None
     token_id = tokenizer.convert_tokens_to_ids(call_end)

--- a/packages/driver/src/mlx-ml/tool-call-parser.ts
+++ b/packages/driver/src/mlx-ml/tool-call-parser.ts
@@ -48,7 +48,9 @@ export function parseToolCalls(
   const toolCallFormat = runtimeInfo?.features?.chat_template?.tool_call_format;
 
   // 1.1 context-1形式: to=functions.{name}<|channel|>...<|message|>{json}
-  if (toolCallFormat?.call_start === 'to=functions.' || toolCallFormat?.call_end === '<|call|>') {
+  const toolCallEndToken = runtimeInfo?.special_tokens?.['tool_call_end'];
+  const hasCallEndToken = toolCallEndToken && typeof toolCallEndToken === 'object' && 'text' in toolCallEndToken && (toolCallEndToken as SpecialToken).text === '<|call|>';
+  if (toolCallFormat?.call_start === 'to=functions.' || toolCallFormat?.call_end === '<|call|>' || hasCallEndToken) {
     const result = parseContext1ToolCalls(text);
     if (result.toolCalls.length > 0) {
       return result;


### PR DESCRIPTION
## Summary
- `hasNativeToolSupport()` で `tool_call_end` 単体トークンも認識
- `get_tool_stop_token_ids()` で `special_tokens.tool_call_end` へのフォールバック追加
- `parseToolCalls()` で `tool_call_end` 特殊トークンから context-1 パーサー起動

## Background
v0.11.4 で context-1 の `tool_call_end` トークンは検出されるようになったが、`tool_call_format` がテンプレートから抽出できないため `hasNativeToolSupport()` が false のままだった。単体トークンからも判定できるようにする。

## Test plan
- [x] `tool-call-parser.test.ts` 37テスト全パス
- [x] TypeScript ビルド成功
- [ ] context-1 モデルで tools 付きクエリの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)