### PR TITLE
fix: ワークフローログを logEntries に含める

### DIFF
--- a/.changeset/fix-workflow-log-entries.md
+++ b/.changeset/fix-workflow-log-entries.md
@@ -1,0 +1,9 @@
+---
+"@modular-prompt/process": patch
+---
+
+fix: ワークフローレベルのログを WorkflowResult.logEntries に含めるように修正
+
+- toolAgentProcess, agenticProcess, queryWithTools の Logger に `accumulate: true` を設定
+- 各ワークフローのリターンパスで `logger.getLogEntries()` を logEntries に集約
+- `logger.context()` で作成された子ロガーのエントリも明示的に収集

--- a/packages/process/src/workflows/agentic-workflow/agentic-workflow.ts
+++ b/packages/process/src/workflows/agentic-workflow/agentic-workflow.ts
@@ -36,7 +36,7 @@ import {
 } from './process/builtin-tools.js';
 import { queryWithTools, rethrowAsWorkflowError } from './process/query-with-tools.js';
 
-const logger = new Logger({ prefix: 'process', context: 'agentic' });
+const logger = new Logger({ prefix: 'process', context: 'agentic', accumulate: true });
 
 /**
  * Strip <think>...</think> blocks from model output.
@@ -195,7 +195,7 @@ async function executeTask(
       metadata: {
         consumedUsage: result.consumedUsage,
         responseUsage: result.responseUsage,
-        logEntries: result.logEntries,
+        logEntries: aggregateLogEntries([result.logEntries, taskLogger.getLogEntries()]),
         errors: result.errors,
       },
     };
@@ -347,7 +347,10 @@ export async function agenticProcess<T>(
     },
     consumedUsage: aggregateUsage(executionLog.map(l => l.metadata?.consumedUsage)),
     responseUsage: lastLog?.metadata?.responseUsage,
-    logEntries: aggregateLogEntries(executionLog.map(l => l.metadata?.logEntries)),
+    logEntries: aggregateLogEntries([
+      ...executionLog.map(l => l.metadata?.logEntries),
+      logger.getLogEntries(),
+    ]),
     errors: aggregateLogEntries(executionLog.map(l => l.metadata?.errors)),
     metadata: {
       planTasks: taskList.length,

--- a/packages/process/src/workflows/agentic-workflow/process/query-with-tools.ts
+++ b/packages/process/src/workflows/agentic-workflow/process/query-with-tools.ts
@@ -18,7 +18,7 @@ import type { ToolSpec, ToolCallLog } from '../types.js';
 import { isBuiltinTool } from './builtin-tools.js';
 import { aggregateUsage, aggregateLogEntries } from '../../usage-utils.js';
 
-const logger = new Logger({ prefix: 'process', context: 'agentic' });
+const logger = new Logger({ prefix: 'process', context: 'agentic', accumulate: true });
 
 /**
  * Execute builtin tool calls and return ToolResultMessageElements
@@ -121,6 +121,7 @@ export async function queryWithTools(
   const buildResult = (content: string, lastResult: QueryResult, extra?: Partial<QueryWithToolsResult>): QueryWithToolsResult => {
     allUsages.push(lastResult.usage);
     allLogEntries.push(lastResult.logEntries);
+    allLogEntries.push(qLogger.getLogEntries());
     allErrors.push(lastResult.errors);
     return {
       content,

--- a/packages/process/src/workflows/tool-agent-workflow.ts
+++ b/packages/process/src/workflows/tool-agent-workflow.ts
@@ -18,7 +18,7 @@ import { WorkflowExecutionError, type WorkflowResult, type ToolSpec, type ToolCa
 import { type DriverInput, type ModelRole, resolveDriver } from './driver-input.js';
 import { aggregateUsage, aggregateLogEntries } from './usage-utils.js';
 
-const logger = new Logger({ prefix: 'process', context: 'tool-agent' });
+const logger = new Logger({ prefix: 'process', context: 'tool-agent', accumulate: true });
 
 /**
  * Options for tool agent workflow
@@ -98,6 +98,7 @@ export async function toolAgentProcess<TContext extends ToolAgentContext & Recor
         allErrors.push(result.errors);
 
         logger.info(`[end] ${turn} turn(s)`);
+        allLogEntries.push(logger.getLogEntries());
         return {
           output: content,
           context,
@@ -168,6 +169,7 @@ export async function toolAgentProcess<TContext extends ToolAgentContext & Recor
 
     // maxTurns exhausted — return last content
     logger.info(`[end] max turns (${maxTurns}) reached`);
+    allLogEntries.push(logger.getLogEntries());
     return {
       output: '',
       context,


### PR DESCRIPTION
## Summary
- toolAgentProcess, agenticProcess, queryWithTools のワークフロー内部ログ（ツール呼び出し、ターン情報等）が `WorkflowResult.logEntries` に含まれていなかった問題を修正
- Logger の `accumulate` モードを有効化し、各リターンパスで `getLogEntries()` を集約
- `logger.context()` で作成された子ロガーのエントリも明示的に収集（静的共有だが context フィルタにより親では取得不可のため）

## Test plan
- [x] `npx vitest run packages/process/src/workflows/` — 全50テスト通過
- [x] `npx tsc -b packages/process --force` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)