### PR TITLE
fix: context-1 パーサーの特殊トークン対応と stop token 堅牢化

### DIFF
--- a/.changeset/fix-context1-constrain-token.md
+++ b/.changeset/fix-context1-constrain-token.md
@@ -1,0 +1,9 @@
+---
+"@modular-prompt/driver": patch
+---
+
+fix: context-1 パーサーが `<|constrain|>` 等の特殊トークンを含む出力を正しくパースできない問題を修正
+
+- `parseContext1ToolCalls` の正規表現 `[^<]*` → `[\s\S]*?` に変更
+- `get_tool_stop_token_ids()` で `special_tokens.tool_call_end.id` を直接使用するように改善
+- stop token チェックで `response.token` を `int()` キャストして型安全性を確保

--- a/packages/driver/src/mlx-ml/python/__main__.py
+++ b/packages/driver/src/mlx-ml/python/__main__.py
@@ -323,7 +323,8 @@ def generate_text_vlm(prompt, images, options, stop_token_ids=None):
         temperature=temperature,
     ):
         # 追加 stop token チェック（tool call end 等）
-        if stop_token_ids and hasattr(response, 'token') and response.token in stop_token_ids:
+        if stop_token_ids and hasattr(response, 'token') and int(response.token) in stop_token_ids:
+            sys.stderr.write(f"--- stop token detected (vlm): {int(response.token)}\n")
             print('\n', end='\0', flush=True)
             return
         print(response.text.replace('\0', ''), end='', flush=True)
@@ -333,20 +334,25 @@ def generate_text_vlm(prompt, images, options, stop_token_ids=None):
 
 def get_tool_stop_token_ids():
     """tool_call_format.call_end または special_tokens.tool_call_end を stop token ID に変換（汎用）"""
+    stop_ids = set()
+
+    # 1. tool_call_format.call_end から取得
     tcf = capabilities.get('features', {}).get('chat_template', {}).get('tool_call_format')
     call_end = tcf.get('call_end') if tcf else None
-    # フォールバック: special_tokens の tool_call_end 単体トークン
-    if not call_end:
-        tce = capabilities.get('special_tokens', {}).get('tool_call_end')
-        if tce and isinstance(tce, dict) and 'text' in tce:
-            call_end = tce['text']
-    if not call_end:
-        return None
-    token_id = tokenizer.convert_tokens_to_ids(call_end)
-    unk_id = getattr(tokenizer, 'unk_token_id', None)
-    if token_id is not None and token_id != unk_id:
-        return {token_id}
-    return None
+    if call_end:
+        token_id = tokenizer.convert_tokens_to_ids(call_end)
+        unk_id = getattr(tokenizer, 'unk_token_id', None)
+        if token_id is not None and token_id != unk_id:
+            stop_ids.add(int(token_id))
+
+    # 2. special_tokens.tool_call_end から直接 ID を取得（フォールバック）
+    tce = capabilities.get('special_tokens', {}).get('tool_call_end')
+    if tce and isinstance(tce, dict) and 'id' in tce:
+        stop_ids.add(int(tce['id']))
+
+    if stop_ids:
+        sys.stderr.write(f"--- tool stop token IDs: {stop_ids}\n")
+    return stop_ids if stop_ids else None
 
 
 def generate_text(prompt, options, stop_token_ids=None):
@@ -383,7 +389,8 @@ def generate_text(prompt, options, stop_token_ids=None):
             print('\n', end='\0', flush=True)
             break
         # 追加 stop token チェック（tool call end 等）
-        if stop_token_ids and hasattr(response, 'token') and response.token in stop_token_ids:
+        if stop_token_ids and hasattr(response, 'token') and int(response.token) in stop_token_ids:
+            sys.stderr.write(f"--- stop token detected: {int(response.token)}\n")
             eos_detected = True
             print('\n', end='\0', flush=True)
             break

--- a/packages/driver/src/mlx-ml/tool-call-parser.ts
+++ b/packages/driver/src/mlx-ml/tool-call-parser.ts
@@ -510,7 +510,7 @@ function parseContext1ToolCalls(text: string): ToolCallParseResult {
 
   // to=functions.{name} ... <|message|>{json} パターン
   // <|call|> は stop token で切断されるため、出力に含まれない場合も含まれる場合もある
-  const regex = /to=functions\.([\w.]+)(?:<\|channel\|>[^<]*)?<\|message\|>([\s\S]*?)(?:<\|call\|>|$)/g;
+  const regex = /to=functions\.([\w.]+)(?:<\|channel\|>[\s\S]*?)?<\|message\|>([\s\S]*?)(?:<\|call\|>|$)/g;
   let match;
   while ((match = regex.exec(text)) !== null) {
     const name = match[1];
@@ -528,7 +528,7 @@ function parseContext1ToolCalls(text: string): ToolCallParseResult {
   }
 
   if (toolCalls.length > 0) {
-    content = text.replace(/to=functions\.[\w.]+(?:<\|channel\|>[^<]*)?<\|message\|>[\s\S]*?(?:<\|call\|>|$)/g, '').trim();
+    content = text.replace(/to=functions\.[\w.]+(?:<\|channel\|>[\s\S]*?)?<\|message\|>[\s\S]*?(?:<\|call\|>|$)/g, '').trim();
   }
 
   return { content, toolCalls };


### PR DESCRIPTION
## Summary
- `parseContext1ToolCalls` の正規表現 `[^<]*` → `[\s\S]*?` に変更（`<|constrain|>` 等の特殊トークンを含む出力に対応）
- `get_tool_stop_token_ids()` で `special_tokens.tool_call_end.id` を直接使用（`convert_tokens_to_ids` の再変換を回避）
- `generate_text()` / `generate_text_vlm()` で `response.token` を `int()` キャスト（mx.array 型との比較問題を回避）
- デバッグ用 stderr ログを追加

## Test plan
- [x] `tool-call-parser.test.ts` 37テスト全パス
- [x] TypeScript ビルド成功
- [ ] context-1 モデルで `<|constrain|>` を含む tool call 出力のパース確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)