### PR TITLE
fix: agenticプランニングのツール可視性改善

### DIFF
--- a/.changeset/agentic-planning-tool-visibility.md
+++ b/.changeset/agentic-planning-tool-visibility.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/process": patch
+---
+
+fix: agenticワークフローのプランニングプロンプトでツール可視性を改善

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ npm run lint
   - マルチモデル・マルチモジュールテスト
   - コード/AI評価器サポート
   - インライン DriverSet 定義（testCase.models）
+  - 詳細は [packages/experiment/README.md](./packages/experiment/README.md) を参照
 
 ## ドライバーアーキテクチャ
 

--- a/packages/experiment/README.md
+++ b/packages/experiment/README.md
@@ -69,7 +69,55 @@ npx modular-experiment experiment.yaml --evaluate   # 評価付き
 npx modular-experiment experiment.yaml --repeat 10  # 複数回実行
 ```
 
-設定ファイルの詳細、評価器の書き方、プログラマティックAPIについては `skills/experiment/SKILL.md` を参照。
+## 設定ファイルの詳細
+
+### モデル指定: DriverSet記法
+
+テストケースの `models` フィールドでは、単一のモデル名（文字列）または役割別モデルのマッピング（オブジェクト）を指定できます。
+
+#### 単一モデル（文字列）
+
+すべての役割で同じモデルを使用します。
+
+```yaml
+testCases:
+  - name: 基本テスト
+    input:
+      query: "質問内容"
+    models:
+      - gpt4o  # すべての役割でgpt4oを使用
+```
+
+#### DriverSet（役割別モデル）
+
+役割ごとに異なるモデルを指定できます。`default` は必須で、他の役割（`thinking`、`instruct`、`chat`、`plan`）はオプションです。未指定の役割は自動的に `default` にフォールバックします。
+
+```yaml
+models:
+  gemma4:
+    provider: mlx
+    model: gemma4-26b-a4b
+  qwen:
+    provider: mlx
+    model: qwen3.5-9b
+
+testCases:
+  - name: 役割別モデルテスト
+    input:
+      query: "質問内容"
+    models:
+      - default: gemma4     # 通常のタスクはgemma4
+        thinking: qwen      # thinking役割はqwen
+```
+
+**利用可能なModelRole:**
+- `default`: 必須。メインのモデル
+- `thinking`: 推論タスク用（オプション）
+- `instruct`: 指示実行用（オプション）
+- `chat`: 対話用（オプション）
+- `plan`: 計画立案用（オプション）
+
+**注記:** 値には設定ファイルのトップレベル `models:` セクションで定義されたモデル名を指定します。
 
 ## Skills (for Claude Code)
 

--- a/packages/process/experiments/agentic-workflow/e2e.yaml
+++ b/packages/process/experiments/agentic-workflow/e2e.yaml
@@ -34,10 +34,8 @@ models:
       topP: 0.95
       topK: 64
       maxTokens: 1024
-    driverOptions:
-      textOnly: true
-  gemma4-e4b-mxfp8:
-    model: "mlx-community/gemma-4-e4b-it-mxfp8"
+  gemma4-26b-a4b:
+    model: "mlx-community/gemma-4-26B-a4b-it-OptiQ-4bit"
     provider: "mlx"
     defaultOptions:
       temperature: 1.0
@@ -59,7 +57,9 @@ drivers:
 
 _shared:
   models: &models
-    - llm-jp-4-8b-thinking
+    - default: gemma4-e4b
+      plan: gemma4-26b-a4b
+      thinking: gemma4-26b-a4b
 
 modules:
   - name: agentic-time-check
@@ -143,25 +143,25 @@ testCases:
     processOptions:
       maxTasks: 5
 
-  - name: "agenticProcess: TS型推定（簡単）"
-    description: "ジェネリクスの追跡 - think/verifyパターンの生成を観察"
-    modules: [ts-type-inference-easy]
-    models: *models
-    input: {}
-    process: agenticProcess
-    processOptions:
-      maxTasks: 5
-      includeThinking: true
+  # - name: "agenticProcess: TS型推定（簡単）"
+  #   description: "ジェネリクスの追跡 - think/verifyパターンの生成を観察"
+  #   modules: [ts-type-inference-easy]
+  #   models: *models
+  #   input: {}
+  #   process: agenticProcess
+  #   processOptions:
+  #     maxTasks: 5
+  #     includeThinking: true
 
-  - name: "agenticProcess: TS型推定（難しい）"
-    description: "条件型+Mapped Type - 複数段階の型変換追跡でのタスク分解を観察"
-    modules: [ts-type-inference-hard]
-    models: *models
-    input: {}
-    process: agenticProcess
-    processOptions:
-      maxTasks: 8
-      includeThinking: true
+  # - name: "agenticProcess: TS型推定（難しい）"
+  #   description: "条件型+Mapped Type - 複数段階の型変換追跡でのタスク分解を観察"
+  #   modules: [ts-type-inference-hard]
+  #   models: *models
+  #   input: {}
+  #   process: agenticProcess
+  #   processOptions:
+  #     maxTasks: 8
+  #     includeThinking: true
 
 evaluators:
   - name: structured-output-presence

--- a/packages/process/src/workflows/agentic-workflow/agentic-workflow.ts
+++ b/packages/process/src/workflows/agentic-workflow/agentic-workflow.ts
@@ -229,6 +229,7 @@ export async function agenticProcess<T>(
     taskList: resumeState?.taskList ?? bootstrap(userModule, enablePlanning),
     executionLog: resumeState?.executionLog ? [...resumeState.executionLog] : [],
     currentTaskIndex: 0,
+    availableTools: tools.map(t => ({ name: t.name, description: t.description ?? '' })),
   };
 
   const { taskList, executionLog } = internalContext as Required<Pick<AgenticWorkflowContext, 'taskList' | 'executionLog'>>;

--- a/packages/process/src/workflows/agentic-workflow/task-types/planning.ts
+++ b/packages/process/src/workflows/agentic-workflow/task-types/planning.ts
@@ -58,7 +58,7 @@ const planningModule: PromptModule<AgenticWorkflowContext> = {
     '2. **Design & Refine**',
     '  - Design the sequence of Tasks and deliverables that leads from the input to the final deliverable. See "Task Type Guide" and "Planning Theory".',
     '  - Adjust each Task\'s input so it can work correctly and efficiently. Exclude Original Data when deliverables are sufficient. See "What Each Task Can See".',
-    '3. **Register** — Call the task type tool once per Task (e.g. `think({...})`, `output({...})`).',
+    '3. **Register** — Execute the task type tool once per Task. Do not write code — use the tool calling mechanism directly.',
     '  - Each Task\'s `reason` should explain why it is needed. Each Task\'s `instruction` should describe the deliverable to produce.',
   ],
   guidelines: [
@@ -118,6 +118,16 @@ const planningModule: PromptModule<AgenticWorkflowContext> = {
         '  - **withoutMessages**: Exclude messages. Use when the Task instruction captures the intent sufficiently.',
         '  - **withoutInputs**: Exclude inputs. Use when `extractContext` has already extracted what is needed, or when inputs are not relevant to the Task.',
         '  - **withoutMaterials**: Exclude materials. Use when the Task requires focused reasoning on deliverables alone.',
+        '- Each Task can call the following tools:',
+        (ctx: AgenticWorkflowContext) => {
+          const builtinTools = [
+            { name: '__time', description: 'Get the current date and time' },
+            { name: '__replan', description: 'Request re-planning of the workflow' },
+          ];
+          const externalTools = ctx.availableTools ?? [];
+          const allTools = [...builtinTools, ...externalTools];
+          return allTools.map(t => `  - ${t.name}: ${t.description}`).join('\n');
+        },
       ],
     },
   ],
@@ -176,6 +186,6 @@ export const replanningModule: PromptModule<AgenticWorkflowContext> = {
 
 export const config: TaskTypeConfig = {
   module: planningModule,
-  builtinToolNames: [...TASK_TYPE_TOOL_NAMES, '__time'],
+  builtinToolNames: [...TASK_TYPE_TOOL_NAMES],
   maxTokensTier: 'high',
 };

--- a/packages/process/src/workflows/agentic-workflow/types.ts
+++ b/packages/process/src/workflows/agentic-workflow/types.ts
@@ -119,6 +119,8 @@ export interface AgenticWorkflowContext {
   executionLog?: AgenticTaskExecutionLog[];
   /** Index of the currently executing task */
   currentTaskIndex?: number;
+  /** Tools available to execution tasks (for planning prompt visibility) */
+  availableTools?: Array<{ name: string; description: string }>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- プランニングフェーズから `__time` を除外し、タスク登録ツールのみに限定
- 「What Each Task Can See」セクションに実行タスクが使えるツールを description 付き箇条書きで動的リスト化
- ステップ3の Register 指示から Python 的な例示（`think({...})`）を削除し、ツールコール機構の直接使用を明示
- DriverSet 記法のドキュメント追加、e2e 設定更新

## 背景

推論能力の低いモデル（gemma-4-26B 等）がプランニング時に `__time` を直接呼ぶか `act` タスクで呼ぶか迷い、思考がループする問題を修正。
また Python 的な例示がモデルにコード生成を誘発していた問題も解消。

## Test plan

- [x] `pnpm --filter @modular-prompt/process run build` 成功
- [x] `pnpm --filter @modular-prompt/process test` 全78テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)