### PR TITLE
feat: tool call形式検出の一元化とHarmony形式対応

### DIFF
--- a/.changeset/tool-call-format-unification.md
+++ b/.changeset/tool-call-format-unification.md
@@ -1,0 +1,15 @@
+---
+"@modular-prompt/driver": minor
+"@modular-prompt/process": patch
+"@modular-prompt/experiment": patch
+---
+
+tool call形式検出・パーサー選択の一元化と`<think>`タグ抽出のドライバー統合
+
+- tool call形式検出をtool_call_format（Python側検出結果）に一元化
+- hasNativeToolSupport()を簡素化（5シグナル → tool_call_format.call_startのみ）
+- selectResponseProcessorをtool_parser_typeベースに変更
+- parseToolCallsからHarmony/context-1重複パスを削除
+- Harmonyレスポンスパーサーでストリーム出力（暗黙`<|start|>`省略）に対応
+- `<think>`タグ抽出をcontent-utils.extractThinkingContent()に統合し、QueryResult.thinkingContentで一本化
+- process/experimentの個別stripThinkBlocks処理を廃止

--- a/docs/DRIVER_API.md
+++ b/docs/DRIVER_API.md
@@ -106,12 +106,17 @@ interface Attachment {
 
 ```typescript
 interface QueryOptions {
-  temperature?: number;   // 生成のランダム性 (0-2)
-  maxTokens?: number;     // 最大トークン数
-  topP?: number;          // トップPサンプリング
-  stream?: boolean;       // ストリーミング有効化
+  temperature?: number;         // 生成のランダム性 (0-2)
+  maxTokens?: number;           // 最大トークン数
+  topP?: number;                // トップPサンプリング
+  stream?: boolean;             // ストリーミング有効化
+  reasoningEffort?: 'low' | 'medium' | 'high';  // 推論深度（thinking系モデル用）
 }
 ```
+
+**reasoningEffort**: 推論特化モデル（OpenAI o-series、llm-jp-4-thinking等）の思考深度を制御します。
+- 対応ドライバー: OpenAI（APIパラメータとして送信）、MLX（`apply_chat_template`に渡す）
+- 非対応ドライバーでは無視されます
 
 ### QueryResult
 
@@ -120,6 +125,7 @@ interface QueryOptions {
 ```typescript
 interface QueryResult {
   content: string;                     // テキストレスポンス
+  thinkingContent?: string;            // 思考・推論チャネルの内容
   structuredOutput?: unknown;          // 構造化出力（スキーマ指定時）
   finishReason?: 'stop' | 'length' | 'error' | 'tool_calls';
   usage?: {
@@ -131,6 +137,10 @@ interface QueryResult {
   errors?: LogEntry[];                 // エラーレベルのログエントリ
 }
 ```
+
+**thinkingContent**: モデルの思考・推論過程の内容を格納します。
+- Harmonyフォーマット（llm-jp-4等）の `analysis` チャネル
+- 将来的にAnthropicのthinkingブロック等にも対応予定
 
 ### StreamResult
 

--- a/packages/driver/README.md
+++ b/packages/driver/README.md
@@ -146,6 +146,31 @@ npx tsx scripts/check-special-tokens.ts <model-name>
 npx tsx scripts/check-special-tokens.ts mlx-community/gemma-3-270m-it-qat-8bit
 ```
 
+#### Thinking系モデルの推論深度制御
+
+`reasoningEffort` オプションで推論深度を制御できます（llm-jp-4-thinking等に対応）:
+
+```typescript
+const result = await driver.query(prompt, {
+  reasoningEffort: 'high',  // 'low' | 'medium' | 'high'
+  temperature: 0.7
+});
+
+// thinking チャネルの内容を取得
+if (result.thinkingContent) {
+  console.log('Thinking:', result.thinkingContent);
+}
+console.log('Response:', result.content);
+```
+
+**対応モデル**:
+- `llm-jp-4-*-thinking` シリーズ（Harmonyフォーマット）
+- `reasoningEffort` は Python側の `apply_chat_template` に渡されます
+
+**Harmonyフォーマット**: llm-jp-4が採用するOpenAI Harmony Response Format。スペシャルトークン（`<|start|>`, `<|channel|>`, `<|message|>` 等）でメッセージを分割し、`analysis` チャネルを `thinkingContent`、`final` チャネルを `content` に振り分けます。
+
+**技術詳細**: Harmonyフォーマットの後処理設計、ResponseProcessorアーキテクチャ、tool call形式については [prompts/memos/harmony-format-postprocessing.v1.md](../../prompts/memos/harmony-format-postprocessing.v1.md) を参照してください。
+
 ### vLLM（CUDA GPU）
 
 vLLMドライバーは独立したPythonエンジンプロセスとして起動します。

--- a/packages/driver/src/content-utils.test.ts
+++ b/packages/driver/src/content-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { contentToString, extractImagePaths } from './content-utils.js';
+import { contentToString, extractImagePaths, extractThinkingContent } from './content-utils.js';
 import type { Attachment } from '@modular-prompt/core';
 
 describe('contentToString', () => {
@@ -61,6 +61,50 @@ describe('contentToString', () => {
     ];
     const result = contentToString(input);
     expect(result).toBe('Text content\nMore text');
+  });
+});
+
+describe('extractThinkingContent', () => {
+  it('should extract a single think block', () => {
+    const result = extractThinkingContent('<think>考え中...</think>回答です。');
+    expect(result.content).toBe('回答です。');
+    expect(result.thinkingContent).toBe('考え中...');
+  });
+
+  it('should extract multiple think blocks', () => {
+    const result = extractThinkingContent('<think>最初の思考</think>中間テキスト<think>追加の思考</think>最終回答');
+    expect(result.content).toBe('中間テキスト最終回答');
+    expect(result.thinkingContent).toBe('最初の思考\n追加の思考');
+  });
+
+  it('should handle closing tag only (stream truncation)', () => {
+    const result = extractThinkingContent('途中の思考</think>回答です。');
+    expect(result.content).toBe('回答です。');
+    expect(result.thinkingContent).toBe('途中の思考');
+  });
+
+  it('should return undefined thinkingContent when no think tags', () => {
+    const result = extractThinkingContent('普通のテキストです。');
+    expect(result.content).toBe('普通のテキストです。');
+    expect(result.thinkingContent).toBeUndefined();
+  });
+
+  it('should handle empty think block', () => {
+    const result = extractThinkingContent('<think></think>回答');
+    expect(result.content).toBe('回答');
+    expect(result.thinkingContent).toBeUndefined();
+  });
+
+  it('should handle multiline think content', () => {
+    const result = extractThinkingContent('<think>\nステップ1: 分析\nステップ2: 判断\n</think>\n結果です。');
+    expect(result.content).toBe('結果です。');
+    expect(result.thinkingContent).toBe('ステップ1: 分析\nステップ2: 判断');
+  });
+
+  it('should handle empty string input', () => {
+    const result = extractThinkingContent('');
+    expect(result.content).toBe('');
+    expect(result.thinkingContent).toBeUndefined();
   });
 });
 

--- a/packages/driver/src/content-utils.ts
+++ b/packages/driver/src/content-utils.ts
@@ -1,5 +1,39 @@
 import type { Attachment } from '@modular-prompt/core';
 
+export interface ThinkingExtractResult {
+  content: string;
+  thinkingContent?: string;
+}
+
+/**
+ * Extract <think>...</think> blocks from model output.
+ * Returns cleaned content and extracted thinking content.
+ */
+export function extractThinkingContent(text: string): ThinkingExtractResult {
+  const thinkingParts: string[] = [];
+
+  const fullBlockRegex = /<think>([\s\S]*?)<\/think>\s*/g;
+  let match;
+  while ((match = fullBlockRegex.exec(text)) !== null) {
+    const inner = match[1].trim();
+    if (inner) thinkingParts.push(inner);
+  }
+  let cleaned = text.replace(fullBlockRegex, '');
+
+  const headRegex = /^[\s\S]*?<\/think>\s*/;
+  const headMatch = cleaned.match(headRegex);
+  if (headMatch) {
+    const inner = headMatch[0].replace(/<\/think>\s*$/, '').trim();
+    if (inner) thinkingParts.push(inner);
+    cleaned = cleaned.replace(headRegex, '');
+  }
+
+  return {
+    content: cleaned.trim(),
+    thinkingContent: thinkingParts.length > 0 ? thinkingParts.join('\n') : undefined,
+  };
+}
+
 /**
  * Extract text content from string or Attachment array.
  * For Attachment arrays, only text-type attachments are included.

--- a/packages/driver/src/mlx-ml/mlx-driver.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.test.ts
@@ -99,6 +99,92 @@ describe('MlxDriver', () => {
 
   });
 
+  describe('hasNativeToolSupport', () => {
+    it('should return true when tool_call_format.call_start exists', async () => {
+      const driver = new MlxDriver({ model: 'test-model' });
+      // @ts-expect-error - Accessing private property for testing
+      await driver.ensureInitialized();
+      // @ts-expect-error - Accessing private property for testing
+      driver.runtimeInfo = {
+        methods: ['chat'],
+        special_tokens: {},
+        features: {
+          apply_chat_template: true,
+          vocab_size: 32000,
+          model_max_length: 4096,
+          chat_template: {
+            supported_roles: ['system', 'user', 'assistant'],
+            tool_call_format: {
+              tool_parser_type: 'json_tools',
+              call_start: '<tool_call>',
+              call_end: '</tool_call>',
+            }
+          }
+        }
+      };
+
+      // @ts-expect-error - Accessing private method for testing
+      expect(driver.hasNativeToolSupport()).toBe(true);
+    });
+
+    it('should return true for harmony format', async () => {
+      const driver = new MlxDriver({ model: 'test-model' });
+      // @ts-expect-error - Accessing private property for testing
+      await driver.ensureInitialized();
+      // @ts-expect-error - Accessing private property for testing
+      driver.runtimeInfo = {
+        methods: ['chat'],
+        special_tokens: {},
+        features: {
+          apply_chat_template: true,
+          vocab_size: 32000,
+          model_max_length: 4096,
+          chat_template: {
+            supported_roles: ['system', 'user', 'assistant'],
+            tool_call_format: {
+              tool_parser_type: 'harmony',
+              call_start: 'to=functions.',
+              call_end: '<|call|>',
+            }
+          }
+        }
+      };
+
+      // @ts-expect-error - Accessing private method for testing
+      expect(driver.hasNativeToolSupport()).toBe(true);
+    });
+
+    it('should return false when no tool_call_format exists', async () => {
+      const driver = new MlxDriver({ model: 'test-model' });
+      // @ts-expect-error - Accessing private property for testing
+      await driver.ensureInitialized();
+      // @ts-expect-error - Accessing private property for testing
+      driver.runtimeInfo = {
+        methods: ['chat'],
+        special_tokens: {
+          harmony_call: { text: '<|call|>', id: 100 },
+        },
+        features: {
+          apply_chat_template: true,
+          vocab_size: 32000,
+          model_max_length: 4096,
+        }
+      };
+
+      // @ts-expect-error - Accessing private method for testing
+      expect(driver.hasNativeToolSupport()).toBe(false);
+    });
+
+    it('should return false when runtimeInfo is null', async () => {
+      const driver = new MlxDriver({ model: 'test-model' });
+      // @ts-expect-error - Accessing private property for testing
+      driver.runtimeInfo = null;
+
+      // @ts-expect-error - Accessing private method for testing
+      expect(driver.hasNativeToolSupport()).toBe(false);
+    });
+  });
+
   describe('convertMessages', () => {
     it('should convert messages with string content', () => {
       const input: ChatMessage[] = [

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -8,6 +8,7 @@ import { MlxProcess } from './process/index.js';
 import type { MlxMessage, MlxMlModelOptions, MlxModelCapabilities, MlxContentPart } from './types.js';
 import type { MlxRuntimeInfo, MlxToolDefinition } from './process/types.js';
 import { createModelSpecificProcessor, selectApi } from './process/model-specific.js';
+import { selectResponseProcessor } from './process/model-handlers.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
 import { extractJSON } from '@modular-prompt/utils';
 import { parseToolCalls, formatToolDefinitionsAsText } from './tool-call-parser.js';
@@ -333,7 +334,7 @@ export class MlxDriver implements AIDriver {
       const images = vlm
         ? messages.flatMap(m => 'content' in m && !isToolResult(m) ? extractImagePaths(m.content) : [])
         : [];
-      stream = await this.process.chat(mlxMessages, undefined, mlxOptions, nativeTools, images.length > 0 ? images : undefined, images.length > 0 ? this.maxImageSize : undefined);
+      stream = await this.process.chat(mlxMessages, undefined, mlxOptions, nativeTools, images.length > 0 ? images : undefined, images.length > 0 ? this.maxImageSize : undefined, options?.reasoningEffort);
     }
 
     return stream;
@@ -370,7 +371,7 @@ export class MlxDriver implements AIDriver {
       ...(options?.maxTokens !== undefined && { maxTokens: options.maxTokens }),
       ...(options?.temperature !== undefined && { temperature: options.temperature }),
       ...(options?.topP !== undefined && { topP: options.topP }),
-      ...(options?.topK !== undefined && { topK: options.topK })
+      ...(options?.topK !== undefined && { topK: options.topK }),
     };
     this.queryLogger.mark(mlxOptions as Record<string, unknown>);
 
@@ -388,29 +389,41 @@ export class MlxDriver implements AIDriver {
         throw error;
       }
 
-      // Handle structured output if schema is provided
-      let structuredOutput: unknown | undefined;
-      if (prompt.metadata?.outputSchema && content) {
-        const extracted = extractJSON(content, { multiple: false });
-        if (extracted.source !== 'none' && extracted.data !== null) {
-          structuredOutput = extracted.data;
+      // Response post-processing via model-specific processor
+      const responseProcessor = selectResponseProcessor(this.model);
+      let finalContent = content;
+      let thinkingContent: string | undefined;
+      let toolCalls: ToolCall[] | undefined;
+
+      if (responseProcessor) {
+        const parsed = responseProcessor(content);
+        finalContent = parsed.content;
+        thinkingContent = parsed.thinkingContent;
+        toolCalls = parsed.toolCalls;
+      } else {
+        // Legacy flow: tool call detection only
+        if (options?.tools && options.tools.length > 0) {
+          const parseResult = parseToolCalls(content, this.runtimeInfo);
+          if (parseResult.toolCalls.length > 0) {
+            toolCalls = parseResult.toolCalls;
+            finalContent = parseResult.content;
+          }
         }
       }
 
-      // Tool call detection
-      let toolCalls: ToolCall[] | undefined;
-      let finalContent = content;
-      if (options?.tools && options.tools.length > 0) {
-        const parseResult = parseToolCalls(content, this.runtimeInfo);
-        if (parseResult.toolCalls.length > 0) {
-          toolCalls = parseResult.toolCalls;
-          finalContent = parseResult.content;
+      // Handle structured output if schema is provided
+      let structuredOutput: unknown | undefined;
+      if (prompt.metadata?.outputSchema && finalContent) {
+        const extracted = extractJSON(finalContent, { multiple: false });
+        if (extracted.source !== 'none' && extracted.data !== null) {
+          structuredOutput = extracted.data;
         }
       }
 
       const finishReason: FinishReason = toolCalls ? 'tool_calls' : 'stop';
       return {
         content: finalContent,
+        thinkingContent,
         structuredOutput,
         toolCalls,
         finishReason,

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -244,40 +244,10 @@ export class MlxDriver implements AIDriver {
 
   /**
    * モデルがnativeツール対応かを判定
-   * 複数のシグナルから総合的に判定する
+   * tool_call_format（Python側検出結果）を唯一の判断基準とする
    */
   private hasNativeToolSupport(): boolean {
-    // 1. chat_template 由来の tool_call_format
-    const toolCallFormat = this.runtimeInfo?.features?.chat_template?.tool_call_format;
-    if (toolCallFormat?.call_start) {
-      return true;
-    }
-
-    // 2. special_tokens にtool_call関連トークンが存在するか
-    if (this.runtimeInfo?.special_tokens) {
-      const tokens = this.runtimeInfo.special_tokens;
-      const toolCallKeys = [
-        'tool_call', 'tool_call_explicit', 'tool_call_xml',
-        'tool_calls_section', 'function_call_tags',
-        'longcat_tool_call', 'minimax_tool_call'
-      ];
-      for (const key of toolCallKeys) {
-        const token = tokens[key];
-        if (token && typeof token === 'object' && 'start' in token) {
-          return true;
-        }
-      }
-      // Mistral型の単体マーカー
-      if (tokens['tool_calls_marker']) {
-        return true;
-      }
-      // context-1型の単体終了トークン
-      if (tokens['tool_call_end']) {
-        return true;
-      }
-    }
-
-    return false;
+    return !!this.runtimeInfo?.features?.chat_template?.tool_call_format?.call_start;
   }
   
   /**
@@ -390,7 +360,7 @@ export class MlxDriver implements AIDriver {
       }
 
       // Response post-processing via model-specific processor
-      const responseProcessor = selectResponseProcessor(this.model);
+      const responseProcessor = selectResponseProcessor(this.model, this.runtimeInfo);
       let finalContent = content;
       let thinkingContent: string | undefined;
       let toolCalls: ToolCall[] | undefined;

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -12,7 +12,7 @@ import { selectResponseProcessor } from './process/model-handlers.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
 import { extractJSON } from '@modular-prompt/utils';
 import { parseToolCalls, formatToolDefinitionsAsText } from './tool-call-parser.js';
-import { contentToString, extractImagePaths } from '../content-utils.js';
+import { contentToString, extractImagePaths, extractThinkingContent } from '../content-utils.js';
 import { QueryLogger } from '../query-logger.js';
 
 // ========================================================================
@@ -379,6 +379,13 @@ export class MlxDriver implements AIDriver {
             finalContent = parseResult.content;
           }
         }
+      }
+
+      // Extract <think> tags if not already handled by responseProcessor
+      if (!thinkingContent) {
+        const extracted = extractThinkingContent(finalContent);
+        finalContent = extracted.content;
+        thinkingContent = extracted.thinkingContent;
       }
 
       // Handle structured output if schema is provided

--- a/packages/driver/src/mlx-ml/process/harmony-parser.test.ts
+++ b/packages/driver/src/mlx-ml/process/harmony-parser.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { parseHarmonyResponse } from './harmony-parser.js';
+
+describe('parseHarmonyResponse', () => {
+  it('parses analysis and final messages', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant<|channel|>analysis<|message|>ユーザーは天気を聞いている<|end|><|start|>assistant<|channel|>final<|message|>今日は晴れです。<|end|>'
+    );
+
+    expect(result).toEqual({
+      content: '今日は晴れです。',
+      thinkingContent: 'ユーザーは天気を聞いている',
+      toolCalls: undefined,
+    });
+  });
+
+  it('parses a final-only response', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant<|channel|>final<|message|>こんにちは<|end|>'
+    );
+
+    expect(result).toEqual({
+      content: 'こんにちは',
+      thinkingContent: undefined,
+      toolCalls: undefined,
+    });
+  });
+
+  it('extracts a tool call', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant to=functions.get_weather<|channel|>commentary json<|message|>{"location":"Tokyo"}<|call|>'
+    );
+
+    expect(result).toEqual({
+      content: '',
+      thinkingContent: undefined,
+      toolCalls: [
+        {
+          id: 'harmony_call_0',
+          name: 'get_weather',
+          arguments: { location: 'Tokyo' },
+        },
+      ],
+    });
+  });
+
+  it('parses a full tool call flow and skips tool results', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant<|channel|>analysis<|message|>天気APIを呼ぶ<|end|><|start|>assistant to=functions.get_weather<|channel|>commentary json<|message|>{"location":"Tokyo"}<|call|><|start|>functions.get_weather to=assistant<|channel|>commentary<|message|>"sunny"<|end|><|start|>assistant<|channel|>final<|message|>東京は晴れです。<|end|>'
+    );
+
+    expect(result).toEqual({
+      content: '東京は晴れです。',
+      thinkingContent: '天気APIを呼ぶ',
+      toolCalls: [
+        {
+          id: 'harmony_call_0',
+          name: 'get_weather',
+          arguments: { location: 'Tokyo' },
+        },
+      ],
+    });
+  });
+
+  it('handles an incomplete response without an end token', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant<|channel|>final<|message|>途中で切れた'
+    );
+
+    expect(result).toEqual({
+      content: '途中で切れた',
+      thinkingContent: undefined,
+      toolCalls: undefined,
+    });
+  });
+
+  it('handles a response terminated by a return token', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant<|channel|>final<|message|>最終回答<|return|>'
+    );
+
+    expect(result).toEqual({
+      content: '最終回答',
+      thinkingContent: undefined,
+      toolCalls: undefined,
+    });
+  });
+
+  it('joins multiple analysis messages', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant<|channel|>analysis<|message|>まず考える<|end|><|start|>assistant<|channel|>analysis<|message|>さらに検討<|end|><|start|>assistant<|channel|>final<|message|>結論<|end|>'
+    );
+
+    expect(result).toEqual({
+      content: '結論',
+      thinkingContent: 'まず考える\nさらに検討',
+      toolCalls: undefined,
+    });
+  });
+
+  it('trims surrounding whitespace from content', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant<|channel|>final<|message|>  コンテンツ  <|end|>'
+    );
+
+    expect(result).toEqual({
+      content: 'コンテンツ',
+      thinkingContent: undefined,
+      toolCalls: undefined,
+    });
+  });
+
+  it('returns empty values for an empty response', () => {
+    const result = parseHarmonyResponse('');
+
+    expect(result).toEqual({
+      content: '',
+      thinkingContent: undefined,
+      toolCalls: undefined,
+    });
+  });
+
+  it('skips constrain tokens before the message payload', () => {
+    const result = parseHarmonyResponse(
+      '<|start|>assistant<|channel|>final<|constrain|>json<|message|>{"result": true}<|end|>'
+    );
+
+    expect(result).toEqual({
+      content: '{"result": true}',
+      thinkingContent: undefined,
+      toolCalls: undefined,
+    });
+  });
+});

--- a/packages/driver/src/mlx-ml/process/harmony-parser.test.ts
+++ b/packages/driver/src/mlx-ml/process/harmony-parser.test.ts
@@ -120,6 +120,51 @@ describe('parseHarmonyResponse', () => {
     });
   });
 
+  it('parses stream output where initial <|start|> is omitted', () => {
+    // chat templateのadd_generation_promptが<|start|>assistantを付与するため、
+    // ストリーム出力では最初の<|start|>が含まれない
+    const result = parseHarmonyResponse(
+      '<|channel|>analysis<|message|>ユーザーは天気を聞いている<|end|><|start|>assistant<|channel|>final<|message|>今日は晴れです。<|end|>'
+    );
+
+    expect(result).toEqual({
+      content: '今日は晴れです。',
+      thinkingContent: 'ユーザーは天気を聞いている',
+      toolCalls: undefined,
+    });
+  });
+
+  it('parses stream output with leading space before <|channel|>', () => {
+    // 実際の出力では <|channel|> の前にスペースがある場合がある
+    const result = parseHarmonyResponse(
+      ' <|channel|> analysis<|message|> We need to check<|end|><|start|> assistant<|channel|> final<|message|> 1 + 1 = 2<|end|>'
+    );
+
+    expect(result).toEqual({
+      content: '1 + 1 = 2',
+      thinkingContent: 'We need to check',
+      toolCalls: undefined,
+    });
+  });
+
+  it('parses stream output with tool call and no initial <|start|>', () => {
+    const result = parseHarmonyResponse(
+      '<|channel|>analysis<|message|>天気を調べる<|end|><|start|>assistant to=functions.get_weather<|channel|>commentary json<|message|>{"location":"Tokyo"}<|call|>'
+    );
+
+    expect(result).toEqual({
+      content: '',
+      thinkingContent: '天気を調べる',
+      toolCalls: [
+        {
+          id: 'harmony_call_0',
+          name: 'get_weather',
+          arguments: { location: 'Tokyo' },
+        },
+      ],
+    });
+  });
+
   it('skips constrain tokens before the message payload', () => {
     const result = parseHarmonyResponse(
       '<|start|>assistant<|channel|>final<|constrain|>json<|message|>{"result": true}<|end|>'

--- a/packages/driver/src/mlx-ml/process/harmony-parser.ts
+++ b/packages/driver/src/mlx-ml/process/harmony-parser.ts
@@ -62,6 +62,19 @@ function extractHarmonyMessages(rawText: string): ParsedHarmonyMessage[] {
   const messages: ParsedHarmonyMessage[] = [];
   let cursor = 0;
 
+  // ストリーム出力では最初の <|start|>assistant が含まれない場合がある
+  // （chat templateのadd_generation_promptで付与されるため）
+  // <|channel|> から始まるテキストを最初のメッセージとして処理
+  const firstStart = rawText.indexOf(START_TOKEN);
+  const firstChannel = rawText.indexOf(CHANNEL_TOKEN);
+  if (firstChannel !== -1 && (firstStart === -1 || firstChannel < firstStart)) {
+    const implicitMessage = parseMessageAt(rawText, -START_TOKEN.length, true);
+    if (implicitMessage) {
+      messages.push(implicitMessage.value);
+      cursor = implicitMessage.nextIndex;
+    }
+  }
+
   while (cursor < rawText.length) {
     const startIndex = rawText.indexOf(START_TOKEN, cursor);
     if (startIndex === -1) {
@@ -83,10 +96,24 @@ function extractHarmonyMessages(rawText: string): ParsedHarmonyMessage[] {
 
 function parseMessageAt(
   rawText: string,
-  startIndex: number
+  startIndex: number,
+  implicitRole?: boolean
 ): { value: ParsedHarmonyMessage; nextIndex: number } | null {
-  const roleStart = startIndex + START_TOKEN.length;
-  const channelIndex = rawText.indexOf(CHANNEL_TOKEN, roleStart);
+  let role: string;
+  let channelIndex: number;
+
+  if (implicitRole) {
+    // <|start|> が省略されたケース: roleは "assistant" と推定
+    role = 'assistant';
+    channelIndex = rawText.indexOf(CHANNEL_TOKEN, 0);
+  } else {
+    const roleStart = startIndex + START_TOKEN.length;
+    channelIndex = rawText.indexOf(CHANNEL_TOKEN, roleStart);
+    if (channelIndex === -1) {
+      return null;
+    }
+    role = rawText.slice(roleStart, channelIndex).trim();
+  }
 
   if (channelIndex === -1) {
     return null;
@@ -97,7 +124,6 @@ function parseMessageAt(
     return null;
   }
 
-  const role = rawText.slice(roleStart, channelIndex).trim();
   let channel = rawText.slice(channelIndex + CHANNEL_TOKEN.length, messageIndex);
   channel = stripTrailingConstraint(channel).trim();
 

--- a/packages/driver/src/mlx-ml/process/harmony-parser.ts
+++ b/packages/driver/src/mlx-ml/process/harmony-parser.ts
@@ -1,0 +1,198 @@
+import type { ToolCall } from '../../types.js';
+import type { ResponseParseResult, ResponseProcessor } from './response-processor.js';
+
+const START_TOKEN = '<|start|>';
+const END_TOKEN = '<|end|>';
+const RETURN_TOKEN = '<|return|>';
+const CHANNEL_TOKEN = '<|channel|>';
+const MESSAGE_TOKEN = '<|message|>';
+const CALL_TOKEN = '<|call|>';
+const CONSTRAIN_TOKEN = '<|constrain|>';
+
+const MESSAGE_END_TOKENS = [CALL_TOKEN, END_TOKEN, RETURN_TOKEN] as const;
+const FUNCTION_ROLE_PREFIX = 'assistant to=functions.';
+
+interface ParsedHarmonyMessage {
+  role: string;
+  channel: string;
+  content: string;
+}
+
+export const parseHarmonyResponse: ResponseProcessor = (rawText: string): ResponseParseResult => {
+  const messages = extractHarmonyMessages(rawText);
+  const finalParts: string[] = [];
+  const thinkingParts: string[] = [];
+  const toolCalls: ToolCall[] = [];
+
+  for (const message of messages) {
+    const channelBase = getChannelBase(message.channel);
+
+    if (message.role.startsWith('functions.') && message.role.includes(' to=assistant')) {
+      continue;
+    }
+
+    if (channelBase === 'analysis') {
+      if (message.content) {
+        thinkingParts.push(message.content);
+      }
+      continue;
+    }
+
+    if (channelBase === 'final') {
+      if (message.content) {
+        finalParts.push(message.content);
+      }
+      continue;
+    }
+
+    const toolCall = parseToolCallMessage(message, toolCalls.length);
+    if (toolCall) {
+      toolCalls.push(toolCall);
+    }
+  }
+
+  return {
+    content: finalParts.join('\n'),
+    thinkingContent: thinkingParts.length > 0 ? thinkingParts.join('\n') : undefined,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+  };
+};
+
+function extractHarmonyMessages(rawText: string): ParsedHarmonyMessage[] {
+  const messages: ParsedHarmonyMessage[] = [];
+  let cursor = 0;
+
+  while (cursor < rawText.length) {
+    const startIndex = rawText.indexOf(START_TOKEN, cursor);
+    if (startIndex === -1) {
+      break;
+    }
+
+    const message = parseMessageAt(rawText, startIndex);
+    if (!message) {
+      cursor = startIndex + START_TOKEN.length;
+      continue;
+    }
+
+    messages.push(message.value);
+    cursor = message.nextIndex;
+  }
+
+  return messages;
+}
+
+function parseMessageAt(
+  rawText: string,
+  startIndex: number
+): { value: ParsedHarmonyMessage; nextIndex: number } | null {
+  const roleStart = startIndex + START_TOKEN.length;
+  const channelIndex = rawText.indexOf(CHANNEL_TOKEN, roleStart);
+
+  if (channelIndex === -1) {
+    return null;
+  }
+
+  const messageIndex = rawText.indexOf(MESSAGE_TOKEN, channelIndex + CHANNEL_TOKEN.length);
+  if (messageIndex === -1) {
+    return null;
+  }
+
+  const role = rawText.slice(roleStart, channelIndex).trim();
+  let channel = rawText.slice(channelIndex + CHANNEL_TOKEN.length, messageIndex);
+  channel = stripTrailingConstraint(channel).trim();
+
+  const contentStart = messageIndex + MESSAGE_TOKEN.length;
+  const endInfo = findMessageEnd(rawText, contentStart);
+  const contentEnd = endInfo?.index ?? rawText.length;
+  const content = rawText.slice(contentStart, contentEnd).trim();
+
+  return {
+    value: {
+      role,
+      channel,
+      content,
+    },
+    nextIndex: endInfo ? endInfo.index + endInfo.token.length : rawText.length,
+  };
+}
+
+function stripTrailingConstraint(channel: string): string {
+  const constrainIndex = channel.indexOf(CONSTRAIN_TOKEN);
+  return constrainIndex === -1 ? channel : channel.slice(0, constrainIndex);
+}
+
+function findMessageEnd(
+  rawText: string,
+  contentStart: number
+): { index: number; token: typeof CALL_TOKEN | typeof END_TOKEN | typeof RETURN_TOKEN } | null {
+  let nearestIndex = -1;
+  let nearestToken: typeof CALL_TOKEN | typeof END_TOKEN | typeof RETURN_TOKEN | null = null;
+
+  for (const token of MESSAGE_END_TOKENS) {
+    const index = rawText.indexOf(token, contentStart);
+    if (index !== -1 && (nearestIndex === -1 || index < nearestIndex)) {
+      nearestIndex = index;
+      nearestToken = token;
+    }
+  }
+
+  if (nearestIndex === -1 || nearestToken === null) {
+    return null;
+  }
+
+  return { index: nearestIndex, token: nearestToken };
+}
+
+function parseToolCallMessage(message: ParsedHarmonyMessage, index: number): ToolCall | null {
+  if (!message.role.startsWith(FUNCTION_ROLE_PREFIX)) {
+    return null;
+  }
+
+  const name = message.role.slice(FUNCTION_ROLE_PREFIX.length).trim();
+  if (!name) {
+    return null;
+  }
+
+  const channelBase = getChannelBase(message.channel);
+  if (channelBase !== 'commentary') {
+    return null;
+  }
+
+  const parsedArguments = parseToolArguments(message.content);
+  if (!parsedArguments) {
+    return null;
+  }
+
+  return {
+    id: `harmony_call_${index}`,
+    name,
+    arguments: parsedArguments,
+  };
+}
+
+function getChannelBase(channel: string): string {
+  const trimmed = channel.trim();
+  const spaceIndex = trimmed.indexOf(' ');
+  return spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex);
+}
+
+function parseToolArguments(content: string): Record<string, unknown> | null {
+  if (!content) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (isRecord(parsed)) {
+      return parsed;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/driver/src/mlx-ml/process/index.ts
+++ b/packages/driver/src/mlx-ml/process/index.ts
@@ -72,9 +72,9 @@ export class MlxProcess {
   }
 
   // API v2.0 Chat - chat APIを直接使用
-  async chat(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number): Promise<Readable> {
+  async chat(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number, reasoningEffort?: 'low' | 'medium' | 'high'): Promise<Readable> {
     // chat APIを直接使用（前処理はドライバーで実施済み）
-    return this.queueManager.addChatRequest(messages, primer, options, tools, images, maxImageSize);
+    return this.queueManager.addChatRequest(messages, primer, options, tools, images, maxImageSize, reasoningEffort);
   }
 
   // API v2.0 Completion - completion APIを直接使用

--- a/packages/driver/src/mlx-ml/process/model-handlers.test.ts
+++ b/packages/driver/src/mlx-ml/process/model-handlers.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { selectResponseProcessor } from './model-handlers.js';
+import { parseHarmonyResponse } from './harmony-parser.js';
+import type { MlxRuntimeInfo } from './types.js';
+
+describe('selectResponseProcessor', () => {
+  it('should return parseHarmonyResponse when tool_parser_type is harmony', () => {
+    const runtimeInfo = {
+      methods: ['chat'],
+      special_tokens: {},
+      features: {
+        apply_chat_template: true,
+        vocab_size: 32000,
+        model_max_length: 4096,
+        chat_template: {
+          supported_roles: ['system', 'user', 'assistant'],
+          tool_call_format: {
+            tool_parser_type: 'harmony',
+            call_start: 'to=functions.',
+            call_end: '<|call|>',
+          }
+        }
+      }
+    } as MlxRuntimeInfo;
+
+    const result = selectResponseProcessor('some-model', runtimeInfo);
+    expect(result).toBe(parseHarmonyResponse);
+  });
+
+  it('should return parseHarmonyResponse for llm-jp-4 model name (fallback)', () => {
+    const result = selectResponseProcessor('mlx-community/llm-jp-4-8b-thinking-8bit', null);
+    expect(result).toBe(parseHarmonyResponse);
+  });
+
+  it('should prioritize tool_parser_type over model name', () => {
+    const runtimeInfo = {
+      methods: ['chat'],
+      special_tokens: {},
+      features: {
+        apply_chat_template: true,
+        vocab_size: 32000,
+        model_max_length: 4096,
+        chat_template: {
+          supported_roles: ['system', 'user', 'assistant'],
+          tool_call_format: {
+            tool_parser_type: 'harmony',
+            call_start: 'to=functions.',
+            call_end: '<|call|>',
+          }
+        }
+      }
+    } as MlxRuntimeInfo;
+
+    const result = selectResponseProcessor('unrelated-model-name', runtimeInfo);
+    expect(result).toBe(parseHarmonyResponse);
+  });
+
+  it('should return null for unknown models without tool_parser_type', () => {
+    const runtimeInfo = {
+      methods: ['chat'],
+      special_tokens: {},
+      features: {
+        apply_chat_template: true,
+        vocab_size: 32000,
+        model_max_length: 4096,
+      }
+    } as MlxRuntimeInfo;
+
+    const result = selectResponseProcessor('generic-model', runtimeInfo);
+    expect(result).toBeNull();
+  });
+
+  it('should return null when runtimeInfo is null and model name is unknown', () => {
+    const result = selectResponseProcessor('generic-model', null);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for json_tools parser type', () => {
+    const runtimeInfo = {
+      methods: ['chat'],
+      special_tokens: {},
+      features: {
+        apply_chat_template: true,
+        vocab_size: 32000,
+        model_max_length: 4096,
+        chat_template: {
+          supported_roles: ['system', 'user', 'assistant'],
+          tool_call_format: {
+            tool_parser_type: 'json_tools',
+            call_start: '<tool_call>',
+            call_end: '</tool_call>',
+          }
+        }
+      }
+    } as MlxRuntimeInfo;
+
+    const result = selectResponseProcessor('some-model', runtimeInfo);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/driver/src/mlx-ml/process/model-handlers.ts
+++ b/packages/driver/src/mlx-ml/process/model-handlers.ts
@@ -4,7 +4,7 @@
  * 各モデル特有のメッセージ変換やプロンプト生成処理を管理
  */
 
-import type { MlxMessage } from './types.js';
+import type { MlxMessage, MlxRuntimeInfo } from './types.js';
 import type { ResponseProcessor } from './response-processor.js';
 import { parseHarmonyResponse } from './harmony-parser.js';
 
@@ -259,11 +259,20 @@ export function selectCompletionProcessor(modelName: string): ((prompt: string) 
 }
 
 /**
- * モデル名に基づいてレスポンス後処理を選択
+ * レスポンス後処理を選択
  *
+ * tool_parser_type ベースの判定を優先し、モデル名はフォールバック。
  * null を返す場合は既存の tool-call-parser のみで処理する。
  */
-export function selectResponseProcessor(modelName: string): ResponseProcessor | null {
+export function selectResponseProcessor(
+  modelName: string,
+  runtimeInfo: MlxRuntimeInfo | null
+): ResponseProcessor | null {
+  const parserType = runtimeInfo?.features?.chat_template?.tool_call_format?.tool_parser_type;
+  if (parserType === 'harmony') {
+    return parseHarmonyResponse;
+  }
+
   if (modelName.includes('llm-jp-4')) {
     return parseHarmonyResponse;
   }

--- a/packages/driver/src/mlx-ml/process/model-handlers.ts
+++ b/packages/driver/src/mlx-ml/process/model-handlers.ts
@@ -5,6 +5,8 @@
  */
 
 import type { MlxMessage } from './types.js';
+import type { ResponseProcessor } from './response-processor.js';
+import { parseHarmonyResponse } from './harmony-parser.js';
 
 /**
  * システムメッセージをマージ（末尾の改行をtrim）
@@ -254,4 +256,17 @@ export function selectCompletionProcessor(modelName: string): ((prompt: string) 
 
   // デフォルト: 汎用フォーマッタで動作する
   return (prompt: string) => prompt;
+}
+
+/**
+ * モデル名に基づいてレスポンス後処理を選択
+ *
+ * null を返す場合は既存の tool-call-parser のみで処理する。
+ */
+export function selectResponseProcessor(modelName: string): ResponseProcessor | null {
+  if (modelName.includes('llm-jp-4')) {
+    return parseHarmonyResponse;
+  }
+
+  return null;
 }

--- a/packages/driver/src/mlx-ml/process/queue.ts
+++ b/packages/driver/src/mlx-ml/process/queue.ts
@@ -64,7 +64,7 @@ export class QueueManager {
     });
   }
 
-  addChatRequest(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number): Promise<Readable> {
+  addChatRequest(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number, reasoningEffort?: 'low' | 'medium' | 'high'): Promise<Readable> {
     return new Promise((resolve, reject) => {
       try {
         const request: MlxChatRequest = {
@@ -73,7 +73,8 @@ export class QueueManager {
           primer,
           tools,
           options: mapOptionsToPython(options, true),  // strict mode: true
-          ...(images?.length ? { images, maxImageSize } : {})
+          ...(images?.length ? { images, maxImageSize } : {}),
+          ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
         };
         this.queue.push({
           request,

--- a/packages/driver/src/mlx-ml/process/response-processor.ts
+++ b/packages/driver/src/mlx-ml/process/response-processor.ts
@@ -1,0 +1,9 @@
+import type { ToolCall } from '../../types.js';
+
+export interface ResponseParseResult {
+  content: string;
+  thinkingContent?: string;
+  toolCalls?: ToolCall[];
+}
+
+export type ResponseProcessor = (rawText: string) => ResponseParseResult;

--- a/packages/driver/src/mlx-ml/process/types.ts
+++ b/packages/driver/src/mlx-ml/process/types.ts
@@ -76,6 +76,7 @@ export interface MlxChatRequest extends MlxBaseRequest {
   options?: MlxMlModelOptions;
   images?: string[];  // ファイルパス配列（VLM用）
   maxImageSize?: number;  // 画像の最大辺ピクセル数
+  reasoning_effort?: 'low' | 'medium' | 'high';
 }
 
 export interface MlxCompletionRequest extends MlxBaseRequest {

--- a/packages/driver/src/mlx-ml/python/__main__.py
+++ b/packages/driver/src/mlx-ml/python/__main__.py
@@ -134,7 +134,7 @@ def handle_format_test(messages, options=None, tools=None):
 
     print(json.dumps(result), end='\0', flush=True)
 
-def handle_chat(messages, primer=None, options=None, tools=None):
+def handle_chat(messages, primer=None, options=None, tools=None, reasoning_effort=None):
     """chat API の処理"""
     if options is None:
         options = {}
@@ -157,20 +157,39 @@ def handle_chat(messages, primer=None, options=None, tools=None):
         add_generation_prompt = False
         tokenize = False
 
-    # tools対応を試みる（テンプレートが対応していなければtools無しで実行）
+    # apply_chat_templateの追加引数（reasoning_effort等）
+    extra_kwargs = {}
+    if tools is not None:
+        extra_kwargs['tools'] = tools
+    if reasoning_effort is not None:
+        extra_kwargs['reasoning_effort'] = reasoning_effort
+
+    # テンプレート適用（対応していないkwargsはTypeErrorになるので段階的にフォールバック）
     try:
         prompt = tokenizer.apply_chat_template(
             messages,
-            tools=tools,
             add_generation_prompt=add_generation_prompt,
             tokenize=tokenize,
+            **extra_kwargs,
         )
     except TypeError:
-        prompt = tokenizer.apply_chat_template(
-            messages,
-            add_generation_prompt=add_generation_prompt,
-            tokenize=tokenize,
-        )
+        # reasoning_effort非対応の場合、toolsのみで再試行
+        try:
+            fallback_kwargs = {}
+            if tools is not None:
+                fallback_kwargs['tools'] = tools
+            prompt = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=add_generation_prompt,
+                tokenize=tokenize,
+                **fallback_kwargs,
+            )
+        except TypeError:
+            prompt = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=add_generation_prompt,
+                tokenize=tokenize,
+            )
 
     if primer is not None:
         prompt = primer.join(prompt.split(primer)[0:-1]) + primer
@@ -410,12 +429,13 @@ def main():
                 options = req.get('options', {})
                 tools = req.get('tools')
                 images = req.get('images', [])
+                reasoning_effort = req.get('reasoning_effort')
 
                 if model_kind == "vlm":
                     max_image_size = req.get('maxImageSize', 768)
                     handle_chat_vlm(messages, images, options, max_image_size, tools, primer)
                 else:
-                    handle_chat(messages, primer, options, tools)
+                    handle_chat(messages, primer, options, tools, reasoning_effort=reasoning_effort)
             
             elif method == 'completion':
                 prompt = req.get('prompt')

--- a/packages/driver/src/mlx-ml/python/token_utils.py
+++ b/packages/driver/src/mlx-ml/python/token_utils.py
@@ -152,7 +152,8 @@ def get_special_tokens(tokenizer):
 
         # ツール関連の単体トークン（追加）
         "tool_calls_marker": "[TOOL_CALLS]",
-        "tool_call_end": "<|call|>",
+        # Harmony形式のcallトークン（tool_call_endとは異なる用途）
+        "harmony_call": "<|call|>",
     }
     
     # VLM processorではconvert_tokens_to_idsがない場合がある
@@ -254,8 +255,6 @@ def detect_tool_call_format(tokenizer):
             (r'<longcat_tool_call>', r'</longcat_tool_call>'),
             # <minimax:tool_call>...</minimax:tool_call>
             (r'<minimax:tool_call>', r'</minimax:tool_call>'),
-            # context-1形式: to=functions.{name}...<|call|>
-            (r'to=functions\.', r'<\|call\|>'),
         ]
 
         for start_pattern, end_pattern in tool_call_patterns:
@@ -265,6 +264,16 @@ def detect_tool_call_format(tokenizer):
                 result["call_start"] = start_match.group(0)
                 result["call_end"] = end_match.group(0)
                 break
+
+        # Harmony形式の専用検出
+        # テンプレート内で "functions." と <|call|> が共存する場合
+        if "call_start" not in result:
+            has_functions = re.search(r'"functions\."', template)
+            has_call = re.search(r'<\|call\|>', template)
+            if has_functions and has_call:
+                result["tool_parser_type"] = "harmony"
+                result["call_start"] = "to=functions."
+                result["call_end"] = "<|call|>"
 
         # Mistral特殊ケース
         if "call_start" not in result:

--- a/packages/driver/src/mlx-ml/tool-call-parser.ts
+++ b/packages/driver/src/mlx-ml/tool-call-parser.ts
@@ -21,7 +21,6 @@ const KNOWN_TOOL_PARSER_DELIMITERS: Record<string, { start: string; end: string 
   glm47: { start: '<tool_call>', end: '</tool_call>' },
   qwen3_coder: { start: '<tool_call>', end: '</tool_call>' },
   minimax_m2: { start: '<minimax:tool_call>', end: '</minimax:tool_call>' },
-  context_1: { start: 'to=functions.', end: '<|call|>' },
   gemma4: { start: '<|tool_call>', end: '<tool_call|>' },
 };
 
@@ -47,16 +46,6 @@ export function parseToolCalls(
 ): ToolCallParseResult {
   // 1. tool_call_format（テンプレート由来）による検出
   const toolCallFormat = runtimeInfo?.features?.chat_template?.tool_call_format;
-
-  // 1.1 context-1形式: to=functions.{name}<|channel|>...<|message|>{json}
-  const toolCallEndToken = runtimeInfo?.special_tokens?.['tool_call_end'];
-  const hasCallEndToken = toolCallEndToken && typeof toolCallEndToken === 'object' && 'text' in toolCallEndToken && (toolCallEndToken as SpecialToken).text === '<|call|>';
-  if (toolCallFormat?.call_start === 'to=functions.' || toolCallFormat?.call_end === '<|call|>' || hasCallEndToken) {
-    const result = parseContext1ToolCalls(text);
-    if (result.toolCalls.length > 0) {
-      return result;
-    }
-  }
 
   if (toolCallFormat?.call_start && toolCallFormat?.call_end) {
     const result = parseWithDelimiters(text, toolCallFormat.call_start, toolCallFormat.call_end);
@@ -563,42 +552,6 @@ function extractJsonObject(text: string, start: number): string | null {
   }
 
   return null;
-}
-
-/**
- * context-1形式のtool callをパース
- * 出力形式:
- *   to=functions.{name}<|channel|>commentary json<|message|>{"key": "value"}<|call|>
- */
-function parseContext1ToolCalls(text: string): ToolCallParseResult {
-  const toolCalls: ToolCall[] = [];
-  let content = text;
-  let callIndex = 0;
-
-  // to=functions.{name} ... <|message|>{json} パターン
-  // <|call|> は stop token で切断されるため、出力に含まれない場合も含まれる場合もある
-  const regex = /to=functions\.([\w.]+)(?:<\|channel\|>[\s\S]*?)?<\|message\|>([\s\S]*?)(?:<\|call\|>|$)/g;
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    const name = match[1];
-    const argsStr = match[2].trim();
-    try {
-      const args = JSON.parse(argsStr);
-      toolCalls.push({
-        id: `call_${callIndex++}`,
-        name,
-        arguments: typeof args === 'object' && args !== null ? args : {}
-      });
-    } catch {
-      // JSON パース失敗 → スキップ
-    }
-  }
-
-  if (toolCalls.length > 0) {
-    content = text.replace(/to=functions\.[\w.]+(?:<\|channel\|>[\s\S]*?)?<\|message\|>[\s\S]*?(?:<\|call\|>|$)/g, '').trim();
-  }
-
-  return { content, toolCalls };
 }
 
 function parseMistralStyleToolCalls(

--- a/packages/driver/src/openai/openai-driver.ts
+++ b/packages/driver/src/openai/openai-driver.ts
@@ -38,8 +38,6 @@ export interface OpenAIQueryOptions extends QueryOptions {
   seed?: number;
   tools?: ToolDefinition[];
   toolChoice?: ToolChoice;
-  /** Reasoning effort for o-series models (requires mode: 'thinking') */
-  reasoningEffort?: 'low' | 'medium' | 'high';
 }
 
 /**

--- a/packages/driver/src/types.ts
+++ b/packages/driver/src/types.ts
@@ -94,6 +94,12 @@ export interface QueryResult {
   content: string;
 
   /**
+   * Thinking/reasoning content from the model.
+   * Populated when the model uses a thinking channel (e.g., Harmony analysis, Anthropic thinking blocks).
+   */
+  thinkingContent?: string;
+
+  /**
    * Structured output extracted from the response
    * - undefined: no schema was specified or no valid JSON found
    * - object/array: extracted JSON matching the schema
@@ -154,6 +160,8 @@ export interface QueryOptions {
   tools?: ToolDefinition[];
   /** Tool usage strategy */
   toolChoice?: ToolChoice;
+  /** Reasoning effort level for thinking models (e.g., o-series, llm-jp-4-thinking) */
+  reasoningEffort?: 'low' | 'medium' | 'high';
 }
 
 /**

--- a/packages/experiment/examples/tools-experiment.yaml
+++ b/packages/experiment/examples/tools-experiment.yaml
@@ -14,6 +14,7 @@ models:
     driverOptions:
       textOnly: true
     priority: 10
+    disabled: true
   qwen3-4b:
     model: "mlx-community/Qwen3-4B-Thinking-2507-heretic-8bit"
     provider: "mlx"
@@ -57,16 +58,16 @@ models:
     priority: 20
     disabled: true
   llm-jp-4-8b-thinking:
-    model: llm-jp/llm-jp-4-8b-thinking
+    model: "mlx-community/llm-jp-4-8b-thinking-8bit"
     provider: "mlx"
-    capabilities: ["local", "tools"]
-    priority: 20
-    disabled: true
+    capabilities: ["local", "tools", "thinking"]
+    priority: 5
   qwen3.5-4b-optiq:
     model: mlx-community/Qwen3.5-4B-OptiQ-4bit
     provider: "mlx"
     capabilities: ["local", "tools"]
     priority: 10
+    disabled: true
 
 drivers:
   mlx: {}

--- a/packages/experiment/src/runner/experiment.ts
+++ b/packages/experiment/src/runner/experiment.ts
@@ -299,9 +299,7 @@ export class ExperimentRunner {
         logger.verbose(`Module ${moduleName} run ${i + 1}: Success (${elapsed}ms)`);
 
         // Display result summary (思考ブロックはプレビューから除外)
-        const displayContent = result.content
-          .replace(/<think>[\s\S]*?<\/think>\s*/g, '')
-          .replace(/^[\s\S]*?<\/think>\s*/g, '');
+        const displayContent = result.content;
         const contentPreview = displayContent.length > 200
           ? displayContent.substring(0, 200) + '...'
           : displayContent;

--- a/packages/process/src/integration.test.ts
+++ b/packages/process/src/integration.test.ts
@@ -83,15 +83,15 @@ describe('integration tests', () => {
     // Planning → Think×2 → OutputMessage の4タスクシーケンス
     const driver = new TestDriver({
       responses: [
-        // Planning: __register_task × 2
+        // Planning: think × 2
         {
           content: '',
           toolCalls: [
-            { id: 'tc-1', name: '__register_task', arguments: {
-              name: 'analyze', instruction: '入力データを分析する', taskType: 'think', reason: '分析が必要'
+            { id: 'tc-1', name: 'think', arguments: {
+              name: 'analyze', instruction: '入力データを分析する', reason: '分析が必要'
             }},
-            { id: 'tc-2', name: '__register_task', arguments: {
-              name: 'summarize', instruction: '分析結果をまとめる', taskType: 'think', reason: 'まとめが必要'
+            { id: 'tc-2', name: 'think', arguments: {
+              name: 'summarize', instruction: '分析結果をまとめる', reason: 'まとめが必要'
             }},
           ]
         },
@@ -146,11 +146,11 @@ describe('integration tests', () => {
         {
           content: '',
           toolCalls: [
-            { id: 'tc-1', name: '__register_task', arguments: {
-              name: 'fetch', instruction: 'データを取得する', taskType: 'act', reason: '取得が必要'
+            { id: 'tc-1', name: 'act', arguments: {
+              name: 'fetch', instruction: 'データを取得する', reason: '取得が必要'
             }},
-            { id: 'tc-2', name: '__register_task', arguments: {
-              name: 'process', instruction: 'データを処理する', taskType: 'think', reason: '処理が必要'
+            { id: 'tc-2', name: 'think', arguments: {
+              name: 'process', instruction: 'データを処理する', reason: '処理が必要'
             }},
           ]
         },

--- a/packages/process/src/workflows/agentic-workflow/agentic-workflow.test.ts
+++ b/packages/process/src/workflows/agentic-workflow/agentic-workflow.test.ts
@@ -8,15 +8,15 @@ describe('agenticProcess v2', () => {
   it('should execute basic workflow with planning and tasks', async () => {
     const driver = new TestDriver({
       responses: [
-        // Planning: __register_task × 2
+        // Planning: think × 2
         {
           content: '',
           toolCalls: [
-            { id: 'tc-1', name: '__register_task', arguments: {
-              name: 'analyze', instruction: 'Analyze input data', taskType: 'think', reason: 'Need analysis'
+            { id: 'tc-1', name: 'think', arguments: {
+              name: 'analyze', instruction: 'Analyze input data', reason: 'Need analysis'
             }},
-            { id: 'tc-2', name: '__register_task', arguments: {
-              name: 'process', instruction: 'Process results', taskType: 'think', reason: 'Need processing'
+            { id: 'tc-2', name: 'think', arguments: {
+              name: 'process', instruction: 'Process results', reason: 'Need processing'
             }},
           ]
         },
@@ -63,8 +63,8 @@ describe('agenticProcess v2', () => {
         // Planning
         {
           content: '',
-          toolCalls: [{ id: 'tc-1', name: '__register_task', arguments: {
-            name: 'fetch', instruction: 'Get external data', taskType: 'act', reason: 'Need data'
+          toolCalls: [{ id: 'tc-1', name: 'act', arguments: {
+            name: 'fetch', instruction: 'Get external data', reason: 'Need data'
           }}]
         },
         // Think: 外部ツール呼び出し → pending として返す
@@ -97,8 +97,8 @@ describe('agenticProcess v2', () => {
         // Planning
         {
           content: '',
-          toolCalls: [{ id: 'tc-1', name: '__register_task', arguments: {
-            name: 'simple', instruction: 'Simple task', taskType: 'think', reason: 'Need to think'
+          toolCalls: [{ id: 'tc-1', name: 'think', arguments: {
+            name: 'simple', instruction: 'Simple task', reason: 'Need to think'
           }}]
         },
         // Think
@@ -123,11 +123,11 @@ describe('agenticProcess v2', () => {
         {
           content: '',
           toolCalls: [
-            { id: 'tc-1', name: '__register_task', arguments: { name: 't1', instruction: 'Task 1', taskType: 'think', reason: 'r' } },
-            { id: 'tc-2', name: '__register_task', arguments: { name: 't2', instruction: 'Task 2', taskType: 'think', reason: 'r' } },
-            { id: 'tc-3', name: '__register_task', arguments: { name: 't3', instruction: 'Task 3', taskType: 'think', reason: 'r' } },
-            { id: 'tc-4', name: '__register_task', arguments: { name: 't4', instruction: 'Task 4', taskType: 'think', reason: 'r' } },
-            { id: 'tc-5', name: '__register_task', arguments: { name: 't5', instruction: 'Task 5', taskType: 'think', reason: 'r' } },
+            { id: 'tc-1', name: 'think', arguments: { name: 't1', instruction: 'Task 1', reason: 'r' } },
+            { id: 'tc-2', name: 'think', arguments: { name: 't2', instruction: 'Task 2', reason: 'r' } },
+            { id: 'tc-3', name: 'think', arguments: { name: 't3', instruction: 'Task 3', reason: 'r' } },
+            { id: 'tc-4', name: 'think', arguments: { name: 't4', instruction: 'Task 4', reason: 'r' } },
+            { id: 'tc-5', name: 'think', arguments: { name: 't5', instruction: 'Task 5', reason: 'r' } },
           ]
         },
         // maxTasks=3: planning + think×2 まで実行
@@ -178,8 +178,8 @@ describe('agenticProcess v2', () => {
         // Planning
         {
           content: '',
-          toolCalls: [{ id: 'tc-1', name: '__register_task', arguments: {
-            name: 'check', instruction: 'Check time', taskType: 'think', reason: 'Need time'
+          toolCalls: [{ id: 'tc-1', name: 'think', arguments: {
+            name: 'check', instruction: 'Check time', reason: 'Need time'
           }}]
         },
         // Think: __time ツール呼び出し（1回のqueryで完了、tool結果は次タスクへ）
@@ -208,8 +208,8 @@ describe('agenticProcess v2', () => {
         // Planning
         {
           content: '',
-          toolCalls: [{ id: 'tc-1', name: '__register_task', arguments: {
-            name: 'analyze', instruction: 'Analyze', taskType: 'think', reason: 'Need analysis'
+          toolCalls: [{ id: 'tc-1', name: 'think', arguments: {
+            name: 'analyze', instruction: 'Analyze', reason: 'Need analysis'
           }}]
         },
         // Think

--- a/packages/process/src/workflows/agentic-workflow/agentic-workflow.ts
+++ b/packages/process/src/workflows/agentic-workflow/agentic-workflow.ts
@@ -32,24 +32,12 @@ import { replanningModule } from './task-types/planning.js';
 import {
   createPlanningTools,
   createExecutionBuiltinTools,
+  TASK_TYPE_TOOL_NAMES,
 } from './process/builtin-tools.js';
 import { queryWithTools, rethrowAsWorkflowError } from './process/query-with-tools.js';
 import { topologicalSortTasks } from './process/topological-sort.js';
 
 const logger = new Logger({ prefix: 'process', context: 'agentic', accumulate: true });
-
-/**
- * Strip <think>...</think> blocks from model output.
- * Thinking traces are internal reasoning and should not be passed to subsequent tasks.
- */
-function stripThinkBlocks(text: string): string {
-  return text
-    .replace(/<think>[\s\S]*?<\/think>\s*/g, '')
-    .replace(/^[\s\S]*?<\/think>\s*/g, '')
-    .replace(/<\|channel>thought[\s\S]*?<channel\|>\s*/g, '')
-    .replace(/^[\s\S]*?<channel\|>\s*/g, '')
-    .trim();
-}
 
 /**
  * Check if the resolved user module's messages end with a tool result.
@@ -109,7 +97,8 @@ function getBuiltinToolsForTask(
 
   const allTools: ToolSpec[] = [];
 
-  if (toolNames.has('__register_task')) {
+  const hasPlanningTools = [...TASK_TYPE_TOOL_NAMES].some(name => toolNames.has(name));
+  if (hasPlanningTools) {
     allTools.push(...createPlanningTools(taskList, currentIndex));
   }
 
@@ -192,7 +181,7 @@ async function executeTask(
       taskName: task.name,
       taskType: task.taskType,
       instruction: task.instruction,
-      result: stripThinkBlocks(result.content),
+      result: result.content,
       toolCallLog: result.toolCallLog.length > 0 ? result.toolCallLog : undefined,
       pendingToolCalls: result.pendingToolCalls,
       metadata: {

--- a/packages/process/src/workflows/agentic-workflow/process/builtin-tools.ts
+++ b/packages/process/src/workflows/agentic-workflow/process/builtin-tools.ts
@@ -1,9 +1,13 @@
 /**
- * Agentic workflow 組み込みツール定義 (v2)
+ * Agentic workflow 組み込みツール定義 (v3)
  *
- * - __register_task: タスク登録（planning タスクから利用可能、1タスクずつ呼び出し）
- * - __replan: 再プランニング要求（execution タスクから利用可能）
- * - __time: 現在時刻取得
+ * Planning tools:
+ *   タスクタイプ名をそのままツール名として使用（think, verify, act, ...）
+ *   モデルが自然に呼びやすい形式
+ *
+ * Execution tools:
+ *   __replan: 再プランニング要求（execution タスクから利用可能）
+ *   __time: 現在時刻取得
  */
 
 import type { ToolSpec, AgenticTask, TaskType } from '../types.js';
@@ -12,21 +16,18 @@ import { EXECUTION_TASK_DEFS } from '../task-types/execution-tasks.js';
 
 export const BUILTIN_TOOL_PREFIX = '__';
 
-/** 有効な実行タスクタイプ（planning は除外 — モデルが指定する対象外） */
-const VALID_TASK_TYPES = new Set<string>([...Object.keys(EXECUTION_TASK_DEFS), 'output']);
+/** タスクタイプ名ツール（planning用） */
+export const TASK_TYPE_TOOL_NAMES = new Set<string>([...Object.keys(EXECUTION_TASK_DEFS), 'output']);
 
 /**
  * 組み込みツールかどうかを判定
  */
 export function isBuiltinTool(name: string): boolean {
-  return name.startsWith(BUILTIN_TOOL_PREFIX);
+  return name.startsWith(BUILTIN_TOOL_PREFIX) || TASK_TYPE_TOOL_NAMES.has(name);
 }
 
 /**
- * Planning フェーズ用の組み込みツールを生成
- */
-/**
- * 単一タスク定義の型
+ * 単一タスク定義の型（内部用、taskType はツール名から暗黙設定）
  */
 interface TaskEntry {
   name?: string;
@@ -41,19 +42,14 @@ interface TaskEntry {
   insertAt?: number;
 }
 
-const TASK_ENTRY_SCHEMA = {
+/** 有効な実行タスクタイプ（planning は除外 — モデルが指定する対象外） */
+const VALID_TASK_TYPES = new Set<string>([...Object.keys(EXECUTION_TASK_DEFS), 'output']);
+
+const COMMON_TASK_PARAMS = {
   type: 'object',
   properties: {
     name: { type: 'string', description: 'Short identifier for this task (e.g. "search", "analyze"). Used in dep references and display.' },
     instruction: { type: 'string', description: 'Description of the deliverable this task produces.' },
-    taskType: {
-      type: 'string',
-      enum: [...Object.keys(EXECUTION_TASK_DEFS), 'output'],
-      description: Object.entries(EXECUTION_TASK_DEFS)
-        .map(([name, def]) => `${name}: ${def.toolDescription}`)
-        .concat(['output: produces the final user-facing response (must be the last task)'])
-        .join('. ') + '. Default: think',
-    },
     reason: {
       type: 'string',
       description: 'Why this task is necessary — what gap it fills in the deliverable chain.',
@@ -85,11 +81,11 @@ const TASK_ENTRY_SCHEMA = {
       description: 'Position in the task list to insert at. If omitted, the task is scheduled as the next task. Values before the current task are ignored.',
     },
   },
-  required: ['name', 'instruction', 'taskType', 'reason'],
+  required: ['name', 'instruction', 'reason'],
 } as const;
 
 /**
- * TaskEntry からタスクを登録し、結果メッセージを返す
+ * TaskEntry からタスクを登録する
  * @param currentIndex 現在実行中のタスクのインデックス。insertAt がこれ以下の場合はクランプされる。
  */
 function registerTask(taskList: AgenticTask[], entry: TaskEntry, currentIndex: number): void {
@@ -119,28 +115,37 @@ function registerTask(taskList: AgenticTask[], entry: TaskEntry, currentIndex: n
 /**
  * Planning フェーズ用の組み込みツールを生成
  *
- * __register_task ツールは1タスクずつ登録する。
- * 複数タスクの場合はモデルが複数回 tool call する。
+ * タスクタイプ名をそのままツール名として使用:
+ * think(), verify(), act(), extractContext(), recall(), determine(), output()
  */
 export function createPlanningTools(taskList: AgenticTask[], currentIndex: number): ToolSpec[] {
   let insertOffset = 0;
-  return [{
+
+  const outputDescription = 'produces the final user-facing response (must be the last task)';
+
+  const taskTypeEntries: Array<[string, string]> = [
+    ...Object.entries(EXECUTION_TASK_DEFS).map(([name, def]) => [name, def.toolDescription] as [string, string]),
+    ['output', outputDescription],
+  ];
+
+  return taskTypeEntries.map(([typeName, description]) => ({
     definition: {
-      name: '__register_task',
-      description: 'Register a single task into the workflow. Call once per task. Tasks are appended after the current position. Each task produces a specific deliverable and is executed by a separate AI instance.',
-      parameters: TASK_ENTRY_SCHEMA,
+      name: typeName,
+      description: `Register a "${typeName}" task: ${description}. Call once per task.`,
+      parameters: COMMON_TASK_PARAMS,
     },
-    handler: async (args) => {
+    handler: async (args: Record<string, unknown>) => {
       const entry = args as unknown as TaskEntry;
+      entry.taskType = typeName;
       if (!entry.instruction) {
         throw new Error('Provide an "instruction" field.');
       }
       registerTask(taskList, entry, currentIndex + insertOffset);
       insertOffset++;
 
-      return `Registered: [${entry.name}] (${entry.taskType || 'think'})`;
+      return `Registered: [${entry.name}] (${typeName})`;
     },
-  }];
+  }));
 }
 
 /**
@@ -169,12 +174,7 @@ const timeTool: ToolSpec = {
 };
 
 /**
- * 再プランニング要求ツール
- * ワークフロー側で検出され、実際の再プランニングが実行される
- */
-/**
  * Execution フェーズ用の __replan ツールを生成
- * タスクリストと現在位置を参照してログに残す
  */
 function createReplanTool(taskList: AgenticTask[], currentIndex: number): ToolSpec {
   return {

--- a/packages/process/src/workflows/agentic-workflow/prompt-inspection.test.ts
+++ b/packages/process/src/workflows/agentic-workflow/prompt-inspection.test.ts
@@ -61,7 +61,7 @@ describe('Agentic Workflow v2 Prompt Inspection', () => {
     // objective は指示側にある
     const instructionText = collectText(prompt.instructions);
     expect(instructionText).toContain('文書を分析し、重要な洞察を抽出する');
-    expect(instructionText).toContain('__register_task');
+    expect(instructionText).toContain('task type tool');
 
     // terms が指示側にある（taskCommon + userModule）
     expect(instructionText).toContain('Objective');  // taskCommon.terms

--- a/packages/process/src/workflows/agentic-workflow/task-types/planning.ts
+++ b/packages/process/src/workflows/agentic-workflow/task-types/planning.ts
@@ -9,9 +9,9 @@
  * - userModule compiled as "Original Request" material (includes inputs)
  *
  * Output side:
- * - cue: user message instructing to call __register_task tool
+ * - cue: user message instructing to call task type tools
  *
- * Tools: __register_task
+ * Tools: think, verify, act, extractContext, recall, determine, output
  */
 
 import type { PromptModule } from '@modular-prompt/core';
@@ -20,6 +20,7 @@ import { formatCompletionPrompt } from '@modular-prompt/driver';
 import type { AgenticWorkflowContext } from '../types.js';
 import type { TaskTypeConfig } from './index.js';
 import { buildTaskListWithResults } from './index.js';
+import { TASK_TYPE_TOOL_NAMES } from '../process/builtin-tools.js';
 
 const planningModule: PromptModule<AgenticWorkflowContext> = {
   objective: [
@@ -45,7 +46,7 @@ const planningModule: PromptModule<AgenticWorkflowContext> = {
     '- Your job is to design this Workflow: decide what deliverables are needed and how each Task produces them.',
     '- This planning Task produces two kinds of output:',
     '  - **Text output**: Your analysis of the request. This becomes a deliverable visible to all subsequent Tasks.',
-    '  - **Tool calls** (`__register_task`): Each call registers a Task into the Workflow.',
+    '  - **Tool calls**: Call the task type tool (e.g. `think()`, `output()`) to register each Task into the Workflow.',
   ],
   instructions: [
     'Follow these 3 steps:',
@@ -57,7 +58,7 @@ const planningModule: PromptModule<AgenticWorkflowContext> = {
     '2. **Design & Refine**',
     '  - Design the sequence of Tasks and deliverables that leads from the input to the final deliverable. See "Task Type Guide" and "Planning Theory".',
     '  - Adjust each Task\'s input so it can work correctly and efficiently. Exclude Original Data when deliverables are sufficient. See "What Each Task Can See".',
-    '3. **Register** — Call `__register_task` tool once per Task.',
+    '3. **Register** — Call the task type tool once per Task (e.g. `think({...})`, `output({...})`).',
     '  - Each Task\'s `reason` should explain why it is needed. Each Task\'s `instruction` should describe the deliverable to produce.',
   ],
   guidelines: [
@@ -175,6 +176,6 @@ export const replanningModule: PromptModule<AgenticWorkflowContext> = {
 
 export const config: TaskTypeConfig = {
   module: planningModule,
-  builtinToolNames: ['__register_task', '__time'],
+  builtinToolNames: [...TASK_TYPE_TOOL_NAMES, '__time'],
   maxTokensTier: 'high',
 };

--- a/prompts/memos/harmony-format-postprocessing.v1.md
+++ b/prompts/memos/harmony-format-postprocessing.v1.md
@@ -1,0 +1,210 @@
+# Harmony形式レスポンスの後処理設計
+
+## Context
+
+llm-jp-4モデルはOpenAIのHarmony Response Formatを採用している。`-instruct` と `-thinking` バリアントがあり、スペシャルトークンによるチャネル分離（analysis/final/tool_call）が特徴。
+
+MLX変換モデル（`mlx-community/llm-jp-4-8b-thinking-4bit`等）をmodular-promptのMLXドライバーで利用する場合、レスポンスの後処理が必要になる。
+
+### Harmonyフォーマットの構造
+
+```
+<|start|>{role}<|channel|>{channel_type}<|message|>{content}<|end|>
+```
+
+スペシャルトークン一覧:
+
+| トークン | 用途 |
+|---------|------|
+| `<\|start\|>` | メッセージ開始 |
+| `<\|end\|>` | メッセージ終了 |
+| `<\|return\|>` | 生成終了（EOS相当） |
+| `<\|channel\|>` | チャネル指定開始 |
+| `<\|message\|>` | メッセージ本文開始 |
+| `<\|call\|>` | ツール呼び出し終了 |
+| `<\|constrain\|>` | 制約指定 |
+
+チャネルの種類:
+
+| チャネル | 用途 | 対応するQueryResult |
+|---------|------|-------------------|
+| `analysis` | 内部推論（thinking） | → `thinkingContent` (新設) |
+| `final` | ユーザーへの最終回答 | → `content` |
+| `commentary to=functions.{name}` | ツール呼び出し | → `toolCalls` |
+
+### レスポンス例
+
+```
+<|start|>assistant<|channel|>analysis<|message|>ユーザーは天気を聞いている...<|end|>
+<|start|>assistant<|channel|>final<|message|>今日の東京は晴れです。<|end|>
+```
+
+thinkingからtool callを経て最終回答に至る例:
+```
+<|start|>assistant<|channel|>analysis<|message|>天気APIを呼ぶ必要がある<|end|>
+<|start|>assistant to=functions.get_weather<|channel|>commentary json<|message|>{"location":"Tokyo"}<|call|>
+<|start|>functions.get_weather to=assistant<|channel|>commentary<|message|>"sunny, 25°C"<|end|>
+<|start|>assistant<|channel|>final<|message|>東京は晴れ、25°Cです。<|end|>
+```
+
+## 設計方針
+
+### 原則
+
+1. **後処理はTypeScriptに寄せる** — Python側はchat template適用とトークン生成のみ
+2. **モデル固有の分岐は許容する** — モデル名ベースのハンドラ選択は既存パターン（gemma-3/4）に倣う
+3. **既存のQueryResult/QueryOptionsを拡張する** — Harmony固有の型は作らず共通型に統合
+
+### 変更対象
+
+#### 1. QueryOptions: `reasoningEffort` の追加
+
+現状 `reasoningEffort` はOpenAIドライバーのローカル型にのみ存在する。これを共通の `QueryOptions` に昇格する。
+
+```typescript
+// packages/driver/src/types.ts
+export interface QueryOptions {
+  // ...existing fields...
+  /** Reasoning effort level for thinking models */
+  reasoningEffort?: 'low' | 'medium' | 'high';
+}
+```
+
+- OpenAIドライバー: 既存のローカル型から移行、APIパラメータとして送信
+- MLXドライバー: `apply_chat_template` の引数として Python 側に渡す
+- vLLMドライバー: 同上
+- 他ドライバー: 無視（既存動作に影響なし）
+
+#### 2. QueryResult: `thinkingContent` の追加
+
+thinkingチャネルの内容を返すフィールドを新設する。
+
+```typescript
+// packages/driver/src/types.ts
+export interface QueryResult {
+  content: string;
+  /** Thinking/reasoning content from the model (e.g., Harmony analysis channel) */
+  thinkingContent?: string;
+  // ...existing fields...
+}
+```
+
+- llm-jp-4 (Harmony): `analysis` チャネル → `thinkingContent`
+- 将来的にAnthropicの `thinking` ブロックなどにも対応可能
+
+#### 3. MLXドライバー: Harmonyレスポンスパーサー（TS側）
+
+`packages/driver/src/mlx-ml/process/` に Harmony パーサーを追加する。
+
+**パース処理の概要:**
+
+入力: モデルの生テキストレスポンス（スペシャルトークン含む）
+出力: `{ content: string, thinkingContent?: string, toolCalls?: ToolCall[] }`
+
+```
+parseHarmonyResponse(rawText: string) → HarmonyParseResult
+```
+
+パースロジック:
+1. `<|start|>` でメッセージ境界を分割
+2. 各メッセージから `<|channel|>` で チャネル種別を判定
+3. `<|message|>` と `<|end|>` / `<|call|>` / `<|return|>` の間がコンテンツ
+4. チャネル別に振り分け:
+   - `analysis` → thinkingContent に結合
+   - `final` → content
+   - `commentary to=functions.*` → toolCalls として抽出
+
+**ストリーミングとクエリの挙動差:**
+
+- **query（非ストリーミング）**: analysis/finalを分離し、`thinkingContent` と `content` に分けて返す
+- **streamQuery（ストリーミング）**: thinkingチャンクもそのままストリームに流す。`result` Promise では分離した結果を返す
+
+**レスポンスパーサーのインターフェース統一:**
+
+Harmony固有のパーサーではなく、モデル非依存の統一インターフェースとする。`selectResponseProcessor` は全モデルで同じ型を返す:
+
+```typescript
+interface ResponseParseResult {
+  content: string;
+  thinkingContent?: string;
+  toolCalls?: ToolCall[];
+}
+
+type ResponseProcessor = (rawText: string) => ResponseParseResult;
+
+selectResponseProcessor(modelName: string): ResponseProcessor | null
+```
+
+- llm-jp-4: Harmonyチャネルパーサーが `ResponseProcessor` を実装
+- 将来的に他モデル（thinking分離が必要なもの）も同じインターフェースで追加可能
+- `null` を返す場合はレガシー動作（rawTextをそのままcontentに入れる）
+
+#### 4. MLXドライバー Python側: `reasoning_effort` の受け渡し
+
+`handle_chat` で `apply_chat_template` を呼ぶ際に、options経由で受け取った `reasoning_effort` を引数として渡す。
+
+```python
+# __main__.py handle_chat()
+prompt = tokenizer.apply_chat_template(
+    messages,
+    tools=tools,
+    add_generation_prompt=add_generation_prompt,
+    tokenize=tokenize,
+    reasoning_effort=options.get('reasoning_effort', 'medium'),  # 追加
+)
+```
+
+#### 5. デコード時の空白修正
+
+Sentencepieceベースのトークナイザーでは、Harmonyスペシャルトークンの前後で不正な空白が挿入される問題がある（llm-jp-4のカスタムトークナイザー `Llmjp4Tokenizer._decode()` が回避している処理）。
+
+MLXの `mlx-lm` はカスタムトークナイザーを使わないため、2つの対処法がある:
+
+- **案A: Python側で後処理** — token_idsレベルでHarmonyトークン境界を検出し分割デコード
+- **案B: TS側で後処理** — テキストレベルでスペシャルトークン前後の不正空白を除去
+
+→ TS側にパーサーを置く方針なので、**案B**が整合的。パーサーがスペシャルトークンを認識する過程で空白を正規化する。
+
+## Harmony Tool Call形式
+
+Harmonyのtool callはgemma-4とは異なる固有形式:
+
+```
+<|start|>assistant to=functions.{name}<|channel|>commentary json<|message|>{JSON引数}<|call|>
+```
+
+tool結果の返却:
+```
+<|start|>functions.{name} to=assistant<|channel|>commentary<|message|>{JSON結果}<|end|>
+```
+
+既存の `tool-call-parser.ts` の `parseToolCallContent` にHarmony形式を追加するか、Harmonyパーサー内で直接処理するか要検討。Harmonyパーサーがメッセージ構造を認識する時点でtool callの検出もできるため、パーサー内で処理する方が自然。
+
+## 対象モデルの判定
+
+`selectChatProcessor` 等と同様、モデル名ベースで判定:
+
+```typescript
+if (modelName.includes('llm-jp-4') || modelName.includes('llm-jp/llm-jp-4')) {
+  return processHarmonyResponse;
+}
+```
+
+将来的にHarmony形式を採用する他モデルが出た場合は、条件を追加する。
+
+## 影響範囲
+
+| パッケージ | ファイル | 変更内容 |
+|-----------|---------|---------|
+| `@modular-prompt/driver` | `src/types.ts` | `QueryOptions` に `reasoningEffort` 追加、`QueryResult` に `thinkingContent` 追加 |
+| `@modular-prompt/driver` | `src/openai/openai-driver.ts` | ローカル型からQueryOptionsの共通型に移行 |
+| `@modular-prompt/driver` | `src/mlx-ml/process/model-handlers.ts` | llm-jp-4ハンドラ追加、`selectResponseProcessor` 新設 |
+| `@modular-prompt/driver` | `src/mlx-ml/process/harmony-parser.ts` | 新規: Harmonyレスポンスパーサー |
+| `@modular-prompt/driver` | `src/mlx-ml/mlx-driver.ts` | レスポンス後処理呼び出し、`reasoning_effort` 送信 |
+| `@modular-prompt/driver` | `src/mlx-ml/python/__main__.py` | `reasoning_effort` を `apply_chat_template` に渡す |
+
+## 未決事項
+
+- [ ] vLLMドライバーでの同等対応（vLLMは `trust_remote_code` 対応なので空白問題はないが、`thinkingContent` 分離はTS側で必要。`ResponseProcessor` インターフェースを共有できるはず）
+- [ ] ストリーミング時のチャンク境界処理（スペシャルトークンが分断される場合のバッファリング戦略）
+- [ ] `thinkingContent` をprocess層（agentic-workflow等）でどう利用するか


### PR DESCRIPTION
## Summary

- MLXドライバーのtool call形式検出・パーサー選択を`tool_call_format`（Python側検出結果）に一元化
- llm-jp-4のHarmony形式レスポンスパーサーを追加
- `reasoningEffort`オプションの共通化（OpenAI/MLX）
- agenticワークフローのplanning改善（トポロジカルソート、分析出力指示）
- experiment結果のJSON保存機能追加

### tool call形式検出の一元化
- `hasNativeToolSupport()`: 5シグナルチェック → `tool_call_format.call_start`のみに簡素化
- `selectResponseProcessor()`: モデル名ベース → `tool_parser_type`ベースに変更
- `parseToolCalls()`: Harmony/context-1重複パスを削除
- Python `token_utils.py`: `<|call|>`をharmony_callに分類、Harmony専用検出ロジック追加

### Harmony形式対応
- `parseHarmonyResponse`: analysis/final/tool_callチャネルのパース
- ストリーム出力で`<|start|>`が省略されるケースに対応

## Test plan

- [x] `selectResponseProcessor`ユニットテスト（6テスト）
- [x] `hasNativeToolSupport`ユニットテスト（4テスト）
- [x] `parseHarmonyResponse`ユニットテスト（13テスト）
- [x] `parseToolCalls`ユニットテスト（43テスト）
- [x] TypeScriptビルド通過
- [x] llm-jp-4-8b-thinking実機テストでcapabilities検出確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)