### PR TITLE
fix: Gemma4 thinking ブロック除去対応

### DIFF
--- a/.changeset/strip-gemma4-think-blocks.md
+++ b/.changeset/strip-gemma4-think-blocks.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/process": patch
+---
+
+fix: Gemma4 の `<|channel>thought...<channel|>` ブロックを `<think>` と同様に除去する対応を追加

--- a/packages/process/src/workflows/agentic-workflow/agentic-workflow.ts
+++ b/packages/process/src/workflows/agentic-workflow/agentic-workflow.ts
@@ -42,7 +42,12 @@ const logger = new Logger({ prefix: 'process', context: 'agentic', accumulate: t
  * Thinking traces are internal reasoning and should not be passed to subsequent tasks.
  */
 function stripThinkBlocks(text: string): string {
-  return text.replace(/<think>[\s\S]*?<\/think>\s*/g, '').replace(/^[\s\S]*?<\/think>\s*/g, '').trim();
+  return text
+    .replace(/<think>[\s\S]*?<\/think>\s*/g, '')
+    .replace(/^[\s\S]*?<\/think>\s*/g, '')
+    .replace(/<\|channel>thought[\s\S]*?<channel\|>\s*/g, '')
+    .replace(/^[\s\S]*?<channel\|>\s*/g, '')
+    .trim();
 }
 
 /**


### PR DESCRIPTION
## Summary
- `stripThinkBlocks` に Gemma4 の `<|channel>thought...<channel|>` パターンを追加
- `<think>...</think>` と同様に、thinking トレースが後続タスクに渡されないようにする
- Gemma4 では `thought` が唯一のチャネルタイプであり、内部推論の隠蔽用途

## Test plan
- [x] process パッケージの全テスト通過（12ファイル78テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)