### PR TITLE
feat: ElementにcacheHintプロパティを追加

### DIFF
--- a/.changeset/cache-hint-elements.md
+++ b/.changeset/cache-hint-elements.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/core": minor
+---
+
+ElementにcacheHintプロパティを追加。コンパイル時にDynamicContent由来の要素を'contextual'、静的定義の要素を'static'として分類し、ドライバー層でのKVキャッシュ最適化を可能にする。

--- a/packages/core/src/compile-static-elements.test.ts
+++ b/packages/core/src/compile-static-elements.test.ts
@@ -77,7 +77,8 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'data',
         title: 'Prepared Materials',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
 
       // 次にMaterialElementが追加される
@@ -85,7 +86,8 @@ describe('compile with static Elements', () => {
         type: 'material',
         id: 'api-doc',
         title: 'API Documentation',
-        content: 'This is the API documentation content'
+        content: 'This is the API documentation content',
+        cacheHint: 'static'
       });
     });
 
@@ -115,7 +117,8 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'data',
         title: 'Prepared Materials',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       expect(result.data[1].type).toBe('material');
       expect(result.data[2].type).toBe('material');
@@ -144,14 +147,16 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'data',
         title: 'Input Chunks',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       expect(result.data[1]).toEqual({
         type: 'chunk',
         content: 'Chunk content',
         partOf: 'document',
         index: 0,
-        total: 3
+        total: 3,
+        cacheHint: 'static'
       });
     });
   });
@@ -181,17 +186,20 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'data',
         title: 'Messages',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       expect(result.data[1]).toEqual({
         type: 'message',
         role: 'user',
-        content: 'What is the weather?'
+        content: 'What is the weather?',
+        cacheHint: 'static'
       });
       expect(result.data[2]).toEqual({
         type: 'message',
         role: 'assistant',
-        content: 'I can help you check the weather.'
+        content: 'I can help you check the weather.',
+        cacheHint: 'static'
       });
     });
   });
@@ -216,13 +224,15 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'instructions',
         title: 'Instructions',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
 
       // 次にTextElement
       expect(result.instructions[1]).toEqual({
         type: 'text',
-        content: 'This is a text element'
+        content: 'This is a text element',
+        cacheHint: 'static'
       });
     });
   });
@@ -251,7 +261,8 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'data',
         title: 'Prepared Materials',
-        items: ['String content', 'Another string']
+        items: ['String content', 'Another string'],
+        cacheHint: 'static'
       });
 
       // MaterialElement
@@ -259,7 +270,8 @@ describe('compile with static Elements', () => {
         type: 'material',
         id: 'doc',
         title: 'Document',
-        content: 'Document content'
+        content: 'Document content',
+        cacheHint: 'static'
       });
     });
 
@@ -295,13 +307,15 @@ describe('compile with static Elements', () => {
             title: 'Steps',
             items: ['Step 1', 'Step 2']
           }
-        ]
+        ],
+        cacheHint: 'static'
       });
 
       // TextElement
       expect(result.instructions[1]).toEqual({
         type: 'text',
-        content: 'Text element content'
+        content: 'Text element content',
+        cacheHint: 'static'
       });
     });
 
@@ -344,7 +358,8 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'data',
         title: 'Prepared Materials',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
 
       // Both static and dynamic MaterialElements should be present
@@ -352,14 +367,16 @@ describe('compile with static Elements', () => {
         type: 'material',
         id: 'static-doc',
         title: 'Static Document',
-        content: 'Static content'
+        content: 'Static content',
+        cacheHint: 'static'
       });
 
       expect(result.data[2]).toEqual({
         type: 'material',
         id: 'dynamic-doc',
         title: 'Dynamic Document',
-        content: 'Dynamic content'
+        content: 'Dynamic content',
+        cacheHint: 'contextual'
       });
     });
   });
@@ -387,7 +404,8 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'instructions',
         title: 'Instructions',
-        items: ['Outer instruction']
+        items: ['Outer instruction'],
+        cacheHint: 'static'
       });
 
       // Nested SectionElement (直接追加される)
@@ -395,7 +413,8 @@ describe('compile with static Elements', () => {
         type: 'section',
         category: 'instructions',
         title: 'Nested Section',
-        items: ['Nested item 1', 'Nested item 2']
+        items: ['Nested item 1', 'Nested item 2'],
+        cacheHint: 'static'
       });
     });
   });

--- a/packages/core/src/compile.test.ts
+++ b/packages/core/src/compile.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { compile, createContext } from './compile';
-import type { 
-  PromptModule, 
+import { compile, createContext, distribute } from './compile';
+import type {
+  PromptModule,
   SubSectionElement,
   TextElement,
   MessageElement,
@@ -36,13 +36,15 @@ describe('compile', () => {
         type: 'section',
         category: 'instructions',
         title: 'Objective and Role',
-        items: ['AIアシスタントとして動作する']
+        items: ['AIアシスタントとして動作する'],
+        cacheHint: 'static'
       });
       expect(result.instructions[1]).toEqual({
         type: 'section',
         category: 'instructions',
         title: 'Processing Methodology',
-        items: ['データを分析', '結果を生成']
+        items: ['データを分析', '結果を生成'],
+        cacheHint: 'static'
       });
     });
 
@@ -74,7 +76,8 @@ describe('compile', () => {
                 title: '変換処理',
             items: ['正規化', '特徴抽出']
           }
-        ]
+        ],
+        cacheHint: 'static'
       });
     });
   });
@@ -98,12 +101,14 @@ describe('compile', () => {
         type: 'section',
         category: 'data',
         title: 'Current State',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       // 次にTextElement
       expect(result.data[1]).toEqual({
         type: 'text',
-        content: 'Value: test123'
+        content: 'Value: test123',
+        cacheHint: 'contextual'
       });
     });
 
@@ -126,13 +131,15 @@ describe('compile', () => {
         type: 'section',
         category: 'data',
         title: 'Messages',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       // 次にMessageElement
       expect(result.data[1]).toEqual({
         type: 'message',
         role: 'user',
-        content: 'Hello, AI!'
+        content: 'Hello, AI!',
+        cacheHint: 'contextual'
       });
     });
 
@@ -162,14 +169,16 @@ describe('compile', () => {
         type: 'section',
         category: 'data',
         title: 'Prepared Materials',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       // 次にMaterialElement
       expect(result.data[1]).toEqual({
         type: 'material',
         id: 'doc1',
         title: 'API Guide',
-        content: 'API documentation content'
+        content: 'API documentation content',
+        cacheHint: 'contextual'
       });
     });
 
@@ -197,18 +206,21 @@ describe('compile', () => {
         type: 'section',
         category: 'data',
         title: 'Input Chunks',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       // 次にChunkElement
       expect(result.data[1]).toEqual({
         type: 'chunk',
         partOf: 'document.txt',
-        content: 'Part 1 content'
+        content: 'Part 1 content',
+        cacheHint: 'contextual'
       });
       expect(result.data[2]).toEqual({
         type: 'chunk',
         partOf: 'document.txt',
-        content: 'Part 2 content'
+        content: 'Part 2 content',
+        cacheHint: 'contextual'
       });
     });
 
@@ -228,20 +240,23 @@ describe('compile', () => {
         type: 'section',
         category: 'data',
         title: 'Current State',
-        items: ['固定の状態']
+        items: ['固定の状態'],
+        cacheHint: 'static'
       });
       expect(result1.data[1]).toEqual({
         type: 'text',
-        content: '動的な状態'
+        content: '動的な状態',
+        cacheHint: 'contextual'
       });
-      
+
       const result2 = compile(module, { includeState: false });
       expect(result2.data).toHaveLength(1);
       expect(result2.data[0]).toEqual({
         type: 'section',
         category: 'data',
         title: 'Current State',
-        items: ['固定の状態']
+        items: ['固定の状態'],
+        cacheHint: 'static'
       });
     });
   });
@@ -334,22 +349,26 @@ describe('compile', () => {
                 title: '詳細手順',
             items: ['初期化', '検証', '実行']
           }
-        ]
+        ],
+        cacheHint: 'static'
       });
       // TextElement（ステップ情報）
       expect(result.instructions[1]).toEqual({
         type: 'text',
-        content: 'ステップ 3/5 を実行中'
+        content: 'ステップ 3/5 を実行中',
+        cacheHint: 'contextual'
       });
       // TextElement（詳細1）
       expect(result.instructions[2]).toEqual({
         type: 'text',
-        content: '詳細1'
+        content: '詳細1',
+        cacheHint: 'contextual'
       });
       // TextElement（詳細2）
       expect(result.instructions[3]).toEqual({
         type: 'text',
-        content: '詳細2'
+        content: '詳細2',
+        cacheHint: 'contextual'
       });
     });
   });
@@ -574,11 +593,13 @@ describe('compile', () => {
         type: 'section',
         category: 'instructions',
         title: 'Processing Methodology',
-        items: ['プロセス開始', '合計: 5件']
+        items: ['プロセス開始', '合計: 5件'],
+        cacheHint: 'contextual'
       });
       expect(result.instructions[1]).toEqual({
         type: 'text',
-        content: '詳細情報'
+        content: '詳細情報',
+        cacheHint: 'contextual'
       });
     });
     
@@ -640,18 +661,21 @@ describe('compile', () => {
         type: 'section',
         category: 'data',
         title: 'Messages',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       // 次にMessageElement
       expect(result.data[1]).toEqual({
         type: 'message',
         role: 'user',
-        content: 'Hello'
+        content: 'Hello',
+        cacheHint: 'static'
       });
       expect(result.data[2]).toEqual({
         type: 'message',
         role: 'assistant',
-        content: 'Hi there!'
+        content: 'Hi there!',
+        cacheHint: 'static'
       });
     });
 
@@ -670,14 +694,16 @@ describe('compile', () => {
         type: 'section',
         category: 'data',
         title: 'Prepared Materials',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       // 次にMaterialElement
       expect(result.data[1]).toEqual({
         type: 'material',
         id: 'doc1',
         title: 'Document 1',
-        content: 'Content 1'
+        content: 'Content 1',
+        cacheHint: 'static'
       });
     });
 
@@ -697,7 +723,8 @@ describe('compile', () => {
         type: 'section',
         category: 'data',
         title: 'Input Chunks',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
       // 次にChunkElement
       expect(result.data[1]).toEqual({
@@ -705,14 +732,209 @@ describe('compile', () => {
         partOf: 'dataset',
         index: 0,
         total: 2,
-        content: 'Chunk 1'
+        content: 'Chunk 1',
+        cacheHint: 'static'
       });
       expect(result.data[2]).toEqual({
         type: 'chunk',
         partOf: 'dataset',
         index: 1,
         total: 2,
-        content: 'Chunk 2'
+        content: 'Chunk 2',
+        cacheHint: 'static'
+      });
+    });
+  });
+
+  describe('cacheHint', () => {
+    it('should mark all-static section elements as static', () => {
+      const module: PromptModule = {
+        objective: ['Be helpful'],
+        persona: ['A friendly assistant']
+      };
+      const result = compile(module);
+
+      expect(result.instructions[0]).toMatchObject({
+        type: 'section',
+        title: 'Objective and Role',
+        cacheHint: 'static'
+      });
+      expect(result.instructions[1]).toMatchObject({
+        type: 'section',
+        title: 'Persona and Character',
+        cacheHint: 'static'
+      });
+    });
+
+    it('should mark section with DynamicContent as contextual', () => {
+      const module: PromptModule<{ user: string }> = {
+        createContext: () => ({ user: 'Alice' }),
+        objective: [
+          'Be helpful',
+          (ctx) => `Current user: ${ctx.user}`
+        ]
+      };
+      const result = compile(module);
+
+      expect(result.instructions[0]).toMatchObject({
+        type: 'section',
+        title: 'Objective and Role',
+        cacheHint: 'contextual'
+      });
+    });
+
+    it('should mark standalone DynamicElement from static source as static', () => {
+      const staticChunk: ChunkElement = {
+        type: 'chunk',
+        partOf: 'dataset',
+        index: 0,
+        total: 1,
+        content: 'Chunk data'
+      };
+      const module: PromptModule = {
+        chunks: [staticChunk]
+      };
+      const result = compile(module);
+
+      // SectionElement (index 0) is static
+      expect(result.data[0]).toMatchObject({
+        type: 'section',
+        cacheHint: 'static'
+      });
+      // ChunkElement (index 1) is static
+      expect(result.data[1]).toMatchObject({
+        type: 'chunk',
+        cacheHint: 'static'
+      });
+    });
+
+    it('should mark standalone DynamicElement from DynamicContent as contextual', () => {
+      const module: PromptModule<{ data: string }> = {
+        createContext: () => ({ data: 'test' }),
+        materials: [
+          (ctx): MaterialElement => ({
+            type: 'material',
+            id: 'mat1',
+            title: 'Dynamic Material',
+            content: ctx.data
+          })
+        ]
+      };
+      const result = compile(module);
+
+      // SectionElement should be static (no plain items from dynamic)
+      expect(result.data[0]).toMatchObject({
+        type: 'section',
+        cacheHint: 'static'
+      });
+      // MaterialElement should be contextual
+      expect(result.data[1]).toMatchObject({
+        type: 'material',
+        cacheHint: 'contextual'
+      });
+    });
+
+    it('should mark section with dynamic SubSection content as contextual', () => {
+      const module: PromptModule<{ level: string }> = {
+        createContext: () => ({ level: 'expert' }),
+        instructions: [
+          {
+            type: 'subsection',
+            title: 'Behavior',
+            items: [
+              'Always be polite',
+              (ctx: { level: string }) => `Expertise level: ${ctx.level}`
+            ]
+          } as SubSectionElement<{ level: string }>
+        ]
+      };
+      const result = compile(module);
+
+      expect(result.instructions[0]).toMatchObject({
+        type: 'section',
+        title: 'Instructions',
+        cacheHint: 'contextual'
+      });
+    });
+
+    it('should mark mixed static/dynamic standalone elements correctly', () => {
+      const staticText: TextElement = { type: 'text', content: 'Static note' };
+      const module: PromptModule<{ info: string }> = {
+        createContext: () => ({ info: 'dynamic' }),
+        state: [
+          staticText,
+          (ctx): TextElement => ({ type: 'text', content: ctx.info })
+        ]
+      };
+      const result = compile(module);
+
+      // SectionElement (empty items since both are DynamicElements)
+      expect(result.data[0]).toMatchObject({
+        type: 'section',
+        cacheHint: 'static'
+      });
+      // Static TextElement
+      expect(result.data[1]).toMatchObject({
+        type: 'text',
+        content: 'Static note',
+        cacheHint: 'static'
+      });
+      // Dynamic TextElement
+      expect(result.data[2]).toMatchObject({
+        type: 'text',
+        content: 'dynamic',
+        cacheHint: 'contextual'
+      });
+    });
+
+    it('should not add cacheHint when distribute is called without resolve', () => {
+      // distribute() without resolve() should not add cacheHint (backward compat)
+      const resolved = {
+        objective: ['Be helpful']
+      };
+      const result = distribute(resolved);
+
+      expect(result.instructions[0]).toEqual({
+        type: 'section',
+        category: 'instructions',
+        title: 'Objective and Role',
+        items: ['Be helpful']
+      });
+      expect((result.instructions[0] as any).cacheHint).toBeUndefined();
+    });
+
+    it('should handle DynamicContent returning string arrays correctly', () => {
+      const module: PromptModule<{ items: string[] }> = {
+        createContext: () => ({ items: ['a', 'b'] }),
+        guidelines: [
+          'Static guideline',
+          (ctx) => ctx.items
+        ]
+      };
+      const result = compile(module);
+
+      expect(result.instructions[0]).toMatchObject({
+        type: 'section',
+        title: 'Guidelines',
+        cacheHint: 'contextual'
+      });
+    });
+
+    it('should independently determine cacheHint per section', () => {
+      const module: PromptModule<{ name: string }> = {
+        createContext: () => ({ name: 'test' }),
+        objective: ['Static objective'],
+        persona: [(ctx) => `I am ${ctx.name}`]
+      };
+      const result = compile(module);
+
+      expect(result.instructions[0]).toMatchObject({
+        title: 'Objective and Role',
+        cacheHint: 'static'
+      });
+      expect(result.instructions[1]).toMatchObject({
+        title: 'Persona and Character',
+        cacheHint: 'contextual'
       });
     });
   });

--- a/packages/core/src/compile.ts
+++ b/packages/core/src/compile.ts
@@ -11,9 +11,12 @@ import type {
   Element,
   JSONElement,
   ResolvedSectionContent,
-  ResolvedModule
+  ResolvedModule,
+  CacheHint
 } from './types.js';
 import { STANDARD_SECTIONS } from './types.js';
+
+const dynamicOriginsStore = new WeakMap<ResolvedModule, Map<StandardSectionName, Set<number>>>();
 
 // ========================================================================
 // resolve: DynamicContent を解決して静的な ResolvedModule を返す
@@ -31,11 +34,16 @@ export function resolve<TContext = any>(
 ): ResolvedModule {
   const actualContext = context ?? (module.createContext ? module.createContext() : {} as TContext);
   const result: Partial<Record<StandardSectionName, ResolvedSectionContent>> = {};
+  const originsMap = new Map<StandardSectionName, Set<number>>();
 
   for (const sectionName of Object.keys(STANDARD_SECTIONS) as StandardSectionName[]) {
     const content = module[sectionName];
     if (!content) continue;
-    result[sectionName] = resolveSectionContent(content, actualContext);
+    const { items, dynamicIndices } = resolveSectionContent(content, actualContext);
+    result[sectionName] = items;
+    if (dynamicIndices.size > 0) {
+      originsMap.set(sectionName, dynamicIndices);
+    }
   }
 
   const resolved = result as ResolvedModule;
@@ -43,6 +51,8 @@ export function resolve<TContext = any>(
   if (module.sections) {
     resolved.sections = module.sections as SectionElement[];
   }
+
+  dynamicOriginsStore.set(resolved, originsMap);
 
   return resolved;
 }
@@ -53,8 +63,9 @@ export function resolve<TContext = any>(
 function resolveSectionContent<TContext>(
   content: SectionContent<TContext>,
   context: TContext
-): ResolvedSectionContent {
+): { items: ResolvedSectionContent; dynamicIndices: Set<number> } {
   const items: ResolvedSectionContent = [];
+  const dynamicIndices = new Set<number>();
   const contentItems = typeof content === 'string' ? [content] : Array.isArray(content) ? content : [];
 
   for (const item of contentItems) {
@@ -62,6 +73,7 @@ function resolveSectionContent<TContext>(
       const dynamicResult = item(context);
       const resolved = processDynamicContentToElements(dynamicResult);
       for (const elem of resolved) {
+        dynamicIndices.add(items.length);
         items.push(elem);
       }
     } else if (typeof item === 'string') {
@@ -70,13 +82,18 @@ function resolveSectionContent<TContext>(
       if (item.type === 'subsection') {
         // SubSection 内の SimpleDynamicContent を解決
         const resolvedItems: string[] = [];
+        let hasDynamicSubContent = false;
         for (const subItem of item.items) {
           if (typeof subItem === 'function') {
+            hasDynamicSubContent = true;
             const result = processSimpleDynamicContent(subItem as SimpleDynamicContent<any>, context);
             resolvedItems.push(...result);
           } else if (typeof subItem === 'string') {
             resolvedItems.push(subItem);
           }
+        }
+        if (hasDynamicSubContent) {
+          dynamicIndices.add(items.length);
         }
         items.push({ ...item, items: resolvedItems } as SubSectionElement);
       } else {
@@ -85,7 +102,7 @@ function resolveSectionContent<TContext>(
     }
   }
 
-  return items;
+  return { items, dynamicIndices };
 }
 
 // ========================================================================
@@ -102,12 +119,14 @@ export function distribute(resolved: ResolvedModule): CompiledPrompt {
     data: [],
     output: []
   };
+  const originsMap = dynamicOriginsStore.get(resolved);
 
   for (const sectionName of Object.keys(STANDARD_SECTIONS) as StandardSectionName[]) {
     let content = resolved[sectionName];
     if (!content || content.length === 0) continue;
 
     const sectionDef = STANDARD_SECTIONS[sectionName];
+    const dynamicIndices = originsMap ? (originsMap.get(sectionName) ?? new Set<number>()) : undefined;
 
     // schema セクション: JSONElement を metadata に抽出
     if (sectionName === 'schema') {
@@ -129,7 +148,7 @@ export function distribute(resolved: ResolvedModule): CompiledPrompt {
       if (content.length === 0) continue;
     }
 
-    const elements = wrapInSection(content, sectionDef.title, sectionDef.type);
+    const elements = wrapInSection(content, sectionDef.title, sectionDef.type, dynamicIndices);
     compiled[sectionDef.type].push(...elements);
   }
 
@@ -142,21 +161,32 @@ export function distribute(resolved: ResolvedModule): CompiledPrompt {
 function wrapInSection(
   content: ResolvedSectionContent,
   title: string,
-  category: SectionType
+  category: SectionType,
+  dynamicIndices?: Set<number>
 ): Element[] {
   const elements: Element[] = [];
   const plainItems: string[] = [];
   const subsections: SubSectionElement[] = [];
+  let hasDynamicSectionContent = false;
 
-  for (const item of content) {
+  for (let i = 0; i < content.length; i++) {
+    const item = content[i];
+    const isDynamic = dynamicIndices?.has(i) ?? false;
+
     if (typeof item === 'string') {
       plainItems.push(item);
+      if (isDynamic) hasDynamicSectionContent = true;
     } else if (item && typeof item === 'object' && 'type' in item) {
       if (item.type === 'subsection') {
         subsections.push(item as SubSectionElement);
+        if (isDynamic) hasDynamicSectionContent = true;
       } else {
         // DynamicElement (message, material, text, chunk, json) を直接追加
-        elements.push(item);
+        if (dynamicIndices) {
+          elements.push({ ...item, cacheHint: (isDynamic ? 'contextual' : 'static') as CacheHint });
+        } else {
+          elements.push(item);
+        }
       }
     }
   }
@@ -168,7 +198,8 @@ function wrapInSection(
       type: 'section',
       category,
       title,
-      items: [...plainItems, ...subsections]
+      items: [...plainItems, ...subsections],
+      ...(dynamicIndices ? { cacheHint: (hasDynamicSectionContent ? 'contextual' : 'static') as CacheHint } : {})
     };
     elements.unshift(sectionElement);
   }

--- a/packages/core/src/integration.test.ts
+++ b/packages/core/src/integration.test.ts
@@ -158,7 +158,8 @@ describe('Core Integration Tests', () => {
         type: 'section',
         category: 'data',
         title: 'Current State',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
 
       expect(compiled.data[1]).toEqual({
@@ -166,19 +167,22 @@ describe('Core Integration Tests', () => {
         id: 'doc-1',
         title: 'Documentation',
         content: 'API documentation content',
-        usage: 100
+        usage: 100,
+        cacheHint: 'contextual'
       });
       expect(compiled.data[2]).toEqual({
         type: 'message',
         role: 'user',
-        content: 'What is the weather?'
+        content: 'What is the weather?',
+        cacheHint: 'contextual'
       });
       expect(compiled.data[3]).toEqual({
         type: 'message',
         role: 'assistant',
-        content: 'I can help with weather information.'
+        content: 'I can help with weather information.',
+        cacheHint: 'contextual'
       });
-      
+
       // Check output - should have 2 elements (SectionElement, ChunkElement)
       expect(compiled.output).toHaveLength(2);
 
@@ -187,7 +191,8 @@ describe('Core Integration Tests', () => {
         type: 'section',
         category: 'output',
         title: 'Output',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
 
       expect(compiled.output[1]).toEqual({
@@ -195,7 +200,8 @@ describe('Core Integration Tests', () => {
         partOf: 'response.txt',
         index: 1,
         total: 3,
-        content: 'First part of response'
+        content: 'First part of response',
+        cacheHint: 'contextual'
       });
     });
   });
@@ -591,7 +597,8 @@ function processData(data: any[]) {
         type: 'section',
         category: 'data',
         title: 'Current State',
-        items: []
+        items: [],
+        cacheHint: 'static'
       });
 
       const dataElement = compiled.data[1];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,7 @@
 // 基本型定義
 
+export type CacheHint = 'static' | 'contextual';
+
 // Attachment定義
 export interface Attachment {
   type: 'text' | 'image_url' | 'file';
@@ -12,6 +14,7 @@ export interface Attachment {
 export interface TextElement {
   type: 'text';
   content: string;
+  cacheHint?: CacheHint;
 }
 
 // 標準メッセージ要素
@@ -22,6 +25,7 @@ export interface StandardMessageElement {
   name?: string;
   /** tool call付きassistantメッセージ用 */
   toolCalls?: ToolCall[];
+  cacheHint?: CacheHint;
 }
 
 // ツール実行結果の種類
@@ -39,6 +43,7 @@ export interface ToolResultMessageElement {
   kind: ToolResultKind;
   /** ツール実行結果の値そのもの */
   value: unknown;
+  cacheHint?: CacheHint;
 }
 
 // メッセージ要素（Union型）
@@ -51,6 +56,7 @@ export interface MaterialElement {
   id: string;
   title: string;
   usage?: number;
+  cacheHint?: CacheHint;
 }
 
 // 分割テキスト要素
@@ -61,6 +67,7 @@ export interface ChunkElement {
   index?: number;
   total?: number;  // Total number of chunks
   usage?: number;
+  cacheHint?: CacheHint;
 }
 
 // セクション要素（第1階層）
@@ -69,6 +76,7 @@ export interface SectionElement<TContext = any> {
   category: SectionType;  // 配置先の大セクション（instructions/data/output）
   title: string;
   items: (string | SubSectionElement<TContext> | DynamicContent<TContext>)[];
+  cacheHint?: CacheHint;
 }
 
 // サブセクション要素（第2階層）
@@ -77,6 +85,7 @@ export interface SubSectionElement<TContext = any> {
   type: 'subsection';
   title: string;
   items: (string | SimpleDynamicContent<TContext>)[];
+  cacheHint?: CacheHint;
 }
 
 // ツール呼び出し（モデル → アプリ）
@@ -95,6 +104,7 @@ export interface ToolCall {
 export interface JSONElement {
   type: 'json';
   content: object | string;  // JSONSchemaオブジェクトまたはJSON文字列
+  cacheHint?: CacheHint;
 }
 
 // 統合型

--- a/packages/process/src/modules/dialogue.test.ts
+++ b/packages/process/src/modules/dialogue.test.ts
@@ -29,12 +29,12 @@ describe('dialogue modules', () => {
       // messagesセクションの確認
       const messageElements = result.data.filter(e => e.type === 'message');
       expect(messageElements).toHaveLength(2);
-      expect(messageElements[0]).toEqual({
+      expect(messageElements[0]).toMatchObject({
         type: 'message',
         role: 'user',
         content: 'Hello'
       });
-      expect(messageElements[1]).toEqual({
+      expect(messageElements[1]).toMatchObject({
         type: 'message',
         role: 'assistant',
         content: 'Hi there!'
@@ -57,12 +57,12 @@ describe('dialogue modules', () => {
       // MessageElementを直接チェック（SectionElement.itemsではなく）
       const messageElements = result.data.filter(e => e.type === 'message');
       expect(messageElements).toHaveLength(2);
-      expect(messageElements[0]).toEqual({
+      expect(messageElements[0]).toMatchObject({
         type: 'message',
         role: 'assistant',
         content: 'Response 1'
       });
-      expect(messageElements[1]).toEqual({
+      expect(messageElements[1]).toMatchObject({
         type: 'message',
         role: 'user',
         content: 'Message 2'

--- a/packages/process/src/modules/material.test.ts
+++ b/packages/process/src/modules/material.test.ts
@@ -43,13 +43,13 @@ describe('material modules', () => {
       const materialElements = result.data.filter(e => e.type === 'material');
       expect(materialElements).toHaveLength(2);
 
-      expect(materialElements[0]).toEqual({
+      expect(materialElements[0]).toMatchObject({
         type: 'material',
         id: 'doc1',
         title: 'Document 1',
         content: 'This is the content of document 1'
       });
-      expect(materialElements[1]).toEqual({
+      expect(materialElements[1]).toMatchObject({
         type: 'material',
         id: 'doc2',
         title: 'Document 2',

--- a/packages/process/src/modules/stream-processing.test.ts
+++ b/packages/process/src/modules/stream-processing.test.ts
@@ -36,7 +36,7 @@ describe('stream-processing modules', () => {
       const result = compile(streamProcessing, context);
       const chunkElements = result.data.filter(e => e.type === 'chunk');
       expect(chunkElements).toHaveLength(1);
-      expect(chunkElements[0]).toEqual({
+      expect(chunkElements[0]).toMatchObject({
         type: 'chunk',
         partOf: 'state',
         content: 'Previous iteration result',
@@ -64,14 +64,14 @@ describe('stream-processing modules', () => {
       const result = compile(streamProcessing, context);
       const chunkElements = result.data.filter(e => e.type === 'chunk');
       expect(chunkElements).toHaveLength(2);
-      expect(chunkElements[0]).toEqual({
+      expect(chunkElements[0]).toMatchObject({
         type: 'chunk',
         partOf: 'Document A',
         index: 0,
         content: 'Chunk 1 content',
         usage: 50
       });
-      expect(chunkElements[1]).toEqual({
+      expect(chunkElements[1]).toMatchObject({
         type: 'chunk',
         partOf: 'Document B',
         index: 1,


### PR DESCRIPTION
## Summary
- 全ElementインターフェースにcacheHint?: CacheHintプロパティを追加（'static' | 'contextual'）
- コンパイル時にDynamicContent由来の要素を'contextual'、静的定義の要素を'static'として自動分類
- WeakMapによる来歴追跡でresolve→distributeパイプラインを通じてヒントを伝搬

## 動機
ドライバー層（特にAnthropicのcache_control）がKVキャッシュ戦略を適切に適用するための基盤。ドライバー層の変更は別タスクとしてスコープ外。

## 変更内容
- `types.ts`: CacheHint型と全8 Elementインターフェースへのプロパティ追加
- `compile.ts`: dynamicOriginsStore(WeakMap)による来歴追跡、resolve/distributeでのヒント付与
- テスト: 8つの新規cacheHintテスト + 既存テストのアサーション更新（88テスト全パス）

## 後方互換性
distribute()を直接呼んだ場合（resolveを経由しない）はcacheHintが付与されず、既存の動作を維持。

## Test plan
- [x] compile.test.ts: 静的/動的/混在パターンのcacheHint検証（8テスト追加）
- [x] compile-static-elements.test.ts: 既存テストのアサーション更新（14テスト）
- [x] integration.test.ts: 統合テストのアサーション更新（11テスト）
- [x] 全88テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)