### PR TITLE
feat: @google/genai v2アップグレード + thoughtSignature対応

### DIFF
--- a/.changeset/googlegenai-v2-thought-signature.md
+++ b/.changeset/googlegenai-v2-thought-signature.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/driver": minor
+---
+
+feat: @google/genai v2アップグレード + Gemini 3 thoughtSignature対応

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "vitest": "3.2.4"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "pnpm": ">=9.0.0"
   },
   "packageManager": "pnpm@9.14.4",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -35,7 +35,7 @@
     "@anthropic-ai/sdk": "0.61.0",
     "@anthropic-ai/vertex-sdk": "0.14.4",
     "@google-cloud/vertexai": "1.10.0",
-    "@google/genai": "^2.0.1",
+    "@google/genai": "2.0.1",
     "@modular-prompt/core": "workspace:*",
     "@modular-prompt/utils": "workspace:*",
     "@types/js-yaml": "4.0.9",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -35,7 +35,7 @@
     "@anthropic-ai/sdk": "0.61.0",
     "@anthropic-ai/vertex-sdk": "0.14.4",
     "@google-cloud/vertexai": "1.10.0",
-    "@google/genai": "1.34.0",
+    "@google/genai": "^2.0.1",
     "@modular-prompt/core": "workspace:*",
     "@modular-prompt/utils": "workspace:*",
     "@types/js-yaml": "4.0.9",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -53,6 +53,9 @@
     "typescript": "5.9.3",
     "vitest": "3.2.4"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/driver/src/google-genai/google-genai-driver.test.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.test.ts
@@ -688,6 +688,7 @@ describe('GoogleGenAIDriver', () => {
       } as unknown as ReturnType<typeof driver['client']['models']['generateContentStream']>);
 
       const { stream, result } = await driver.streamQuery(basicPrompt, { tools: toolDefs });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       for await (const _chunk of stream) { /* consume */ }
 
       const finalResult = await result;

--- a/packages/driver/src/google-genai/google-genai-driver.test.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.test.ts
@@ -543,6 +543,159 @@ describe('GoogleGenAIDriver', () => {
     });
   });
 
+  describe('thought signature support', () => {
+    const toolDefs: ToolDefinition[] = [
+      {
+        name: 'get_weather',
+        description: 'Get the weather',
+        parameters: { type: 'object', properties: { location: { type: 'string' } } }
+      }
+    ];
+
+    const basicPrompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'You are helpful' }],
+      data: [{ type: 'text', content: 'What is the weather?' }],
+      output: []
+    };
+
+    it('should preserve thoughtSignature in ToolCall.metadata', async () => {
+      vi.spyOn(driver['client'].models, 'generateContent').mockResolvedValue({
+        get text() { throw new Error('no text'); },
+        candidates: [{
+          finishReason: 'STOP',
+          content: {
+            parts: [{
+              functionCall: {
+                id: 'call_1',
+                name: 'get_weather',
+                args: { location: 'Tokyo' }
+              },
+              thoughtSignature: 'sig_abc123'
+            }]
+          }
+        }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 }
+      });
+
+      const result = await driver.query(basicPrompt, { tools: toolDefs });
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].metadata).toEqual({ thoughtSignature: 'sig_abc123' });
+    });
+
+    it('should not set metadata when no thoughtSignature', async () => {
+      vi.spyOn(driver['client'].models, 'generateContent').mockResolvedValue({
+        get text() { throw new Error('no text'); },
+        candidates: [{
+          finishReason: 'STOP',
+          content: {
+            parts: [{
+              functionCall: {
+                id: 'call_1',
+                name: 'get_weather',
+                args: { location: 'Tokyo' }
+              }
+            }]
+          }
+        }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 }
+      });
+
+      const result = await driver.query(basicPrompt, { tools: toolDefs });
+
+      expect(result.toolCalls![0].metadata).toBeUndefined();
+    });
+
+    it('should handle parallel tool calls where only first has thoughtSignature', async () => {
+      vi.spyOn(driver['client'].models, 'generateContent').mockResolvedValue({
+        get text() { throw new Error('no text'); },
+        candidates: [{
+          finishReason: 'STOP',
+          content: {
+            parts: [
+              {
+                functionCall: { id: 'call_1', name: 'get_weather', args: { location: 'Tokyo' } },
+                thoughtSignature: 'sig_parallel'
+              },
+              {
+                functionCall: { id: 'call_2', name: 'get_weather', args: { location: 'Osaka' } }
+              }
+            ]
+          }
+        }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 }
+      });
+
+      const result = await driver.query(basicPrompt, { tools: toolDefs });
+
+      expect(result.toolCalls).toHaveLength(2);
+      expect(result.toolCalls![0].metadata).toEqual({ thoughtSignature: 'sig_parallel' });
+      expect(result.toolCalls![1].metadata).toBeUndefined();
+    });
+
+    it('should restore thoughtSignature in elementToContent', async () => {
+      const prompt: CompiledPrompt = {
+        instructions: [{ type: 'text', content: 'You are helpful' }],
+        data: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: '',
+            toolCalls: [{
+              id: 'call_1',
+              name: 'get_weather',
+              arguments: { location: 'Tokyo' },
+              metadata: { thoughtSignature: 'sig_restore' }
+            }]
+          },
+          {
+            type: 'message',
+            role: 'tool',
+            toolCallId: 'call_1',
+            name: 'get_weather',
+            kind: 'data',
+            value: { temp: 25 }
+          }
+        ],
+        output: []
+      };
+
+      const mockGenerateContent = driver['client'].models.generateContent as ReturnType<typeof vi.fn>;
+      await driver.query(prompt);
+
+      const callArgs = mockGenerateContent.mock.calls[mockGenerateContent.mock.calls.length - 1][0];
+      const modelMsg = callArgs.contents.find((c: { role: string }) => c.role === 'model');
+      const fcPart = modelMsg.parts.find((p: { functionCall?: unknown }) => p.functionCall);
+      expect(fcPart.thoughtSignature).toBe('sig_restore');
+    });
+
+    it('should preserve thoughtSignature in stream response', async () => {
+      vi.spyOn(driver['client'].models, 'generateContentStream').mockResolvedValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield {
+            get text() { throw new Error('no text'); },
+            candidates: [{
+              finishReason: 'STOP',
+              content: {
+                parts: [{
+                  functionCall: { id: 'call_stream', name: 'get_weather', args: { location: 'Tokyo' } },
+                  thoughtSignature: 'sig_stream'
+                }]
+              }
+            }]
+          };
+        }
+      } as unknown as ReturnType<typeof driver['client']['models']['generateContentStream']>);
+
+      const { stream, result } = await driver.streamQuery(basicPrompt, { tools: toolDefs });
+      for await (const _chunk of stream) { /* consume */ }
+
+      const finalResult = await result;
+      expect(finalResult.toolCalls).toHaveLength(1);
+      expect(finalResult.toolCalls![0].metadata).toEqual({ thoughtSignature: 'sig_stream' });
+    });
+  });
+
   describe('finish reason mapping', () => {
     it('should map finish reasons correctly', async () => {
       const testCases = [

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -184,7 +184,11 @@ export class GoogleGenAIDriver implements AIDriver {
         const content = contentToString(element.content);
         if (content) parts.push({ text: content });
         for (const tc of element.toolCalls) {
-          parts.push({ functionCall: { name: tc.name, args: tc.arguments as Record<string, unknown> } });
+          const part: Part = { functionCall: { name: tc.name, args: tc.arguments as Record<string, unknown> } };
+          if (tc.metadata?.thoughtSignature) {
+            part.thoughtSignature = tc.metadata.thoughtSignature as string;
+          }
+          parts.push(part);
         }
         return { role: 'model', parts };
       } else {
@@ -219,12 +223,13 @@ export class GoogleGenAIDriver implements AIDriver {
         parts.push({ text: textContent });
       }
       for (const tc of message.toolCalls) {
-        parts.push({
-          functionCall: {
-            name: tc.name,
-            args: tc.arguments as Record<string, unknown>
-          }
-        });
+        const part: Part = {
+          functionCall: { name: tc.name, args: tc.arguments as Record<string, unknown> }
+        };
+        if (tc.metadata?.thoughtSignature) {
+          part.thoughtSignature = tc.metadata.thoughtSignature as string;
+        }
+        parts.push(part);
       }
       return { role: 'model', parts };
     } else if (isToolResult(message)) {
@@ -323,11 +328,15 @@ export class GoogleGenAIDriver implements AIDriver {
     for (const part of parts) {
       if (part.functionCall) {
         const fc = part.functionCall;
-        toolCalls.push({
+        const toolCall: ToolCall = {
           id: fc.id || `call_${toolCalls.length}`,
           name: fc.name || '',
           arguments: fc.args ?? {},
-        });
+        };
+        if (part.thoughtSignature) {
+          toolCall.metadata = { thoughtSignature: part.thoughtSignature };
+        }
+        toolCalls.push(toolCall);
       }
     }
     return toolCalls;

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -185,8 +185,8 @@ export class GoogleGenAIDriver implements AIDriver {
         if (content) parts.push({ text: content });
         for (const tc of element.toolCalls) {
           const part: Part = { functionCall: { name: tc.name, args: tc.arguments as Record<string, unknown> } };
-          if (tc.metadata?.thoughtSignature) {
-            part.thoughtSignature = tc.metadata.thoughtSignature as string;
+          if (typeof tc.metadata?.thoughtSignature === 'string') {
+            part.thoughtSignature = tc.metadata.thoughtSignature;
           }
           parts.push(part);
         }
@@ -226,8 +226,8 @@ export class GoogleGenAIDriver implements AIDriver {
         const part: Part = {
           functionCall: { name: tc.name, args: tc.arguments as Record<string, unknown> }
         };
-        if (tc.metadata?.thoughtSignature) {
-          part.thoughtSignature = tc.metadata.thoughtSignature as string;
+        if (typeof tc.metadata?.thoughtSignature === 'string') {
+          part.thoughtSignature = tc.metadata.thoughtSignature;
         }
         parts.push(part);
       }
@@ -333,7 +333,7 @@ export class GoogleGenAIDriver implements AIDriver {
           name: fc.name || '',
           arguments: fc.args ?? {},
         };
-        if (part.thoughtSignature) {
+        if (typeof part.thoughtSignature === 'string') {
           toolCall.metadata = { thoughtSignature: part.thoughtSignature };
         }
         toolCalls.push(toolCall);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         specifier: 1.10.0
         version: 1.10.0
       '@google/genai':
-        specifier: ^2.0.1
+        specifier: 2.0.1
         version: 2.0.1
       '@modular-prompt/core':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 1.10.0
         version: 1.10.0
       '@google/genai':
-        specifier: 1.34.0
-        version: 1.34.0
+        specifier: ^2.0.1
+        version: 2.0.1
       '@modular-prompt/core':
         specifier: workspace:*
         version: link:../core
@@ -556,11 +556,11 @@ packages:
     resolution: {integrity: sha512-HqYqoivNtkq59po8m7KI0n+lWKdz4kabENncYQXZCX/hBWJfXtKAfR/2nUQsP+TwSfHKoA7zDL2RrJYIv/j3VQ==}
     engines: {node: '>=18.0.0'}
 
-  '@google/genai@1.34.0':
-    resolution: {integrity: sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw==}
+  '@google/genai@2.0.1':
+    resolution: {integrity: sha512-trxxbVePM9J8Cuni5x7+xvApoqb2y6Zk27/wugjT2cuwHOT78nFGdf/Ni29MkDxzWwrj90OQpno1Ana6dm3D2A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.24.0
+      '@modelcontextprotocol/sdk': ^1.25.2
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -621,6 +621,36 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rollup/rollup-android-arm-eabi@4.53.5':
     resolution: {integrity: sha512-iDGS/h7D8t7tvZ1t6+WPK04KD0MwzLZrG0se1hzBjSi5fyxlsiggoJHwh18PCFNn7tG43OWb6pdZ6Y+rMlmyNQ==}
@@ -752,6 +782,9 @@ packages:
 
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@typescript-eslint/eslint-plugin@8.50.0':
     resolution: {integrity: sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==}
@@ -1359,6 +1392,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1470,6 +1506,10 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
@@ -1535,6 +1575,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  protobufjs@7.5.7:
+    resolution: {integrity: sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==}
+    engines: {node: '>=12.0.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1556,6 +1600,10 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2138,9 +2186,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google/genai@1.34.0':
+  '@google/genai@2.0.1':
     dependencies:
       google-auth-library: 10.5.0
+      p-retry: 4.6.2
+      protobufjs: 7.5.7
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -2208,6 +2258,29 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.53.5':
     optional: true
@@ -2293,6 +2366,8 @@ snapshots:
   '@types/node@20.19.27':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/retry@0.12.0': {}
 
   '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -2988,6 +3063,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  long@5.3.2: {}
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -3075,6 +3152,11 @@ snapshots:
 
   p-map@2.1.0: {}
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
@@ -3120,6 +3202,21 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  protobufjs@7.5.7:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 20.19.27
+      long: 5.3.2
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -3136,6 +3233,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- `@google/genai` を 1.34.0 → 2.0.1 にアップグレード（v2の破壊的変更はInteractions APIのみ、generateContentは影響なし）
- Gemini 3系モデルのツールコールで必須となる `thoughtSignature` を `ToolCall.metadata` に保持・復元する処理を追加
- `extractToolCalls`: レスポンスの `Part.thoughtSignature` を `ToolCall.metadata` に格納
- `elementToContent` / `chatMessageToContent`: `ToolCall.metadata.thoughtSignature` を `Part` に復元

## Test plan

- [x] thoughtSignature保持テスト（単一・パラレル・ストリーム）
- [x] thoughtSignature未設定時のメタデータ未定義テスト
- [x] elementToContentでのthoughtSignature復元テスト
- [x] 既存テスト全パス（30テスト）
- [x] ビルド・型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)