### PR TITLE
fix: __replan ログ改善、__register_task 二重出力修正、Logger drain デフォルト化

### DIFF
--- a/.changeset/replan-log-and-drain.md
+++ b/.changeset/replan-log-and-drain.md
@@ -1,0 +1,10 @@
+---
+"@modular-prompt/process": patch
+"@modular-prompt/utils": patch
+---
+
+fix: __replan ログ改善、__register_task 二重出力修正、Logger drain デフォルト化
+
+- __replan の tool result に完了済み/残りタスクの情報を含めるようにした
+- __register_task の tool result を登録確認のみに簡素化（並列呼び出し時の冗長出力を解消）
+- Logger.getLogEntries() に drain オプション追加（デフォルト true）で蓄積の無制限増大を防止

--- a/packages/process/src/workflows/agentic-workflow/process/builtin-tools.ts
+++ b/packages/process/src/workflows/agentic-workflow/process/builtin-tools.ts
@@ -137,10 +137,7 @@ export function createPlanningTools(taskList: AgenticTask[], currentIndex: numbe
       registerTask(taskList, entry, currentIndex + insertOffset);
       insertOffset++;
 
-      // Return full updated task list so the model can see the current plan
-      return 'Updated task list:\n' + taskList
-        .map((t, i) => `${i + 1}. ${t.name ? `[${t.name}] ` : ''}(${t.taskType}): ${t.instruction}`)
-        .join('\n');
+      return `Registered: [${entry.name}] (${entry.taskType || 'think'})`;
     },
   }];
 }
@@ -174,38 +171,57 @@ const timeTool: ToolSpec = {
  * 再プランニング要求ツール
  * ワークフロー側で検出され、実際の再プランニングが実行される
  */
-const replanTool: ToolSpec = {
-  definition: {
-    name: '__replan',
-    description: 'Request re-planning of the workflow. Triggers a new planning phase that considers completed deliverables and remaining tasks.',
-    parameters: {
-      type: 'object',
-      properties: {
-        reason: {
-          type: 'string',
-          description: 'Why re-planning is needed.',
+/**
+ * Execution フェーズ用の __replan ツールを生成
+ * タスクリストと現在位置を参照してログに残す
+ */
+function createReplanTool(taskList: AgenticTask[], currentIndex: number): ToolSpec {
+  return {
+    definition: {
+      name: '__replan',
+      description: 'Request re-planning of the workflow. Triggers a new planning phase that considers completed deliverables and remaining tasks.',
+      parameters: {
+        type: 'object',
+        properties: {
+          reason: {
+            type: 'string',
+            description: 'Why re-planning is needed.',
+          },
         },
       },
     },
-  },
-  handler: async (args) => {
-    // Return marker object. Actual re-planning is handled by the workflow.
-    return {
-      replan: true,
-      reason: args.reason,
-    };
-  },
-};
+    handler: async (args) => {
+      const completed = taskList
+        .slice(0, currentIndex + 1)
+        .map((t, i) => `${i + 1}. [${t.name || '-'}] (${t.taskType}): ${t.instruction}`)
+        .join('\n');
+      const remaining = taskList
+        .slice(currentIndex + 1)
+        .map((t, i) => `${currentIndex + 2 + i}. [${t.name || '-'}] (${t.taskType}): ${t.instruction}`)
+        .join('\n');
+
+      return [
+        `Re-planning requested: ${args.reason || '(no reason)'}`,
+        '',
+        'Completed tasks:',
+        completed || '(none)',
+        '',
+        'Remaining tasks (will be cleared):',
+        remaining || '(none)',
+      ].join('\n');
+    },
+  };
+}
 
 /**
  * Execution フェーズ用の組み込みツールを生成
  */
 export function createExecutionBuiltinTools(
-  _taskList: AgenticTask[],
-  _currentIndex: number
+  taskList: AgenticTask[],
+  currentIndex: number
 ): ToolSpec[] {
   return [
-    replanTool,
+    createReplanTool(taskList, currentIndex),
     timeTool,
   ];
 }

--- a/packages/utils/src/logger/logger.test.ts
+++ b/packages/utils/src/logger/logger.test.ts
@@ -248,11 +248,11 @@ describe('Logger', () => {
       logger.info('info msg');
       logger.debug('debug msg');
 
-      const errorLogs = logger.getLogEntries({ level: 'error' });
+      const errorLogs = logger.getLogEntries({ level: 'error', drain: false });
       expect(errorLogs).toHaveLength(1);
       expect(errorLogs[0].level).toBe('error');
 
-      const warnLogs = logger.getLogEntries({ level: ['warn', 'error'] });
+      const warnLogs = logger.getLogEntries({ level: ['warn', 'error'], drain: false });
       expect(warnLogs).toHaveLength(2);
     });
 
@@ -529,13 +529,13 @@ describe('Logger', () => {
       logger2.info('message 2');
 
       // All instances see the same log entries (when filterByContext is disabled)
-      expect(logger1.getLogEntries({ filterByContext: false })).toHaveLength(2);
-      expect(logger2.getLogEntries({ filterByContext: false })).toHaveLength(2);
-      expect(logger.getLogEntries({ filterByContext: false })).toHaveLength(2);
+      expect(logger1.getLogEntries({ filterByContext: false, drain: false })).toHaveLength(2);
+      expect(logger2.getLogEntries({ filterByContext: false, drain: false })).toHaveLength(2);
+      expect(logger.getLogEntries({ filterByContext: false, drain: false })).toHaveLength(2);
 
-      // By default, each instance only sees its own context
-      expect(logger1.getLogEntries()).toHaveLength(1);
-      expect(logger2.getLogEntries()).toHaveLength(1);
+      // By default, each instance only sees its own context (drain removes them)
+      expect(logger1.getLogEntries({ drain: false })).toHaveLength(1);
+      expect(logger2.getLogEntries({ drain: false })).toHaveLength(1);
     });
 
     it('should write to same log file from all instances', async () => {
@@ -573,14 +573,14 @@ describe('Logger', () => {
       testLogger.info('should not log');
       testLogger.warn('should log');
 
-      expect(logger.getLogEntries()).toHaveLength(1);
+      expect(logger.getLogEntries({ drain: false })).toHaveLength(1);
 
       // Change global config
       Logger.configure({ level: 'info', accumulateLevel: 'info' });
 
       testLogger.info('now should log');
 
-      expect(logger.getLogEntries()).toHaveLength(2);
+      expect(logger.getLogEntries({ drain: false })).toHaveLength(2);
     });
 
     it('should filter by context by default', () => {
@@ -597,12 +597,12 @@ describe('Logger', () => {
       dbLogger.info('db message 3');
 
       // Each logger sees only its own context by default
-      expect(apiLogger.getLogEntries()).toHaveLength(2);
-      expect(dbLogger.getLogEntries()).toHaveLength(3);
+      expect(apiLogger.getLogEntries({ drain: false })).toHaveLength(2);
+      expect(dbLogger.getLogEntries({ drain: false })).toHaveLength(3);
 
       // Disable filter to see all
-      expect(apiLogger.getLogEntries({ filterByContext: false })).toHaveLength(5);
-      expect(dbLogger.getLogEntries({ filterByContext: false })).toHaveLength(5);
+      expect(apiLogger.getLogEntries({ filterByContext: false, drain: false })).toHaveLength(5);
+      expect(dbLogger.getLogEntries({ filterByContext: false, drain: false })).toHaveLength(5);
     });
 
     it('should filter stats by context by default', () => {

--- a/packages/utils/src/logger/logger.ts
+++ b/packages/utils/src/logger/logger.ts
@@ -304,6 +304,7 @@ export class Logger {
       limit?: number;
       search?: string;
       filterByContext?: boolean; // デフォルト: true（このインスタンスのcontextのみ）
+      drain?: boolean; // デフォルト: true（取得したエントリを蓄積から除去）
     } = {}
   ): LogEntry[] {
     let filtered = [...Logger.logEntries];
@@ -342,6 +343,13 @@ export class Logger {
     // 制限
     if (options.limit && options.limit > 0) {
       filtered = filtered.slice(-options.limit);
+    }
+
+    // 取得したエントリを蓄積から除去（デフォルト有効）
+    const drain = options.drain ?? true;
+    if (drain && filtered.length > 0) {
+      const drained = new Set(filtered);
+      Logger.logEntries = Logger.logEntries.filter(entry => !drained.has(entry));
     }
 
     return filtered;


### PR DESCRIPTION
## Summary

- `__replan` の tool result に完了済み/残りタスク情報を含め、ログの可読性を向上
- `__register_task` の tool result を登録確認のみに簡素化（並列 tool call 時の冗長なタスクリスト出力を解消）
- `Logger.getLogEntries()` に `drain` オプション追加（デフォルト `true`）で取得済みエントリを自動除去

## Test plan
- [x] `pnpm run build` 成功
- [x] `pnpm test` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)