### PR TITLE
refactor: レスポンスプロセッサをcapabilities駆動に統合

### DIFF
--- a/.changeset/response-processor-capabilities.md
+++ b/.changeset/response-processor-capabilities.md
@@ -1,0 +1,11 @@
+---
+"@modular-prompt/driver": minor
+---
+
+refactor: レスポンスプロセッサをcapabilities駆動に統合
+
+- selectResponseProcessorが常にResponseProcessorを返すように変更（null返却を廃止）
+- createDefaultProcessorファクトリを追加（thinking抽出 + ツールコール解析を合成）
+- Gemma-4の`<|channel>thought...<channel|>`形式のthinking抽出をサポート
+- mlx-driverのpost-processing分岐を統合（if/else → 一本道）
+- model-handlers.tsの内部関数11個をunexport化（公開APIを整理）

--- a/packages/driver/src/content-utils.test.ts
+++ b/packages/driver/src/content-utils.test.ts
@@ -106,6 +106,36 @@ describe('extractThinkingContent', () => {
     expect(result.content).toBe('');
     expect(result.thinkingContent).toBeUndefined();
   });
+
+  it('should extract Gemma-4 channel thinking block', () => {
+    const result = extractThinkingContent('<|channel>thought\n分析中...\nステップ1を実行<channel|>回答です。');
+    expect(result.content).toBe('回答です。');
+    expect(result.thinkingContent).toBe('分析中...\nステップ1を実行');
+  });
+
+  it('should extract multiple Gemma-4 channel thinking blocks', () => {
+    const result = extractThinkingContent('<|channel>thought\n最初の思考<channel|>中間<|channel>thought\n追加の思考<channel|>最終回答');
+    expect(result.content).toBe('中間最終回答');
+    expect(result.thinkingContent).toBe('最初の思考\n追加の思考');
+  });
+
+  it('should handle Gemma-4 stream truncation (closing tag only)', () => {
+    const result = extractThinkingContent('途中の思考<channel|>回答です。');
+    expect(result.content).toBe('回答です。');
+    expect(result.thinkingContent).toBe('途中の思考');
+  });
+
+  it('should handle empty Gemma-4 thinking block', () => {
+    const result = extractThinkingContent('<|channel>thought<channel|>回答');
+    expect(result.content).toBe('回答');
+    expect(result.thinkingContent).toBeUndefined();
+  });
+
+  it('should handle mixed <think> and Gemma-4 blocks', () => {
+    const result = extractThinkingContent('<think>思考1</think>中間<|channel>thought\n思考2<channel|>最終');
+    expect(result.content).toBe('中間最終');
+    expect(result.thinkingContent).toBe('思考1\n思考2');
+  });
 });
 
 describe('extractImagePaths', () => {

--- a/packages/driver/src/content-utils.ts
+++ b/packages/driver/src/content-utils.ts
@@ -12,6 +12,7 @@ export interface ThinkingExtractResult {
 export function extractThinkingContent(text: string): ThinkingExtractResult {
   const thinkingParts: string[] = [];
 
+  // 1. <think>...</think> blocks
   const fullBlockRegex = /<think>([\s\S]*?)<\/think>\s*/g;
   let match;
   while ((match = fullBlockRegex.exec(text)) !== null) {
@@ -20,12 +21,31 @@ export function extractThinkingContent(text: string): ThinkingExtractResult {
   }
   let cleaned = text.replace(fullBlockRegex, '');
 
+  // 1b. Stream truncation: ...content</think> (missing opening tag)
   const headRegex = /^[\s\S]*?<\/think>\s*/;
   const headMatch = cleaned.match(headRegex);
   if (headMatch) {
     const inner = headMatch[0].replace(/<\/think>\s*$/, '').trim();
     if (inner) thinkingParts.push(inner);
     cleaned = cleaned.replace(headRegex, '');
+  }
+
+  // 2. <|channel>thought...<channel|> blocks (Gemma-4)
+  const gemma4Regex = /<\|channel>thought([\s\S]*?)<channel\|>\s*/g;
+  let gemma4Match;
+  while ((gemma4Match = gemma4Regex.exec(cleaned)) !== null) {
+    const inner = gemma4Match[1].trim();
+    if (inner) thinkingParts.push(inner);
+  }
+  cleaned = cleaned.replace(gemma4Regex, '');
+
+  // 2b. Stream truncation: ...content<channel|> (missing opening tag)
+  const gemma4HeadRegex = /^[\s\S]*?<channel\|>\s*/;
+  const gemma4HeadMatch = cleaned.match(gemma4HeadRegex);
+  if (gemma4HeadMatch) {
+    const inner = gemma4HeadMatch[0].replace(/<channel\|>\s*$/, '').trim();
+    if (inner) thinkingParts.push(inner);
+    cleaned = cleaned.replace(gemma4HeadRegex, '');
   }
 
   return {

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -365,7 +365,8 @@ export class MlxDriver implements AIDriver {
       }
 
       // Response post-processing: thinking抽出 + tool call解析
-      const responseProcessor = selectResponseProcessor(this.model, this.runtimeInfo);
+      const hasTools = options?.tools && options.tools.length > 0;
+      const responseProcessor = selectResponseProcessor(this.model, this.runtimeInfo, { enableToolParsing: !!hasTools });
       const parsed = responseProcessor(content);
       let finalContent = parsed.content;
       const thinkingContent = parsed.thinkingContent;

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -11,8 +11,8 @@ import { createModelSpecificProcessor, selectApi } from './process/model-specifi
 import { selectResponseProcessor } from './process/model-handlers.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
 import { extractJSON } from '@modular-prompt/utils';
-import { parseToolCalls, formatToolDefinitionsAsText } from './tool-call-parser.js';
-import { contentToString, extractImagePaths, extractThinkingContent } from '../content-utils.js';
+import { formatToolDefinitionsAsText } from './tool-call-parser.js';
+import { contentToString, extractImagePaths } from '../content-utils.js';
 import { QueryLogger } from '../query-logger.js';
 
 // ========================================================================
@@ -364,33 +364,15 @@ export class MlxDriver implements AIDriver {
         throw error;
       }
 
-      // Response post-processing via model-specific processor
+      // Response post-processing: thinking抽出 + tool call解析
       const responseProcessor = selectResponseProcessor(this.model, this.runtimeInfo);
-      let finalContent = content;
-      let thinkingContent: string | undefined;
-      let toolCalls: ToolCall[] | undefined;
+      const parsed = responseProcessor(content);
+      let finalContent = parsed.content;
+      const thinkingContent = parsed.thinkingContent;
+      const toolCalls = parsed.toolCalls;
 
-      if (responseProcessor) {
-        const parsed = responseProcessor(content);
-        finalContent = parsed.content;
-        thinkingContent = parsed.thinkingContent;
-        toolCalls = parsed.toolCalls;
-      } else {
-        // Legacy flow: tool call detection only
-        if (options?.tools && options.tools.length > 0) {
-          const parseResult = parseToolCalls(content, this.runtimeInfo);
-          if (parseResult.toolCalls.length > 0) {
-            toolCalls = parseResult.toolCalls;
-            finalContent = parseResult.content;
-          }
-        }
-      }
-
-      // Extract <think> tags if not already handled by responseProcessor
-      if (!thinkingContent) {
-        const extracted = extractThinkingContent(finalContent);
-        finalContent = extracted.content;
-        thinkingContent = extracted.thinkingContent;
+      if (thinkingContent) {
+        this.queryLogger.log.verbose('Thinking content:', thinkingContent);
       }
 
       // Handle structured output if schema is provided

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolDefinition, ToolCall, FinishReason } from '../types.js';
+import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolDefinition, FinishReason } from '../types.js';
 import { hasToolCalls, isToolResult } from '../types.js';
 import type { FormatterOptions, ChatMessage } from '../formatter/types.js';
 import { formatPromptAsMessages } from '../formatter/converter.js';

--- a/packages/driver/src/mlx-ml/process/completion-prompt-formatting.test.ts
+++ b/packages/driver/src/mlx-ml/process/completion-prompt-formatting.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect } from 'vitest';
 import { compile } from '@modular-prompt/core';
 import type { PromptModule } from '@modular-prompt/core';
 import { createModelSpecificProcessor } from './model-specific.js';
-import { processLlmJpCompletion } from './model-handlers.js';
+import { selectCompletionProcessor } from './model-handlers.js';
 import { formatCompletionPrompt, defaultFormatterTexts } from '../../formatter/converter.js';
 
 describe('Completion API - Prompt Formatting with Section Headers', () => {
@@ -63,7 +63,9 @@ describe('Completion API - Prompt Formatting with Section Headers', () => {
     });
   });
 
-  describe('processLlmJpCompletion - model-specific processing', () => {
+  describe('llm-jp-3.1 completion processor - model-specific processing', () => {
+    const processLlmJpCompletion = selectCompletionProcessor('mlx-community/llm-jp-3.1-8x13b-instruct4-4bit')!;
+
     it('should wrap prompt with llm-jp template markers', () => {
       const inputPrompt = '# Instructions\n\nFollow these steps\n\n# Data\n\nCurrent state\n\n# Output\n\nWrite response';
       const result = processLlmJpCompletion(inputPrompt);

--- a/packages/driver/src/mlx-ml/process/model-handlers.test.ts
+++ b/packages/driver/src/mlx-ml/process/model-handlers.test.ts
@@ -55,7 +55,7 @@ describe('selectResponseProcessor', () => {
     expect(result).toBe(parseHarmonyResponse);
   });
 
-  it('should return null for unknown models without tool_parser_type', () => {
+  it('should return default processor for unknown models without tool_parser_type', () => {
     const runtimeInfo = {
       methods: ['chat'],
       special_tokens: {},
@@ -67,15 +67,17 @@ describe('selectResponseProcessor', () => {
     } as MlxRuntimeInfo;
 
     const result = selectResponseProcessor('generic-model', runtimeInfo);
-    expect(result).toBeNull();
+    expect(result).toBeTypeOf('function');
+    expect(result).not.toBe(parseHarmonyResponse);
   });
 
-  it('should return null when runtimeInfo is null and model name is unknown', () => {
+  it('should return default processor when runtimeInfo is null and model name is unknown', () => {
     const result = selectResponseProcessor('generic-model', null);
-    expect(result).toBeNull();
+    expect(result).toBeTypeOf('function');
+    expect(result).not.toBe(parseHarmonyResponse);
   });
 
-  it('should return null for json_tools parser type', () => {
+  it('should return default processor for json_tools parser type', () => {
     const runtimeInfo = {
       methods: ['chat'],
       special_tokens: {},
@@ -95,6 +97,54 @@ describe('selectResponseProcessor', () => {
     } as MlxRuntimeInfo;
 
     const result = selectResponseProcessor('some-model', runtimeInfo);
-    expect(result).toBeNull();
+    expect(result).toBeTypeOf('function');
+    expect(result).not.toBe(parseHarmonyResponse);
+  });
+
+  describe('default processor behavior', () => {
+    it('should extract <think> blocks', () => {
+      const processor = selectResponseProcessor('generic-model', null);
+      const result = processor('<think>分析中</think>回答です。');
+      expect(result.content).toBe('回答です。');
+      expect(result.thinkingContent).toBe('分析中');
+    });
+
+    it('should extract Gemma-4 channel thinking blocks', () => {
+      const processor = selectResponseProcessor('generic-model', null);
+      const result = processor('<|channel>thought\n分析中<channel|>回答です。');
+      expect(result.content).toBe('回答です。');
+      expect(result.thinkingContent).toBe('分析中');
+    });
+
+    it('should parse tool calls with delimiters', () => {
+      const runtimeInfo = {
+        methods: ['chat'],
+        special_tokens: {},
+        features: {
+          apply_chat_template: true,
+          chat_template: {
+            supported_roles: ['system', 'user', 'assistant'],
+            tool_call_format: {
+              tool_parser_type: 'json_tools',
+              call_start: '<tool_call>',
+              call_end: '</tool_call>',
+            }
+          }
+        }
+      } as MlxRuntimeInfo;
+
+      const processor = selectResponseProcessor('some-model', runtimeInfo);
+      const result = processor('<tool_call>{"name":"test","arguments":{"a":1}}</tool_call>');
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('test');
+    });
+
+    it('should return plain content when no thinking or tools', () => {
+      const processor = selectResponseProcessor('generic-model', null);
+      const result = processor('普通のテキストです。');
+      expect(result.content).toBe('普通のテキストです。');
+      expect(result.thinkingContent).toBeUndefined();
+      expect(result.toolCalls).toBeUndefined();
+    });
   });
 });

--- a/packages/driver/src/mlx-ml/process/model-handlers.test.ts
+++ b/packages/driver/src/mlx-ml/process/model-handlers.test.ts
@@ -116,7 +116,7 @@ describe('selectResponseProcessor', () => {
       expect(result.thinkingContent).toBe('分析中');
     });
 
-    it('should parse tool calls with delimiters', () => {
+    it('should parse tool calls with delimiters when enableToolParsing is true', () => {
       const runtimeInfo = {
         methods: ['chat'],
         special_tokens: {},
@@ -133,10 +133,17 @@ describe('selectResponseProcessor', () => {
         }
       } as MlxRuntimeInfo;
 
-      const processor = selectResponseProcessor('some-model', runtimeInfo);
+      const processor = selectResponseProcessor('some-model', runtimeInfo, { enableToolParsing: true });
       const result = processor('<tool_call>{"name":"test","arguments":{"a":1}}</tool_call>');
       expect(result.toolCalls).toHaveLength(1);
       expect(result.toolCalls![0].name).toBe('test');
+    });
+
+    it('should not parse tool calls when enableToolParsing is false', () => {
+      const processor = selectResponseProcessor('generic-model', null);
+      const result = processor('{"name":"test","arguments":{"a":1}}');
+      expect(result.content).toBe('{"name":"test","arguments":{"a":1}}');
+      expect(result.toolCalls).toBeUndefined();
     });
 
     it('should return plain content when no thinking or tools', () => {

--- a/packages/driver/src/mlx-ml/process/model-handlers.ts
+++ b/packages/driver/src/mlx-ml/process/model-handlers.ts
@@ -267,7 +267,8 @@ export function selectCompletionProcessor(modelName: string): ((prompt: string) 
  */
 export function selectResponseProcessor(
   modelName: string,
-  runtimeInfo: MlxRuntimeInfo | null
+  runtimeInfo: MlxRuntimeInfo | null,
+  options?: { enableToolParsing?: boolean },
 ): ResponseProcessor {
   const parserType = runtimeInfo?.features?.chat_template?.tool_call_format?.tool_parser_type;
 
@@ -278,5 +279,5 @@ export function selectResponseProcessor(
     return parseHarmonyResponse;
   }
 
-  return createDefaultProcessor(runtimeInfo);
+  return createDefaultProcessor(runtimeInfo, options);
 }

--- a/packages/driver/src/mlx-ml/process/model-handlers.ts
+++ b/packages/driver/src/mlx-ml/process/model-handlers.ts
@@ -6,6 +6,7 @@
 
 import type { MlxMessage, MlxRuntimeInfo } from './types.js';
 import type { ResponseProcessor } from './response-processor.js';
+import { createDefaultProcessor } from './response-processor.js';
 import { parseHarmonyResponse } from './harmony-parser.js';
 
 /**
@@ -65,7 +66,7 @@ function mergeSystemMessagesRaw(msgs: MlxMessage[]): MlxMessage[] {
 /**
  * Tanuki-8B-dpo-v1用のChat処理
  */
-export function processTanukiChat(messages: MlxMessage[]): MlxMessage[] {
+function processTanukiChat(messages: MlxMessage[]): MlxMessage[] {
   // まずsystemメッセージをマージ（改行を保持）
   const mergedMessages = mergeSystemMessagesRaw(messages);
 
@@ -100,7 +101,7 @@ export function processTanukiChat(messages: MlxMessage[]): MlxMessage[] {
  * CodeLlama用のChat処理
  * userメッセージ補完は applyChatSpecificProcessing で汎用的に処理
  */
-export function processCodeLlamaChat(messages: MlxMessage[]): MlxMessage[] {
+function processCodeLlamaChat(messages: MlxMessage[]): MlxMessage[] {
   return mergeSystemMessages(messages);
 }
 
@@ -108,7 +109,7 @@ export function processCodeLlamaChat(messages: MlxMessage[]): MlxMessage[] {
  * Gemma-3用のChat処理
  * userメッセージ補完は applyChatSpecificProcessing で汎用的に処理
  */
-export function processGemmaChat(messages: MlxMessage[]): MlxMessage[] {
+function processGemmaChat(messages: MlxMessage[]): MlxMessage[] {
   return mergeSystemMessages(messages);
 }
 
@@ -116,7 +117,7 @@ export function processGemmaChat(messages: MlxMessage[]): MlxMessage[] {
  * Gemma-4用のChat処理
  * userメッセージ補完は applyChatSpecificProcessing で汎用的に処理
  */
-export function processGemma4Chat(messages: MlxMessage[]): MlxMessage[] {
+function processGemma4Chat(messages: MlxMessage[]): MlxMessage[] {
   const msgs: MlxMessage[] = [
     {
       role: 'system',
@@ -127,7 +128,7 @@ export function processGemma4Chat(messages: MlxMessage[]): MlxMessage[] {
   return msgs;
 }
 
-export function processGemma4Completion(prompt: string): string {
+function processGemma4Completion(prompt: string): string {
   return [
     'You are a helpful assistant.',
     prompt,
@@ -139,7 +140,7 @@ export function processGemma4Completion(prompt: string): string {
  * chat_templateに厳密に準拠した形式
  * Note: llm-jp-3.1はforce-completion設定のため、chat APIは使用されない
  */
-export function processLlmJpCompletion(prompt: string): string {
+function processLlmJpCompletion(prompt: string): string {
   // llm-jpは複数言語の混ぜ書きに弱い傾向があるため、特定の言語を優先しないよう明示的に指示
   const llmJpSpecificInstruction = '指示は英語・日本語の混ぜ書きになっているが、どちらの言語も同等の指示として十分に理解すること。\n出力は与えられたタスクに対してふさわしい言語を選択する。\n\n';
 
@@ -154,7 +155,7 @@ export function processLlmJpCompletion(prompt: string): string {
 /**
  * Tanuki-8B用のCompletion処理
  */
-export function processTanukiCompletion(prompt: string): string {
+function processTanukiCompletion(prompt: string): string {
   // completion APIではブロック化トークンを使用可能
   return `### システム:\n${prompt}\n\n### 応答:\n`;
 }
@@ -162,7 +163,7 @@ export function processTanukiCompletion(prompt: string): string {
 /**
  * Gemma-3用のCompletion処理
  */
-export function processGemmaCompletion(prompt: string): string {
+function processGemmaCompletion(prompt: string): string {
   // Gemma-3はchat形式に依存しないcompletion処理が可能
   return `<start_of_turn>user\n${prompt}<end_of_turn>\n<start_of_turn>model\n`;
 }
@@ -179,7 +180,7 @@ export function processGemmaCompletion(prompt: string): string {
  *
  * Note: <<SYS>>, [INST]などはspecial tokensではなく、複数トークンに分割される
  */
-export function processElyzaCompletion(prompt: string): string {
+function processElyzaCompletion(prompt: string): string {
   const B_INST = '[INST]';
   const E_INST = '[/INST]';
   const B_SYS = '<<SYS>>\n';
@@ -195,7 +196,7 @@ export function processElyzaCompletion(prompt: string): string {
  * LFM用のChat処理
  * userメッセージ補完は applyChatSpecificProcessing で汎用的に処理
  */
-export function processLfmChat(messages: MlxMessage[]): MlxMessage[] {
+function processLfmChat(messages: MlxMessage[]): MlxMessage[] {
   return mergeSystemMessages(messages);
 }
 
@@ -203,7 +204,7 @@ export function processLfmChat(messages: MlxMessage[]): MlxMessage[] {
  * Qwen用のChat処理
  * userメッセージ補完は applyChatSpecificProcessing で汎用的に処理
  */
-export function processQwenChat(messages: MlxMessage[]): MlxMessage[] {
+function processQwenChat(messages: MlxMessage[]): MlxMessage[] {
   return mergeSystemMessages(messages);
 }
 
@@ -262,20 +263,20 @@ export function selectCompletionProcessor(modelName: string): ((prompt: string) 
  * レスポンス後処理を選択
  *
  * tool_parser_type ベースの判定を優先し、モデル名はフォールバック。
- * null を返す場合は既存の tool-call-parser のみで処理する。
+ * 常にResponseProcessorを返す（nullは返さない）。
  */
 export function selectResponseProcessor(
   modelName: string,
   runtimeInfo: MlxRuntimeInfo | null
-): ResponseProcessor | null {
+): ResponseProcessor {
   const parserType = runtimeInfo?.features?.chat_template?.tool_call_format?.tool_parser_type;
+
   if (parserType === 'harmony') {
     return parseHarmonyResponse;
   }
-
   if (modelName.includes('llm-jp-4')) {
     return parseHarmonyResponse;
   }
 
-  return null;
+  return createDefaultProcessor(runtimeInfo);
 }

--- a/packages/driver/src/mlx-ml/process/response-processor.ts
+++ b/packages/driver/src/mlx-ml/process/response-processor.ts
@@ -1,4 +1,7 @@
 import type { ToolCall } from '../../types.js';
+import type { MlxRuntimeInfo } from './types.js';
+import { extractThinkingContent } from '../../content-utils.js';
+import { parseToolCalls } from '../tool-call-parser.js';
 
 export interface ResponseParseResult {
   content: string;
@@ -7,3 +10,21 @@ export interface ResponseParseResult {
 }
 
 export type ResponseProcessor = (rawText: string) => ResponseParseResult;
+
+/**
+ * デフォルトResponseProcessorファクトリ
+ *
+ * thinking抽出（<think>, <|channel>thought等）とツールコール解析を合成する。
+ * 専用パーサ（harmony等）を持たないモデル向けの汎用プロセッサ。
+ */
+export function createDefaultProcessor(runtimeInfo: MlxRuntimeInfo | null): ResponseProcessor {
+  return (rawText: string): ResponseParseResult => {
+    const { content: afterThinking, thinkingContent } = extractThinkingContent(rawText);
+    const { content, toolCalls } = parseToolCalls(afterThinking, runtimeInfo);
+    return {
+      content,
+      thinkingContent,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    };
+  };
+}

--- a/packages/driver/src/mlx-ml/process/response-processor.ts
+++ b/packages/driver/src/mlx-ml/process/response-processor.ts
@@ -17,14 +17,21 @@ export type ResponseProcessor = (rawText: string) => ResponseParseResult;
  * thinking抽出（<think>, <|channel>thought等）とツールコール解析を合成する。
  * 専用パーサ（harmony等）を持たないモデル向けの汎用プロセッサ。
  */
-export function createDefaultProcessor(runtimeInfo: MlxRuntimeInfo | null): ResponseProcessor {
+export function createDefaultProcessor(
+  runtimeInfo: MlxRuntimeInfo | null,
+  options?: { enableToolParsing?: boolean },
+): ResponseProcessor {
+  const enableToolParsing = options?.enableToolParsing ?? false;
   return (rawText: string): ResponseParseResult => {
     const { content: afterThinking, thinkingContent } = extractThinkingContent(rawText);
-    const { content, toolCalls } = parseToolCalls(afterThinking, runtimeInfo);
-    return {
-      content,
-      thinkingContent,
-      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-    };
+    if (enableToolParsing) {
+      const { content, toolCalls } = parseToolCalls(afterThinking, runtimeInfo);
+      return {
+        content,
+        thinkingContent,
+        toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      };
+    }
+    return { content: afterThinking, thinkingContent };
   };
 }

--- a/packages/driver/src/mlx-ml/process/types.ts
+++ b/packages/driver/src/mlx-ml/process/types.ts
@@ -99,7 +99,9 @@ export type KnownToolParserType =
   | 'longcat'
   | 'glm47'
   | 'qwen3_coder'
-  | 'minimax_m2';
+  | 'minimax_m2'
+  | 'gemma4'
+  | 'harmony';
 
 export interface ToolCallFormat {
   tool_parser_type?: string;

--- a/packages/driver/test/integration/mlx-model-handlers.test.ts
+++ b/packages/driver/test/integration/mlx-model-handlers.test.ts
@@ -1,16 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import {
-  processTanukiChat,
-  processCodeLlamaChat,
-  processGemmaChat,
-  processTanukiCompletion,
-  processLlmJpCompletion,
-  processGemmaCompletion
+  selectChatProcessor,
+  selectCompletionProcessor
 } from '../../src/mlx-ml/process/model-handlers.js';
 import type { MlxMessage } from '../../src/mlx-ml/process/types.js';
 
 describe('MLX Model Handlers', () => {
-  describe('processTanukiChat', () => {
+  describe('Tanuki chat processor', () => {
+    const processTanukiChat = selectChatProcessor('Tanuki-8B-dpo-v1')!;
+
     it('should add exact prefix and suffix to system message', () => {
       const messages: MlxMessage[] = [
         { role: 'system', content: 'You are a helpful assistant.' },
@@ -69,7 +67,9 @@ describe('MLX Model Handlers', () => {
     });
   });
 
-  describe('processCodeLlamaChat', () => {
+  describe('CodeLlama chat processor', () => {
+    const processCodeLlamaChat = selectChatProcessor('mlx-community/CodeLlama-7b')!;
+
     it('should merge system messages', () => {
       const messages: MlxMessage[] = [
         { role: 'system', content: 'System prompt' },
@@ -85,7 +85,9 @@ describe('MLX Model Handlers', () => {
     });
   });
 
-  describe('processGemmaChat', () => {
+  describe('Gemma chat processor', () => {
+    const processGemmaChat = selectChatProcessor('gemma-3-4b')!;
+
     it('should merge system messages', () => {
       const messages: MlxMessage[] = [
         { role: 'system', content: 'System' },
@@ -105,15 +107,15 @@ describe('MLX Model Handlers', () => {
 
   describe('Completion processors', () => {
     it('should format Tanuki completion with exact markers', () => {
-      const prompt = 'Generate content';
-      const result = processTanukiCompletion(prompt);
+      const processor = selectCompletionProcessor('Tanuki-8B')!;
+      const result = processor('Generate content');
 
       expect(result).toBe('### システム:\nGenerate content\n\n### 応答:\n');
     });
 
     it('should format LLM-JP completion with exact template', () => {
-      const prompt = 'Task description';
-      const result = processLlmJpCompletion(prompt);
+      const processor = selectCompletionProcessor('llm-jp-3.1-8b')!;
+      const result = processor('Task description');
 
       expect(result).toBe(
         '<s>以下は、タスクを説明する指示です。要求を適切に満たす応答を書きなさい。' +
@@ -126,8 +128,8 @@ describe('MLX Model Handlers', () => {
     });
 
     it('should format Gemma completion with turn markers', () => {
-      const prompt = 'User input';
-      const result = processGemmaCompletion(prompt);
+      const processor = selectCompletionProcessor('gemma-3-4b')!;
+      const result = processor('User input');
 
       expect(result).toBe('<start_of_turn>user\nUser input<end_of_turn>\n<start_of_turn>model\n');
     });

--- a/packages/experiment/README.md
+++ b/packages/experiment/README.md
@@ -69,6 +69,27 @@ npx modular-experiment experiment.yaml --evaluate   # 評価付き
 npx modular-experiment experiment.yaml --repeat 10  # 複数回実行
 ```
 
+#### CLIオプション
+
+| オプション | 説明 | デフォルト |
+|-----------|------|-----------|
+| `--test-case <name>` | テストケース名フィルター（指定した名前のみ実行） | all |
+| `--model <provider>` | モデルプロバイダーフィルター（例: `mlx`, `vertexai`, `googlegenai`） | すべての有効なモデル |
+| `--modules <names>` | カンマ区切りのモジュール名（指定したモジュールのみテスト） | all |
+| `--repeat <count>` | 実行回数（統計的な評価に有用） | 1 |
+| `--evaluate` | AI評価器を有効化（評価フェーズを実行） | false |
+| `--evaluators <names>` | カンマ区切りの評価器名（指定した評価器のみ使用） | all |
+| `--dry-run` | 実行計画の表示のみ（実験を実行しない） | false |
+| `--verbose` | 詳細なログ出力（内部処理の表示） | false |
+| `--log-file <path>` | 詳細ログのJSONL出力先ファイルパス | なし |
+| `--trace-dir <dir>` | 構造化された実行ログの出力ディレクトリ（prefix/contextごとにファイル分割、summary.json付き） | なし |
+| `--output <path>` | 実験結果のJSON出力先ファイルパス（メタデータと結果を含む） | なし |
+
+**ログ・トレースオプション詳細:**
+- `--log-file`: 全実行ログをJSONL形式で1ファイルに出力。各行が1ログエントリ。
+- `--trace-dir`: ログをprefix/context別にファイル分割して出力。summary.jsonに全体統計を含む。読みやすい形式（タイムスタンプ + レベル + メッセージ）。
+- `--output`: 実験結果を構造化JSON形式で保存。タイムスタンプ、使用モデル、繰り返し回数などのメタデータを含む。
+
 ## 設定ファイルの詳細
 
 ### モデル指定: DriverSet記法

--- a/packages/process/experiments/agentic-workflow/e2e.yaml
+++ b/packages/process/experiments/agentic-workflow/e2e.yaml
@@ -9,10 +9,10 @@ models:
   qwen3.5-9b:
     model: mlx-community/Qwen3.5-9B-OptiQ-4bit
     provider: "mlx"
-  qwen3.5-4b-optiq:
+  qwen3.5-4b:
     model: mlx-community/Qwen3.5-4B-OptiQ-4bit
     provider: "mlx"
-  quen3.5-2b-optiq:
+  quen3.5-2b:
     model: mlx-community/Qwen3.5-2B-OptiQ-4bit
     provider: "mlx"
 
@@ -35,7 +35,8 @@ models:
       topK: 64
       maxTokens: 1024
   gemma4-26b-a4b:
-    model: "mlx-community/gemma-4-26B-a4b-it-OptiQ-4bit"
+    model: "mlx-community/gemma-4-26B-A4B-it-heretic-msq-2.6bit"
+    # model: "mlx-community/gemma-4-26B-a4b-it-OptiQ-4bit"
     provider: "mlx"
     defaultOptions:
       temperature: 1.0
@@ -57,9 +58,11 @@ drivers:
 
 _shared:
   models: &models
-    - default: gemma4-e4b
-      plan: gemma4-26b-a4b
-      thinking: gemma4-26b-a4b
+    - qwen3.5-9b
+
+    # - default: gemma4-e4b
+    #   plan: qwen3.5-9b
+    #   thinking: gemma4-26b-a4b
 
 modules:
   - name: agentic-time-check

--- a/packages/process/src/workflows/agentic-workflow/DESIGN.md
+++ b/packages/process/src/workflows/agentic-workflow/DESIGN.md
@@ -1,235 +1,380 @@
-# Agentic Workflow v2 設計
+# Agentic Workflow 設計
 
-## 基本構造
+## 概要
 
-固定フェーズを廃止し、**タスクのシーケンス**で構成する。
-各タスクタイプが独自の入出力契約（何を指示として受け取り、何をデータとして受け取るか）を持つ。
+Agentic Workflow は、複雑なプロンプトをタスク単位に分解して実行する処理フローです。固定されたフェーズではなく、動的にタスクのシーケンスを構築し、各タスクが独立したプロンプトとして実行されます。
 
 ```
-[planning] → [task-1] → [task-2] → ... → [outputXxx]
+[planning] → [task-1] → [task-2] → ... → [output]
 ```
 
-## ブートストラップ
+### 設計原則
 
-初期タスクリストはプログラム的に決定する:
+1. **タスクベースの構成**: 固定フェーズを廃止し、タスク単位で処理を組み立てる
+2. **明確な契約**: 各タスクタイプは入出力の契約（何を受け取り、何を生成するか）を持つ
+3. **プランナーとワーカーの分離**: planning タスクがワークフローを設計し、他のタスクが実行する
+4. **透過的な依存管理**: タスク間の依存関係をトポロジカルソートで自動解決
+5. **動的な再計画**: 実行中にワークフローを見直し、タスクを再構成できる
 
-- `schema` あり: `[planning, outputStructured]`
-- `schema` なし: `[planning, outputMessage]`
+## タスクタイプ
 
-`planning` タスクが `__register_tasks` ツールで中間タスクを挿入する。
-挿入位置のデフォルトは output タスクの直前。
+### タスクタイプ一覧
 
-## タスク定義
+| タイプ | 役割 | デフォルトドライバー | maxTokens |
+|--------|------|---------------------|-----------|
+| `planning` | ワークフロー設計 | `plan` | high (8192) |
+| `act` | 外部アクション実行 | `instruct` | low (2048) |
+| `think` | 分析・推論 | `thinking` | high (8192) |
+| `verify` | 検証・評価 | `thinking` | low (2048) |
+| `extractContext` | 情報抽出 | `thinking` | high (8192) |
+| `recall` | 情報検索 | `instruct` | middle (4096) |
+| `determine` | 判断・決定 | `thinking` | middle (4096) |
+| `output` | 最終出力生成 | `chat` | middle (4096) |
+
+### タスク定義の型
 
 ```typescript
-type TaskType =
-  | 'planning'
-  | 'think'
-  | 'extractContext'
-  | 'outputMessage'
-  | 'outputStructured';
-
 interface AgenticTask {
-  id: number;                    // 自動採番（1, 2, 3, ...）
-  instruction: string;
-  taskType: TaskType;
-  driverRole?: ModelRole;        // デフォルトはタスクタイプによる
-  withoutInputs?: boolean;       // ctx.inputs を除外する（デフォルト: false = 含む）
-  withoutMessages?: boolean;     // ctx.messages を除外する（デフォルト: false = 含む）
-  withoutMaterials?: boolean;    // ctx.materials を除外する（デフォルト: false = 含む）
+  name?: string;               // タスク識別子（dep 参照や表示に使用）
+  instruction: string;         // このタスクが生成すべき成果物の説明
+  taskType: TaskType;          // タスクタイプ
+  dep?: string[];              // 依存する先行タスクの name 配列
+  driverRole?: ModelRole;      // ドライバーロールの上書き
+  withoutInputs?: boolean;     // ユーザー入力データを除外（デフォルト: false = 含む）
+  withoutMessages?: boolean;   // ユーザーメッセージを除外（デフォルト: false = 含む）
+  withoutMaterials?: boolean;  // ユーザーマテリアルを除外（デフォルト: false = 含む）
 }
 ```
 
-- `id` はプログラム的に自動採番する。LLMは指定しない。
-- `guidelines` / `constraints` は廃止。`instruction` でタスクを説明する。
+**重要な変更点**:
+- `id` フィールドは廃止し、`name` に置き換え（より分かりやすく、依存関係の記述が自然）
+- `dep` フィールドで依存関係を明示的に表現（トポロジカルソートで実行順序を自動決定）
 
-## 共通原則
+## ツール体系
 
-全タスクで共通の入力:
+Agentic Workflow は二層のツール構造を持ちます。
 
-| 区分 | 項目 |
-|------|------|
-| **指示** (instructions) | `objective`, `terms`, タスクタイプ固有プロンプト |
-| **データ** (data) | 前タスク結果（常に渡す） |
+### Planning tools（タスクタイプツール）
 
-`objective` は大目標であり、全タスクに指示として渡す。
-`terms` は語彙定義であり、全タスクに指示として渡す。
+planning タスクから利用可能。タスクタイプ名をそのままツール名として使用します。
 
-## タスクタイプ契約
+- `think(name, instruction, reason, ...)`: 推論タスクを登録
+- `act(name, instruction, reason, ...)`: アクションタスクを登録
+- `verify(name, instruction, reason, ...)`: 検証タスクを登録
+- `extractContext(name, instruction, reason, ...)`: 抽出タスクを登録
+- `recall(name, instruction, reason, ...)`: 検索タスクを登録
+- `determine(name, instruction, reason, ...)`: 判断タスクを登録
+- `output(name, instruction, reason, ...)`: 出力タスクを登録
 
-### `planning`
+**共通パラメータ**:
+- `name` (必須): タスク識別子
+- `instruction` (必須): 成果物の説明
+- `reason` (必須): このタスクが必要な理由
+- `dep`: 依存する先行タスクの name 配列
+- `withoutInputs`, `withoutMessages`, `withoutMaterials`: データ除外フラグ
+- `driverRole`: ドライバーロールの上書き
+- `insertAt`: 挿入位置（省略時は次のタスクとして挿入）
 
-| 区分 | 項目 |
-|------|------|
-| **目的** | 目標をタスクに分解し、タスクリストを構築する |
-| **指示** | `objective`, `terms`, planning固有プロンプト |
-| **データ** | `instructions`, `guidelines`, `materials`, `inputs` |
-| **ツール** | `__register_tasks` |
-| **デフォルトドライバー** | `plan` |
+### Execution tools（実行時ツール）
 
-ユーザーModuleの `instructions`, `guidelines`, `materials`, `inputs` は
-planning にとって「分析・分解すべき対象」であり、データとして渡す。
+execution タスク（act, think, verify など）から利用可能。
 
-### `think`
+- `__replan`: ワークフローの再計画を要求
+- `__time`: 現在時刻を取得
 
-| 区分 | 項目 |
-|------|------|
-| **目的** | 分析・推論 |
-| **指示** | `objective`, `terms`, task instruction |
-| **データ** | 前タスク結果 + オプション |
-| **ツール** | `__register_tasks`, `__time` |
-| **デフォルトドライバー** | `instruct` |
+### External tools
 
-オプションとデフォルト値（全データ含む）:
-- `withoutInputs`: `false`
-- `withoutMessages`: `false`
-- `withoutMaterials`: `false`
+`tools` オプションで渡された外部ツール定義も、execution タスクから利用可能です。
 
-### `extractContext`
+## タスクタイプの詳細
 
-| 区分 | 項目 |
-|------|------|
-| **目的** | messages / materials / inputs から情報を抽出する |
-| **指示** | `objective`, `terms`, task instruction |
-| **データ** | 前タスク結果 + オプション |
-| **ツール** | `__register_tasks`, `__time` |
-| **デフォルトドライバー** | `instruct` |
+### planning
 
-オプションとデフォルト値（全データ含む）:
-- `withoutInputs`: `false`
-- `withoutMessages`: `false`
-- `withoutMaterials`: `false`
+**役割**: ユーザーリクエストを分析し、タスクシーケンスを設計する
 
-### `outputMessage`
+**入力契約**:
+- 指示: planning 固有のプロンプト（分析・設計の方法論）
+- データ: ユーザーモジュール全体（"Original Request" として material に変換）
 
-| 区分 | 項目 |
-|------|------|
-| **目的** | テキスト最終出力を生成する |
-| **指示** | `objective`, `terms`, `cue` |
-| **データ** | 全タスク結果 |
-| **ツール** | なし |
-| **デフォルトドライバー** | `chat` |
+**出力**:
+- テキスト出力: リクエスト分析の結果
+- ツール呼び出し: タスクタイプツールを使ってタスクを登録
 
-### `outputStructured`
+**ツール**: すべてのタスクタイプツール (`think`, `act`, ..., `output`)
 
-| 区分 | 項目 |
-|------|------|
-| **目的** | schema に従った構造化データの最終出力を生成する |
-| **指示** | `objective`, `terms`, `schema` |
-| **データ** | 全タスク結果 |
-| **ツール** | なし |
-| **デフォルトドライバー** | `chat` |
+**特殊処理**:
+- 既存の deliverables がある場合（再計画時）、`replanningModule` がマージされ、過去の実行ログが可視化される
+- planning 完了後、登録されたタスクはトポロジカルソートされる
 
-## `__register_tasks` ツール
+### Execution tasks (act, think, verify, extractContext, recall, determine)
 
-全タスクから利用可能（planning 専用ではない）。
+**共通の入力契約**:
+- 指示: タスク固有のプロンプト + 現在タスクの `instruction` (Focus セクション)
+- データ: 
+  - 常に含まれる: 前タスクの deliverables
+  - オプション: ユーザーの inputs, messages, materials（`without*` フラグで制御）
 
-### パラメータ
+**共通のツール**: `__replan`, `__time`, 外部ツール
 
-```
-instruction: string          # 必須
-taskType?: TaskType           # デフォルト: think
-driverRole?: ModelRole        # デフォルト: タスクタイプによる
-withoutInputs?: boolean       # デフォルト: false（含む）
-withoutMessages?: boolean     # デフォルト: false（含む）
-withoutMaterials?: boolean    # デフォルト: false（含む）
-insertAt?: number             # 挿入位置インデックス（省略時: outputタスクの直前）
-```
+**タスクタイプ別の特徴**:
 
-`id` は自動採番。ツール結果として `"Task 3 registered: ..."` のように返す。
+| タイプ | 目的 | 使用場面 | 成果物 |
+|--------|------|----------|--------|
+| `extractContext` | 情報抽出 | 入力が大量、要約が必要 | 抽出・構造化されたデータ |
+| `think` | 分析・推論 | 前向きな分析、創造的作業 | 新しい洞察・生成コンテンツ |
+| `verify` | 検証・評価 | 品質レビュー、妥当性評価 | 評価結果・改善提案 |
+| `determine` | 判断・決定 | 意思決定、yes/no判断 | 明確な結論と根拠 |
+| `act` | 外部アクション | ツール実行が主目的 | ツール実行結果 |
+| `recall` | 情報検索 | 外部検索・記憶参照 | 取得した事実・ドキュメント |
 
-## タスクリスト表示
+### output
 
-methodology セクションで全タスクを表示する。
-フェーズ構成の説明と、現在のタスクの位置を明示する。
+**役割**: 前タスクの deliverables から最終的なユーザー向け出力を生成する
 
-```markdown
-## Processing Methodology
+**入力契約**:
+- 指示: ユーザーモジュール全体 + output 固有のプロンプト
+- データ: 全タスクの deliverables（state セクション経由）
 
-This workflow processes tasks sequentially:
+**出力**: ユーザー向けの最終応答
 
-- Task 1 (planning): Decompose objective into tasks [completed]
-- Task 2 (think): Analyze input data [current]
-- Task 3 (extractContext): Extract key points from documents [pending]
-- Task 4 (outputMessage): Generate final output [pending]
-```
+**ツール**: なし
 
-## ドライバー割り当て
-
-各タスクタイプにデフォルトのドライバーロールがある。
-`driverRole` パラメータで上書き可能。
-
-| タスクタイプ | デフォルト |
-|------------|-----------|
-| `planning` | `plan` |
-| `think` | `instruct` |
-| `extractContext` | `instruct` |
-| `outputMessage` | `chat` |
-| `outputStructured` | `chat` |
-
-## AgenticWorkflowContext
-
-```typescript
-interface AgenticWorkflowContext {
-  objective: string;
-  inputs?: Record<string, unknown>;
-  messages?: MessageElement[];
-  materials?: MaterialElement[];
-  state?: {
-    content: string;
-    usage?: number;
-  };
-  taskList?: AgenticTask[];
-  executionLog?: AgenticTaskExecutionLog[];
-  currentTaskIndex?: number;
-}
-```
-
-注: ユーザーModuleの `instructions`, `guidelines` は Module のセクションとして渡され、
-planning タスクのプロンプト構築時にデータ領域に配置される。
-Context には含めない。
+**特殊処理**:
+- ユーザーモジュール全体が workflowBase として使われる（他のタスクは terms のみ）
+- output タスクは常にワークフローの最後に配置される（トポロジカルソートで除外）
 
 ## ワークフローフロー
 
+### 1. ブートストラップ
+
+初期タスクリストを生成します。
+
+- `enablePlanning=true`（デフォルト）: `[planning]` のみ。output は自動追加される
+- `enablePlanning=false`: `[output]` のみ
+
+### 2. タスクループ
+
+各タスクを順次実行します。
+
 ```
-1. ブートストラップ
-   - schema の有無に応じて初期タスクリスト生成
-   - [planning, outputMessage] or [planning, outputStructured]
-
-2. タスクループ
-   for each task in taskList:
-     a. タスクタイプに応じたプロンプト構築
-        - 共通: objective, terms を指示側に
-        - 共通: 前タスク結果をデータ側に
-        - タイプ固有: 追加の指示・データ
-     b. タスクタイプに応じたドライバー選択
-     c. queryWithTools でクエリ（ツール提供もタイプ依存）
-     d. 結果を executionLog に記録
-     e. タスクリスト変更があれば反映（__register_tasks による挿入）
-     f. 次のタスクへ
-
-3. 最終出力
-   - 最後のタスク（outputMessage / outputStructured）の結果が最終出力
-   - pendingToolCalls がある場合は finishReason: tool_calls
+for each task in taskList:
+  1. プロンプト構築
+     - タスクタイプに応じた module を merge & resolve
+     - output: ユーザーモジュール全体 + outputModule
+     - planning: terms のみ + planningModule (+ replanningModule)
+     - 他: terms のみ + taskCommon + executionTaskModule
+  
+  2. ドライバー選択
+     - task.driverRole または DEFAULT_DRIVER_ROLE[taskType] を使用
+  
+  3. queryWithTools でクエリ
+     - builtin tools + external tools を提供
+     - ツール呼び出しループで結果を取得
+  
+  4. 結果を executionLog に記録
+  
+  5. 特殊処理
+     - planning 完了後: 新規タスクをトポロジカルソート
+     - __replan 呼び出し後: 残タスクをクリアし、新しい planning タスクを挿入
+     - 外部ツール pending: ワークフローを中断（finishReason: tool_calls）
+     - output 完了: ワークフローを終了
 ```
 
-## ファイル構成（予定）
+### 3. 自動 output 追加
+
+最後に実行されたタスクが output でなく、外部ツールも pending していない場合、output タスクが自動的に追加・実行されます。
+
+### 4. 最終出力
+
+- `includeThinking=false`: 最後のタスクの結果を返す
+- `includeThinking=true`: 中間タスクの結果を `<think>` タグで包んで前置
+
+## プロンプト構築の仕組み
+
+各タスクは以下のようにプロンプトを構築します。
+
+### planning タスク
+
+```typescript
+// workflowBase: userModule の terms のみ
+// merge: workflowBase + planningModule (+ replanningModule)
+// userModule 全体は "Original Request" material として提供
+```
+
+**なぜこの構造か**:
+- planning は「ユーザーリクエストを分析して分解する」という meta-level の作業
+- ユーザーの objective や instructions をそのまま planning の objective にすると混乱する
+- したがって、ユーザーモジュールはデータとして material に変換して提供
+
+### execution タスク
+
+```typescript
+// workflowBase: userModule の terms のみ
+// merge: workflowBase + taskCommon + executionTaskModule
+// userModule の inputs, messages, materials は without* フラグで制御
+```
+
+**なぜこの構造か**:
+- execution タスクは「特定の deliverable を生成する」という明確な作業単位
+- taskCommon で共通の methodology と state（deliverables）を提供
+- executionTaskModule で Focus（現在タスクの instruction）を提供
+- ユーザーデータは必要に応じて動的に含める
+
+### output タスク
+
+```typescript
+// workflowBase: userModule 全体
+// merge: workflowBase + taskCommon + outputModule
+```
+
+**なぜこの構造か**:
+- output は「ユーザーの元のリクエストに対する最終応答を生成する」作業
+- ユーザーモジュール全体（objective, instructions など）をそのまま使う
+- deliverables は state セクション経由で提供される（taskCommon から）
+
+## 依存関係とトポロジカルソート
+
+### dep フィールド
+
+タスクの `dep` フィールドは、先行タスクの `name` を配列で指定します。
+
+```typescript
+{ name: 'extract', instruction: '...', taskType: 'extractContext' }
+{ name: 'analyze', instruction: '...', taskType: 'think', dep: ['extract'] }
+{ name: 'decide', instruction: '...', taskType: 'determine', dep: ['analyze'] }
+```
+
+### トポロジカルソート
+
+planning タスク完了後、新規登録されたタスクは Kahn のアルゴリズムでトポロジカルソートされます。
+
+**特徴**:
+- 依存関係のないタスクは元の順序を維持（stable sort）
+- output タスクは常に最後に配置
+- 循環依存を検出した場合は警告し、元の順序を保持
+- 存在しない name への参照は警告し、無視
+
+## Re-planning 機構
+
+### `__replan` ツールの呼び出し
+
+execution タスクから `__replan` を呼ぶと、以下の処理が行われます:
+
+1. 現在のタスクまでの executionLog を保持
+2. 残りのタスクをすべてクリア
+3. 新しい planning タスクを挿入
+4. planning タスクに `replanningModule` がマージされ、既存の deliverables が可視化される
+
+### 再計画時のプロンプト
+
+`replanningModule` は以下を提供します:
+
+- 完了済みタスクとその結果の一覧
+- "Original Request" の messages に tool result が含まれている場合の取り扱い指示
+
+これにより、planning タスクは既存の成果を活用して新しいワークフローを設計できます。
+
+## Resume/Suspend 機構
+
+### AgenticResumeState
+
+```typescript
+interface AgenticResumeState {
+  taskList?: AgenticTask[];
+  executionLog?: AgenticTaskExecutionLog[];
+}
+```
+
+### Suspend（中断）
+
+外部ツールの呼び出しが pending のとき、ワークフローは中断されます:
+
+```typescript
+{
+  output: '...',
+  context: {
+    taskList: [...],
+    executionLog: [...],
+  },
+  metadata: {
+    finishReason: 'tool_calls',
+  },
+}
+```
+
+### Resume（再開）
+
+中断した状態を `options.resumeState` に渡すと、続きから実行されます。
+
+## AgenticWorkflowContext
+
+内部コンテキストの型定義:
+
+```typescript
+interface AgenticWorkflowContext {
+  userModule?: ResolvedModule;      // 解決済みユーザーモジュール
+  taskList?: AgenticTask[];         // 現在のタスクリスト
+  executionLog?: AgenticTaskExecutionLog[];  // 実行ログ
+  currentTaskIndex?: number;        // 現在実行中のタスクインデックス
+  availableTools?: Array<{ name: string; description: string }>;  // planning プロンプトでの可視化用
+}
+```
+
+**重要な設計変更**:
+- `objective`, `inputs`, `messages`, `materials`, `state` は削除
+- `userModule` が ResolvedModule として全てのユーザーデータを保持
+- 各タスクのプロンプト構築時に動的に必要なデータを抽出
+
+## MaxTokensTier
+
+タスクタイプごとに maxTokens の tier を設定します:
+
+```typescript
+type MaxTokensTier = 'low' | 'middle' | 'high';
+
+const MAX_TOKENS_VALUES = {
+  low: 2048,
+  middle: 4096,
+  high: 8192,
+};
+```
+
+実際の値はモデルの `maxOutputTokens` によってキャップされます（TODO: 現在は driver のデフォルトレベルのキャップのみ）。
+
+## ファイル構成
 
 ```
 agentic-workflow/
-  agentic-workflow.ts      # メインワークフロー（ブートストラップ + タスクループ）
-  types.ts                 # 型定義
-  index.ts                 # export
-  DESIGN.md                # この文書
+  agentic-workflow.ts          # メインワークフロー（ブートストラップ + タスクループ）
+  agentic-workflow.test.ts     # ユニットテスト
+  types.ts                     # 型定義（TaskType, AgenticTask, Context など）
+  index.ts                     # export
+  DESIGN.md                    # この文書
+  prompt-inspection.test.ts    # プロンプト検証テスト
   process/
-    query-with-tools.ts    # ツール呼び出しループ（既存を調整）
-    builtin-tools.ts       # __register_tasks, __time ツール定義
-    format-helpers.ts      # プロンプト構築ヘルパー
+    query-with-tools.ts        # ツール呼び出しループ
+    builtin-tools.ts           # planning/execution ツール定義
+    format-helpers.ts          # プロンプト構築ヘルパー
+    topological-sort.ts        # トポロジカルソート
+    index.ts                   # export
   task-types/
-    index.ts               # タスクタイプレジストリ
-    planning.ts            # planning タスクタイプ
-    think.ts               # think タスクタイプ
-    extract-context.ts     # extractContext タスクタイプ
-    output-message.ts      # outputMessage タスクタイプ
-    output-structured.ts   # outputStructured タスクタイプ
+    index.ts                   # タスクタイプレジストリ、共通 module (taskCommon)
+    planning.ts                # planning タスクタイプ + replanningModule
+    output.ts                  # output タスクタイプ
+    execution-tasks.ts         # execution タスクタイプファクトリ + EXECUTION_TASK_DEFS
 ```
+
+## 実装の拡張性
+
+### 新しいタスクタイプの追加
+
+1. `execution-tasks.ts` の `EXECUTION_TASK_DEFS` に定義を追加
+2. `types.ts` の `TaskType` union に追加
+
+レジストリ登録・ツール定義・プロンプト構築は自動的に反映されます。
+
+### 新しいツールの追加
+
+- Planning tools: `builtin-tools.ts` の `createPlanningTools` を修正
+- Execution tools: `builtin-tools.ts` の `createExecutionBuiltinTools` を修正
+- External tools: `options.tools` で渡す

--- a/packages/process/src/workflows/agentic-workflow/task-types/index.ts
+++ b/packages/process/src/workflows/agentic-workflow/task-types/index.ts
@@ -159,6 +159,7 @@ export const taskCommon: PromptModule<AgenticWorkflowContext> = {
     '- **Task Type**: Defines the role of a Task (e.g. think, act, verify). The prompt is pre-configured for each type.',
     '- **Deliverable**: The concrete output a Task produces. It becomes input for subsequent Tasks.',
     '- **Focus**: The specific directive for the current Task — what deliverable to produce.',
+    '- **Tool**: A function that performs an external action.',
   ],
   methodology: [
     `- We accomplish the Workflow's Objective by executing Tasks sequentially.`,

--- a/packages/process/src/workflows/agentic-workflow/task-types/planning.ts
+++ b/packages/process/src/workflows/agentic-workflow/task-types/planning.ts
@@ -38,7 +38,7 @@ const planningModule: PromptModule<AgenticWorkflowContext> = {
     '- **Deliverable**: The concrete output a Task produces. It becomes input for subsequent Tasks.',
     '- **Task**: A unit of work that produces a specific deliverable. Each Task is executed by a separate AI instance.',
     '- **Task Type**: Defines the role and prompt structure of a Task.',
-    '- **Tool**: A function available to Tasks for performing external actions or retrieving information. Used primarily in act and recall Tasks.',
+    '- **Tool**: A function available to Tasks for performing external actions or retrieving information.',
   ],
   methodology: [
     '- A **Workflow** is a sequence of Tasks that begins with this planning Task and ends with an output Task.',
@@ -154,7 +154,7 @@ const planningModule: PromptModule<AgenticWorkflowContext> = {
     {
       type: 'message' as const,
       role: 'user' as const,
-      content: 'Output your analysis in a user-readable format, then register tasks.',
+      content: 'Output your analysis in a user-readable format, then call the task type tools to register each task.',
     },
   ],
 };


### PR DESCRIPTION
## Summary

- `selectResponseProcessor`が常にResponseProcessorを返すように変更し、mlx-driverのpost-processing分岐を一本道に統合
- Gemma-4の`<|channel>thought...<channel|>`形式のthinking抽出をサポート（リグレッション修正）
- `createDefaultProcessor`ファクトリ追加（thinking抽出 + ツールコール解析を合成する汎用プロセッサ）
- model-handlers.tsの内部関数11個をunexport化し公開APIを整理
- planningプロンプトのcueメッセージを改善（tool calling成功率向上）
- agentic workflow DESIGN.mdを現在の実装に合わせて全面更新
- experiment CLIオプションのドキュメント追加

## Test plan

- [ ] `npm test -w @modular-prompt/driver` — 既存テスト + Gemma-4 thinking抽出テスト + default processorテスト
- [ ] `npm run typecheck` — 型チェック通過
- [ ] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)