### PR TITLE
fix(driver): MLX プロセス通信のバグ修正と chat template 文字列の除去

### DIFF
--- a/.changeset/fix-mlx-process-communication.md
+++ b/.changeset/fix-mlx-process-communication.md
@@ -1,0 +1,9 @@
+---
+"@modular-prompt/driver": patch
+---
+
+fix: MLX プロセス通信のバグ修正と chat template 文字列の除去
+
+- capabilities JSON から未使用の template_string フィールドを除去（レスポンスサイズ削減）
+- handleJsonResponse と onRequestCompleted の二重呼び出しによる isProcessing フラグ不整合を修正
+- null文字後のデータが消失するバグを修正（stdout バッファ結合時の対策）

--- a/packages/driver/src/mlx-ml/mlx-driver.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.test.ts
@@ -36,7 +36,6 @@ vi.mock('./process/index.js', () => ({
         vocab_size: 32000,
         model_max_length: 4096,
         chat_template: {
-          template_string: 'some_template',
           supported_roles: ['system', 'user', 'assistant'],
           preview: null,
           constraints: {}

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -445,7 +445,6 @@ export class MlxDriver implements AIDriver {
         vocabSize: this.runtimeInfo.features.vocab_size,
         modelMaxLength: this.runtimeInfo.features.model_max_length,
         chatTemplate: this.runtimeInfo.features.chat_template ? {
-          templateString: this.runtimeInfo.features.chat_template.template_string,
           supportedRoles: this.runtimeInfo.features.chat_template.supported_roles,
           preview: this.runtimeInfo.features.chat_template.preview,
           constraints: this.runtimeInfo.features.chat_template.constraints,

--- a/packages/driver/src/mlx-ml/process/process-communication.ts
+++ b/packages/driver/src/mlx-ml/process/process-communication.ts
@@ -70,14 +70,30 @@ export class ProcessCommunication {
     });
 
     this.process.stdout.on('data', (data) => {
-      // ここはnull文字でなくてはならない
-      const nullIndex = data.indexOf('\0');
-      
+      this.processData(data);
+    });
+
+    this.process.on('error', (err) => {
+      logger.error('Child process error:', err);
+    });
+  }
+
+  /**
+   * stdoutから受信したデータを処理する
+   * null文字をレスポンス区切りとして解釈し、
+   * 1つのdataチャンクに複数のレスポンスが含まれる場合も正しく処理する
+   */
+  private processData(data: Buffer): void {
+    let remaining: Buffer = data;
+
+    while (remaining.length > 0) {
+      const nullIndex = remaining.indexOf('\0');
+
       if (nullIndex !== -1) {
         // null文字が見つかった場合、レスポンス終了
-        const chunk = this.decoder.write(data.slice(0, nullIndex));
+        const chunk = this.decoder.write(remaining.slice(0, nullIndex));
         this.decoder = new StringDecoder('utf8');
-        
+
         if (this.currentStream) {
           // ストリーミングレスポンスの場合
           this.currentStream.push(chunk);
@@ -89,12 +105,15 @@ export class ProcessCommunication {
           this.callbacks.onJsonResponse(this.jsonBuffer);
           this.jsonBuffer = '';
         }
-        
+
         this.callbacks.onRequestCompleted();
+
+        // null文字以降の残りデータを続けて処理
+        remaining = remaining.slice(nullIndex + 1);
       } else {
         // null文字がない場合、データを蓄積
-        const chunk = this.decoder.write(data);
-        
+        const chunk = this.decoder.write(remaining);
+
         if (this.currentStream) {
           // ストリーミング中
           this.currentStream.push(chunk);
@@ -102,12 +121,9 @@ export class ProcessCommunication {
           // JSONレスポンス蓄積中
           this.jsonBuffer += chunk;
         }
+        break;
       }
-    });
-
-    this.process.on('error', (err) => {
-      logger.error('Child process error:', err);
-    });
+    }
   }
 
   createNewStream(): Readable {

--- a/packages/driver/src/mlx-ml/process/queue.ts
+++ b/packages/driver/src/mlx-ml/process/queue.ts
@@ -158,8 +158,9 @@ export class QueueManager {
         }
       }
     }
-    this.isProcessing = false;
-    this.processNext(); // 次のリクエストを処理
+    // 注: isProcessing/processNext は onRequestCompleted() に一元化
+    // handleJsonResponse と onRequestCompleted の二重呼び出しによる
+    // isProcessing フラグの不整合を防止
   }
 
   onRequestCompleted(): void {

--- a/packages/driver/src/mlx-ml/process/types.ts
+++ b/packages/driver/src/mlx-ml/process/types.ts
@@ -109,7 +109,6 @@ export interface ToolCallFormat {
 }
 
 export interface ChatTemplateInfo {
-  template_string?: string;
   supported_roles: string[];
   preview?: string;
   constraints: Record<string, unknown>;

--- a/packages/driver/src/mlx-ml/python/token_utils.py
+++ b/packages/driver/src/mlx-ml/python/token_utils.py
@@ -291,7 +291,6 @@ def get_chat_template_info(tokenizer):
         return None
 
     template_info = {
-        "template_string": getattr(tokenizer, 'chat_template', None),
         "supported_roles": [],
         "preview": None,
         "constraints": {}

--- a/packages/driver/src/mlx-ml/types.ts
+++ b/packages/driver/src/mlx-ml/types.ts
@@ -85,7 +85,6 @@ export interface ToolCallFormat {
  * チャットテンプレート情報
  */
 export interface ChatTemplateInfo {
-  templateString?: string;
   supportedRoles: string[];
   preview?: string;
   constraints: Record<string, unknown>;


### PR DESCRIPTION
## Summary

- capabilities JSON から未使用の `template_string`（Jinja2テンプレート全文）を除去し、レスポンスサイズを大幅に削減
- `handleJsonResponse` と `onRequestCompleted` の二重呼び出しによる `isProcessing` フラグ不整合を修正（キュー状態遷移を `onRequestCompleted` に一元化）
- `process-communication.ts` で null文字後のデータが消失するバグを修正（`processData` ループ化で stdout バッファ結合時にも正しく処理）

## 詳細

### template_string 除去
`token_utils.py` の `get_chat_template_info()` が `tokenizer.chat_template`（数千文字のJinja2テンプレート）をそのまま capabilities JSON に含めていた。TypeScript 側では一切使用されておらず、ログやデバッグ出力に漏れるリスクがあったため削除。

### double-call バグ
JSON レスポンス受信時、`handleJsonResponse()` と `onRequestCompleted()` の両方が `isProcessing = false` + `processNext()` を実行していた。`handleJsonResponse()` 内の `processNext()` で次のストリーミングリクエストが開始された直後に、`onRequestCompleted()` が `isProcessing` を `false` にリセットしてしまう可能性があった。

### null文字後データ消失
`stdout.on('data')` で受信したバッファに null文字の後にもデータが続く場合（OS カーネルのバッファ結合）、後続データが無視されていた。`while` ループで残りデータを正しく処理するよう修正。

## Test plan
- [x] `pnpm run build` 成功
- [x] `pnpm test` 全テスト通過（442 passed in driver）

🤖 Generated with [Claude Code](https://claude.com/claude-code)