### PR TITLE
chore: selfPromptingProcessをdeprecatedに変更

### DIFF
--- a/.changeset/deprecate-self-prompting-process.md
+++ b/.changeset/deprecate-self-prompting-process.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/process": patch
+---
+
+selfPromptingProcessをdeprecatedに変更（agenticProcessに統合予定）

--- a/packages/process/src/workflows/self-prompting-workflow/index.ts
+++ b/packages/process/src/workflows/self-prompting-workflow/index.ts
@@ -1,9 +1,7 @@
 /**
  * Self-prompting workflow - AI generates complete prompts for each execution step
  *
- * This workflow is an alternative to agentic-workflow where the AI generates
- * complete prompts (instructions + data arrays) during planning, and executes
- * them directly without moduler-prompt compilation during execution phase.
+ * @deprecated agenticProcess に統合予定。新規利用は agenticProcess を使用してください。
  */
 
 export { selfPromptingProcess } from './self-prompting-workflow.js';

--- a/packages/process/src/workflows/self-prompting-workflow/self-prompting-workflow.ts
+++ b/packages/process/src/workflows/self-prompting-workflow/self-prompting-workflow.ts
@@ -274,6 +274,7 @@ async function executeIntegrationPhase(
 /**
  * Self-prompting workflow - AI generates complete prompts for each step
  *
+ * @deprecated agenticProcess に統合予定。新規利用は agenticProcess を使用してください。
  * @param driver - AI driver for executing prompts
  * @param module - User's prompt module (merged with phase modules internally)
  * @param context - Workflow context


### PR DESCRIPTION
## Summary
- `selfPromptingProcess` に `@deprecated` アノテーションを追加
- agenticProcess に統合予定のため、新規利用を非推奨化

## Test plan
- [ ] 型チェック通過確認（アノテーション追加のみのため既存動作に影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)