### PR TITLE
feat: PromptCacheControllerとGoogle GenAIキャッシュ対応

### DIFF
--- a/.changeset/googlegenai-prompt-caching.md
+++ b/.changeset/googlegenai-prompt-caching.md
@@ -1,0 +1,7 @@
+---
+'@modular-prompt/driver': minor
+---
+
+Google GenAIドライバーにプロンプトキャッシング対応を追加。
+PromptCacheControllerインターフェースとGoogleGenAICacheController実装を提供。
+Element変換ロジックをelement-converter.tsに抽出し、ドライバーとCacheControllerで共有。

--- a/packages/driver/src/cache-controller.ts
+++ b/packages/driver/src/cache-controller.ts
@@ -10,6 +10,7 @@ export interface CachePrepareParams {
 
 export interface CacheHandle {
   ref: string;
+  /** What the cache contains. Drivers use these flags to avoid sending duplicate content. */
   includes: {
     instructions: boolean;
     dataElementCount: number;

--- a/packages/driver/src/cache-controller.ts
+++ b/packages/driver/src/cache-controller.ts
@@ -1,0 +1,24 @@
+import type { Element } from '@modular-prompt/core';
+import type { ToolDefinition } from './types.js';
+
+export interface CachePrepareParams {
+  model: string;
+  instructions?: Element[];
+  data?: Element[];
+  tools?: ToolDefinition[];
+}
+
+export interface CacheHandle {
+  ref: string;
+  includes: {
+    instructions: boolean;
+    dataElementCount: number;
+    tools: boolean;
+  };
+}
+
+export interface PromptCacheController {
+  prepare(params: CachePrepareParams): Promise<CacheHandle>;
+  invalidate(handle: CacheHandle): Promise<void>;
+  close(): Promise<void>;
+}

--- a/packages/driver/src/cache-utils.test.ts
+++ b/packages/driver/src/cache-utils.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import type { CompiledPrompt, Element } from '@modular-prompt/core';
+import { isElementCacheable, partitionPrompt } from './cache-utils.js';
+
+describe('isElementCacheable', () => {
+  it('cacheHint: static → cacheable', () => {
+    const el: Element = { type: 'text', content: 'hello', cacheHint: 'static' };
+    expect(isElementCacheable(el)).toBe(true);
+  });
+
+  it('cacheHint: contextual → not cacheable', () => {
+    const el: Element = { type: 'text', content: 'hello', cacheHint: 'contextual' };
+    expect(isElementCacheable(el)).toBe(false);
+  });
+
+  it('message without cacheHint → cacheable', () => {
+    const el: Element = { type: 'message', role: 'user', content: 'hi' };
+    expect(isElementCacheable(el)).toBe(true);
+  });
+
+  it('material without cacheHint → cacheable', () => {
+    const el: Element = { type: 'material', id: 'm1', title: 'Doc', content: 'text' };
+    expect(isElementCacheable(el)).toBe(true);
+  });
+
+  it('chunk without cacheHint → not cacheable', () => {
+    const el: Element = { type: 'chunk', partOf: 'doc', content: 'part' };
+    expect(isElementCacheable(el)).toBe(false);
+  });
+
+  it('section "Current State" → not cacheable', () => {
+    const el: Element = { type: 'section', category: 'data', title: 'Current State', items: ['state'] };
+    expect(isElementCacheable(el)).toBe(false);
+  });
+
+  it('section "Input Chunks" → not cacheable', () => {
+    const el: Element = { type: 'section', category: 'data', title: 'Input Chunks', items: ['chunk'] };
+    expect(isElementCacheable(el)).toBe(false);
+  });
+
+  it('section with other title → cacheable', () => {
+    const el: Element = { type: 'section', category: 'instructions', title: 'Guidelines', items: ['rule'] };
+    expect(isElementCacheable(el)).toBe(true);
+  });
+
+  it('text without cacheHint → cacheable', () => {
+    const el: Element = { type: 'text', content: 'hello' };
+    expect(isElementCacheable(el)).toBe(true);
+  });
+
+  it('cacheHint overrides default heuristic', () => {
+    const el: Element = { type: 'chunk', partOf: 'doc', content: 'part', cacheHint: 'static' };
+    expect(isElementCacheable(el)).toBe(true);
+  });
+});
+
+describe('partitionPrompt', () => {
+  it('instructions are always in cacheable', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'Be helpful' }],
+      data: [],
+      output: [],
+    };
+    const result = partitionPrompt(prompt);
+    expect(result.cacheable.instructions).toHaveLength(1);
+    expect(result.cacheable.data).toHaveLength(0);
+    expect(result.volatile.data).toHaveLength(0);
+  });
+
+  it('data elements are partitioned by cacheability', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [],
+      data: [
+        { type: 'material', id: 'm1', title: 'Doc', content: 'text' },
+        { type: 'chunk', partOf: 'doc', content: 'part' },
+        { type: 'message', role: 'user', content: 'hello' },
+      ],
+      output: [],
+    };
+    const result = partitionPrompt(prompt);
+    expect(result.cacheable.data).toHaveLength(2);
+    expect(result.volatile.data).toHaveLength(1);
+    expect(result.volatile.data[0].type).toBe('chunk');
+  });
+
+  it('output goes to volatile', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [],
+      data: [],
+      output: [{ type: 'text', content: 'respond now' }],
+    };
+    const result = partitionPrompt(prompt);
+    expect(result.volatile.output).toHaveLength(1);
+  });
+
+  it('handles empty prompt', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [],
+      data: [],
+      output: [],
+    };
+    const result = partitionPrompt(prompt);
+    expect(result.cacheable.instructions).toHaveLength(0);
+    expect(result.cacheable.data).toHaveLength(0);
+    expect(result.volatile.data).toHaveLength(0);
+    expect(result.volatile.output).toHaveLength(0);
+  });
+});

--- a/packages/driver/src/cache-utils.test.ts
+++ b/packages/driver/src/cache-utils.test.ts
@@ -55,7 +55,7 @@ describe('isElementCacheable', () => {
 });
 
 describe('partitionPrompt', () => {
-  it('instructions are always in cacheable', () => {
+  it('instructions without cacheHint go to cacheable', () => {
     const prompt: CompiledPrompt = {
       instructions: [{ type: 'text', content: 'Be helpful' }],
       data: [],
@@ -63,8 +63,25 @@ describe('partitionPrompt', () => {
     };
     const result = partitionPrompt(prompt);
     expect(result.cacheable.instructions).toHaveLength(1);
+    expect(result.volatile.instructions).toHaveLength(0);
     expect(result.cacheable.data).toHaveLength(0);
     expect(result.volatile.data).toHaveLength(0);
+  });
+
+  it('contextual instructions go to volatile', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [
+        { type: 'text', content: 'Be helpful' },
+        { type: 'text', content: 'Current time is 12:00', cacheHint: 'contextual' },
+        { type: 'text', content: 'Static rule', cacheHint: 'static' },
+      ],
+      data: [],
+      output: [],
+    };
+    const result = partitionPrompt(prompt);
+    expect(result.cacheable.instructions).toHaveLength(2);
+    expect(result.volatile.instructions).toHaveLength(1);
+    expect(result.volatile.instructions[0].type).toBe('text');
   });
 
   it('data elements are partitioned by cacheability', () => {
@@ -101,6 +118,7 @@ describe('partitionPrompt', () => {
     };
     const result = partitionPrompt(prompt);
     expect(result.cacheable.instructions).toHaveLength(0);
+    expect(result.volatile.instructions).toHaveLength(0);
     expect(result.cacheable.data).toHaveLength(0);
     expect(result.volatile.data).toHaveLength(0);
     expect(result.volatile.output).toHaveLength(0);

--- a/packages/driver/src/cache-utils.test.ts
+++ b/packages/driver/src/cache-utils.test.ts
@@ -18,6 +18,11 @@ describe('isElementCacheable', () => {
     expect(isElementCacheable(el)).toBe(true);
   });
 
+  it('tool message without cacheHint → not cacheable', () => {
+    const el: Element = { type: 'message', role: 'tool', toolCallId: 'tc1', name: 'search', kind: 'text', value: 'result' } as Element;
+    expect(isElementCacheable(el)).toBe(false);
+  });
+
   it('material without cacheHint → cacheable', () => {
     const el: Element = { type: 'material', id: 'm1', title: 'Doc', content: 'text' };
     expect(isElementCacheable(el)).toBe(true);

--- a/packages/driver/src/cache-utils.ts
+++ b/packages/driver/src/cache-utils.ts
@@ -5,7 +5,9 @@ export function isElementCacheable(el: Element): boolean {
     return el.cacheHint === 'static';
   }
   switch (el.type) {
-    case 'message': return true;
+    case 'message':
+      if ('role' in el && el.role === 'tool') return false;
+      return true;
     case 'material': return true;
     case 'section':
       if (el.title === 'Current State' || el.title === 'Input Chunks') return false;

--- a/packages/driver/src/cache-utils.ts
+++ b/packages/driver/src/cache-utils.ts
@@ -21,6 +21,7 @@ export interface PromptPartition {
     data: Element[];
   };
   volatile: {
+    instructions: Element[];
     data: Element[];
     output: Element[];
   };
@@ -28,13 +29,24 @@ export interface PromptPartition {
 
 export function partitionPrompt(prompt: CompiledPrompt): PromptPartition {
   const cacheable = {
-    instructions: prompt.instructions || [],
+    instructions: [] as Element[],
     data: [] as Element[],
   };
   const volatile = {
+    instructions: [] as Element[],
     data: [] as Element[],
     output: prompt.output || [],
   };
+
+  if (prompt.instructions) {
+    for (const el of prompt.instructions) {
+      if (isElementCacheable(el)) {
+        cacheable.instructions.push(el);
+      } else {
+        volatile.instructions.push(el);
+      }
+    }
+  }
 
   if (prompt.data) {
     for (const el of prompt.data) {

--- a/packages/driver/src/cache-utils.ts
+++ b/packages/driver/src/cache-utils.ts
@@ -1,0 +1,50 @@
+import type { CompiledPrompt, Element } from '@modular-prompt/core';
+
+export function isElementCacheable(el: Element): boolean {
+  if ('cacheHint' in el) {
+    return el.cacheHint === 'static';
+  }
+  switch (el.type) {
+    case 'message': return true;
+    case 'material': return true;
+    case 'section':
+      if (el.title === 'Current State' || el.title === 'Input Chunks') return false;
+      return true;
+    case 'chunk': return false;
+    default: return true;
+  }
+}
+
+export interface PromptPartition {
+  cacheable: {
+    instructions: Element[];
+    data: Element[];
+  };
+  volatile: {
+    data: Element[];
+    output: Element[];
+  };
+}
+
+export function partitionPrompt(prompt: CompiledPrompt): PromptPartition {
+  const cacheable = {
+    instructions: prompt.instructions || [],
+    data: [] as Element[],
+  };
+  const volatile = {
+    data: [] as Element[],
+    output: prompt.output || [],
+  };
+
+  if (prompt.data) {
+    for (const el of prompt.data) {
+      if (isElementCacheable(el)) {
+        cacheable.data.push(el);
+      } else {
+        volatile.data.push(el);
+      }
+    }
+  }
+
+  return { cacheable, volatile };
+}

--- a/packages/driver/src/google-genai/element-converter.ts
+++ b/packages/driver/src/google-genai/element-converter.ts
@@ -1,0 +1,136 @@
+import type { Part, Content, FunctionDeclaration } from '@google/genai';
+import type { Element } from '@modular-prompt/core';
+import type { ToolDefinition } from '../types.js';
+import { contentToString } from '../content-utils.js';
+
+export function toFunctionResponsePayload(kind: string, value: unknown): Record<string, unknown> {
+  if (kind === 'text') {
+    return { output: String(value) };
+  } else if (kind === 'data') {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype) {
+      return value as Record<string, unknown>;
+    }
+    return { output: value };
+  } else {
+    return { error: value };
+  }
+}
+
+export function elementToPart(element: Element | string): Part {
+  if (typeof element === 'string') {
+    return { text: element };
+  }
+
+  switch (element.type) {
+    case 'text':
+      return { text: element.content };
+
+    case 'message': {
+      if (element.role === 'tool') {
+        const toolResultEl = element as { role: 'tool'; toolCallId: string; name: string; kind: string; value: unknown };
+        const textValue = toolResultEl.kind === 'text' ? String(toolResultEl.value) : JSON.stringify(toolResultEl.value);
+        return { text: `${element.role}: ${textValue}` };
+      }
+      const messageContent = contentToString(element.content);
+      return { text: `${element.role}: ${messageContent}` };
+    }
+
+    case 'material': {
+      const materialContent = contentToString(element.content);
+      return { text: `# ${element.title}\n${materialContent}` };
+    }
+
+    case 'chunk': {
+      const chunkContent = contentToString(element.content);
+      const chunkHeader = element.index !== undefined && element.total !== undefined
+        ? `[Chunk ${element.index + 1}/${element.total} of ${element.partOf}]`
+        : `[Chunk of ${element.partOf}]`;
+      return { text: `${chunkHeader}\n${chunkContent}` };
+    }
+
+    case 'section':
+    case 'subsection': {
+      const flattenItems = (items: unknown[]): string => {
+        return items.map(item => {
+          if (typeof item === 'string') return item;
+          if (typeof item === 'function') return '';
+          return elementToPart(item as Element).text || '';
+        }).filter(Boolean).join('\n');
+      };
+      return { text: flattenItems(element.items) };
+    }
+
+    case 'json':
+      return { text: typeof element.content === 'string' ? element.content : JSON.stringify(element.content, null, 2) };
+
+    default:
+      return { text: JSON.stringify(element) };
+  }
+}
+
+export function elementToContent(element: Element | string): Content {
+  if (typeof element === 'string') {
+    return { parts: [{ text: element }] };
+  }
+
+  if (element.type === 'message') {
+    if (element.role === 'tool') {
+      const toolResultEl = element as { role: 'tool'; toolCallId: string; name: string; kind: string; value: unknown };
+      return {
+        role: 'user',
+        parts: [{
+          functionResponse: {
+            name: toolResultEl.name,
+            response: toFunctionResponsePayload(toolResultEl.kind, toolResultEl.value)
+          }
+        }]
+      };
+    } else if ('toolCalls' in element && element.toolCalls) {
+      const parts: Part[] = [];
+      const content = contentToString(element.content);
+      if (content) parts.push({ text: content });
+      for (const tc of element.toolCalls) {
+        const part: Part = { functionCall: { name: tc.name, args: tc.arguments as Record<string, unknown> } };
+        if (typeof tc.metadata?.thoughtSignature === 'string') {
+          part.thoughtSignature = tc.metadata.thoughtSignature;
+        }
+        parts.push(part);
+      }
+      return { role: 'model', parts };
+    } else {
+      const role = element.role === 'assistant' ? 'model' : 'user';
+      const messageContent = contentToString(element.content);
+      return { role, parts: [{ text: messageContent }] };
+    }
+  }
+
+  return { parts: [elementToPart(element)] };
+}
+
+export function convertTools(tools: ToolDefinition[]): { functionDeclarations: FunctionDeclaration[] }[] {
+  const functionDeclarations: FunctionDeclaration[] = tools.map(tool => ({
+    name: tool.name,
+    description: tool.description,
+    parametersJsonSchema: tool.parameters,
+  }));
+  return [{ functionDeclarations }];
+}
+
+export function mergeToolResultContents(contents: Content[]): Content[] {
+  const merged: Content[] = [];
+  for (const c of contents) {
+    const prev = merged[merged.length - 1];
+    if (
+      prev &&
+      c.role === 'user' &&
+      prev.role === 'user' &&
+      c.parts?.length === 1 && c.parts[0].functionResponse &&
+      prev.parts && prev.parts.length > 0 && prev.parts[0].functionResponse
+    ) {
+      prev.parts!.push(c.parts[0]);
+    } else {
+      merged.push(c);
+    }
+  }
+  return merged;
+}

--- a/packages/driver/src/google-genai/element-converter.ts
+++ b/packages/driver/src/google-genai/element-converter.ts
@@ -1,9 +1,9 @@
 import type { Part, Content, FunctionDeclaration } from '@google/genai';
-import type { Element } from '@modular-prompt/core';
+import type { Element, ToolResultKind } from '@modular-prompt/core';
 import type { ToolDefinition } from '../types.js';
 import { contentToString } from '../content-utils.js';
 
-export function toFunctionResponsePayload(kind: string, value: unknown): Record<string, unknown> {
+export function toFunctionResponsePayload(kind: ToolResultKind, value: unknown): Record<string, unknown> {
   if (kind === 'text') {
     return { output: String(value) };
   } else if (kind === 'data') {
@@ -27,7 +27,7 @@ export function elementToPart(element: Element | string): Part {
 
     case 'message': {
       if (element.role === 'tool') {
-        const toolResultEl = element as { role: 'tool'; toolCallId: string; name: string; kind: string; value: unknown };
+        const toolResultEl = element as { role: 'tool'; toolCallId: string; name: string; kind: ToolResultKind; value: unknown };
         const textValue = toolResultEl.kind === 'text' ? String(toolResultEl.value) : JSON.stringify(toolResultEl.value);
         return { text: `${element.role}: ${textValue}` };
       }
@@ -75,7 +75,7 @@ export function elementToContent(element: Element | string): Content {
 
   if (element.type === 'message') {
     if (element.role === 'tool') {
-      const toolResultEl = element as { role: 'tool'; toolCallId: string; name: string; kind: string; value: unknown };
+      const toolResultEl = element as { role: 'tool'; toolCallId: string; name: string; kind: ToolResultKind; value: unknown };
       return {
         role: 'user',
         parts: [{

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -97,6 +97,11 @@ describe('GoogleGenAICacheController', () => {
       expect(createCall.config.ttl).toBe('7200s');
     });
 
+    it('should throw on invalid TTL format', () => {
+      expect(() => new GoogleGenAICacheController(mockClient as any, { ttl: '1h' }))
+        .toThrow('Invalid TTL format');
+    });
+
     it('should handle empty instructions and data', async () => {
       const handle = await controller.prepare({
         model: 'gemini-2.5-flash',

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -105,6 +105,46 @@ describe('GoogleGenAICacheController', () => {
       expect(handle.includes.instructions).toBe(false);
       expect(handle.includes.dataElementCount).toBe(0);
     });
+
+    it('should reuse cache for identical params', async () => {
+      const params = {
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text' as const, content: 'Be helpful' }],
+        data: [{ type: 'material' as const, id: 'm1', title: 'Doc', content: 'text' }],
+      };
+      const handle1 = await controller.prepare(params);
+      const handle2 = await controller.prepare(params);
+
+      expect(handle1.ref).toBe(handle2.ref);
+      expect(mockClient.caches.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create separate caches for different params', async () => {
+      mockClient.caches.create
+        .mockResolvedValueOnce({ name: 'cachedContents/cache-1' })
+        .mockResolvedValueOnce({ name: 'cachedContents/cache-2' });
+
+      const handle1 = await controller.prepare({
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text' as const, content: 'prompt A' }],
+      });
+      const handle2 = await controller.prepare({
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text' as const, content: 'prompt B' }],
+      });
+
+      expect(handle1.ref).not.toBe(handle2.ref);
+      expect(mockClient.caches.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw when cache.name is missing', async () => {
+      mockClient.caches.create.mockResolvedValueOnce({ name: undefined });
+
+      await expect(controller.prepare({
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text' as const, content: 'prompt' }],
+      })).rejects.toThrow('returned a cache without a name');
+    });
   });
 
   describe('invalidate', () => {
@@ -116,6 +156,21 @@ describe('GoogleGenAICacheController', () => {
 
       await controller.invalidate(handle);
       expect(mockClient.caches.delete).toHaveBeenCalledWith({ name: 'cachedContents/test-cache-123' });
+    });
+
+    it('should allow re-creation after invalidation', async () => {
+      const params = {
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text' as const, content: 'prompt' }],
+      };
+      const handle1 = await controller.prepare(params);
+      await controller.invalidate(handle1);
+
+      mockClient.caches.create.mockResolvedValueOnce({ name: 'cachedContents/new-cache' });
+      const handle2 = await controller.prepare(params);
+
+      expect(handle2.ref).toBe('cachedContents/new-cache');
+      expect(mockClient.caches.create).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -226,6 +226,10 @@ describe('GoogleGenAICacheController', () => {
 
   describe('close', () => {
     it('should delete all managed caches', async () => {
+      mockClient.caches.create
+        .mockResolvedValueOnce({ name: 'cachedContents/close-1' })
+        .mockResolvedValueOnce({ name: 'cachedContents/close-2' });
+
       await controller.prepare({ model: 'gemini-2.5-flash', instructions: [{ type: 'text', content: 'a' }] });
       await controller.prepare({ model: 'gemini-2.5-flash', instructions: [{ type: 'text', content: 'b' }] });
 

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -360,6 +360,68 @@ describe('GoogleGenAIDriver with CacheController', () => {
     expect(config.cachedContent).toBe('cachedContents/abc');
   });
 
+  it('should fall back to sending all instructions when cache excludes them', async () => {
+    const controllerNoInstructions: PromptCacheController = {
+      prepare: vi.fn().mockResolvedValue({
+        ref: 'cachedContents/partial',
+        includes: { instructions: false, dataElementCount: 1, tools: false },
+      }),
+      invalidate: vi.fn(),
+      close: vi.fn(),
+    };
+    const partialDriver = new GoogleGenAIDriver({
+      apiKey: 'test-api-key',
+      model: 'gemini-2.5-flash',
+      cacheController: controllerNoInstructions,
+    });
+
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'Static rule' }],
+      data: [{ type: 'material', id: 'm1', title: 'Doc', content: 'text' }],
+      output: [{ type: 'text', content: 'go' }],
+    };
+
+    await partialDriver.query(prompt);
+
+    const generateContent = (partialDriver as any).client.models.generateContent;
+    const config = generateContent.mock.calls[0][0].config;
+    expect(config.cachedContent).toBe('cachedContents/partial');
+    expect(config.systemInstruction).toBeDefined();
+    expect(config.systemInstruction).toHaveLength(1);
+    expect(config.systemInstruction[0].text).toContain('Static rule');
+  });
+
+  it('should fall back to sending all data when cache excludes them', async () => {
+    const controllerNoData: PromptCacheController = {
+      prepare: vi.fn().mockResolvedValue({
+        ref: 'cachedContents/no-data',
+        includes: { instructions: true, dataElementCount: 0, tools: false },
+      }),
+      invalidate: vi.fn(),
+      close: vi.fn(),
+    };
+    const noDataDriver = new GoogleGenAIDriver({
+      apiKey: 'test-api-key',
+      model: 'gemini-2.5-flash',
+      cacheController: controllerNoData,
+    });
+
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'system' }],
+      data: [
+        { type: 'material', id: 'm1', title: 'Doc', content: 'stable' },
+        { type: 'chunk', partOf: 'doc', content: 'volatile' },
+      ],
+      output: [{ type: 'text', content: 'go' }],
+    };
+
+    await noDataDriver.query(prompt);
+
+    const generateContent = (noDataDriver as any).client.models.generateContent;
+    const contents = generateContent.mock.calls[0][0].contents;
+    expect(contents.length).toBeGreaterThanOrEqual(3);
+  });
+
   it('should skip cache when all cacheable elements are empty', async () => {
     const prompt: CompiledPrompt = {
       instructions: [{ type: 'text', content: 'dynamic only', cacheHint: 'contextual' }],

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -145,6 +145,27 @@ describe('GoogleGenAICacheController', () => {
         instructions: [{ type: 'text' as const, content: 'prompt' }],
       })).rejects.toThrow('returned a cache without a name');
     });
+
+    it('should coalesce concurrent calls with identical params', async () => {
+      let resolveCreate: (val: { name: string }) => void;
+      mockClient.caches.create.mockReturnValueOnce(
+        new Promise(resolve => { resolveCreate = resolve; })
+      );
+
+      const params = {
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text' as const, content: 'prompt' }],
+      };
+      const p1 = controller.prepare(params);
+      const p2 = controller.prepare(params);
+
+      resolveCreate!({ name: 'cachedContents/coalesced' });
+
+      const [h1, h2] = await Promise.all([p1, p2]);
+      expect(h1.ref).toBe('cachedContents/coalesced');
+      expect(h2.ref).toBe('cachedContents/coalesced');
+      expect(mockClient.caches.create).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('invalidate', () => {
@@ -275,6 +296,26 @@ describe('GoogleGenAIDriver with CacheController', () => {
     const generateContent = (driver as any).client.models.generateContent;
     const contents = generateContent.mock.calls[0][0].contents;
     expect(contents).toHaveLength(2);
+  });
+
+  it('should send volatile instructions as systemInstruction even when cache includes instructions', async () => {
+    const prompt: CompiledPrompt = {
+      instructions: [
+        { type: 'text', content: 'Static rule' },
+        { type: 'text', content: 'Current time is 12:00', cacheHint: 'contextual' },
+      ],
+      data: [],
+      output: [{ type: 'text', content: 'go' }],
+    };
+
+    await driver.query(prompt);
+
+    const generateContent = (driver as any).client.models.generateContent;
+    const config = generateContent.mock.calls[0][0].config;
+    expect(config.cachedContent).toBe('cachedContents/abc');
+    expect(config.systemInstruction).toBeDefined();
+    expect(config.systemInstruction).toHaveLength(1);
+    expect(config.systemInstruction[0].text).toContain('Current time');
   });
 
   it('should work with streamQuery', async () => {

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GoogleGenAICacheController } from './google-genai-cache-controller.js';
+import { GoogleGenAIDriver } from './google-genai-driver.js';
+import type { CompiledPrompt } from '@modular-prompt/core';
+import type { PromptCacheController } from '../cache-controller.js';
+
+vi.mock('@google/genai', () => {
+  return {
+    GoogleGenAI: vi.fn().mockImplementation(() => {
+      return {
+        models: {
+          generateContent: vi.fn().mockResolvedValue({
+            text: 'Test response',
+            candidates: [{ finishReason: 'STOP' }],
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 20, totalTokenCount: 30 }
+          }),
+          generateContentStream: vi.fn().mockResolvedValue({
+            [Symbol.asyncIterator]: async function* () {
+              yield { text: 'Streamed', candidates: [{ finishReason: 'STOP' }] };
+            },
+          })
+        },
+        caches: {
+          create: vi.fn().mockResolvedValue({ name: 'cachedContents/test-cache-123' }),
+          delete: vi.fn().mockResolvedValue({}),
+        }
+      };
+    }),
+    FunctionCallingConfigMode: {
+      MODE_UNSPECIFIED: 'MODE_UNSPECIFIED',
+      AUTO: 'AUTO',
+      ANY: 'ANY',
+      NONE: 'NONE',
+      VALIDATED: 'VALIDATED',
+    }
+  };
+});
+
+describe('GoogleGenAICacheController', () => {
+  let mockClient: { caches: { create: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn> } };
+  let controller: GoogleGenAICacheController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = {
+      caches: {
+        create: vi.fn().mockResolvedValue({ name: 'cachedContents/test-cache-123' }),
+        delete: vi.fn().mockResolvedValue({}),
+      }
+    };
+    controller = new GoogleGenAICacheController(mockClient as any);
+  });
+
+  describe('prepare', () => {
+    it('should create cache with instructions and data', async () => {
+      const handle = await controller.prepare({
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text', content: 'Be helpful' }],
+        data: [{ type: 'material', id: 'm1', title: 'Doc', content: 'reference text' }],
+      });
+
+      expect(handle.ref).toBe('cachedContents/test-cache-123');
+      expect(handle.includes.instructions).toBe(true);
+      expect(handle.includes.dataElementCount).toBe(1);
+      expect(handle.includes.tools).toBe(false);
+
+      expect(mockClient.caches.create).toHaveBeenCalledWith({
+        model: 'gemini-2.5-flash',
+        config: expect.objectContaining({
+          systemInstruction: expect.any(Array),
+          contents: expect.any(Array),
+          ttl: '3600s',
+        }),
+      });
+    });
+
+    it('should include tools when provided', async () => {
+      const handle = await controller.prepare({
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text', content: 'system prompt' }],
+        tools: [{ name: 'get_weather', description: 'Get weather', parameters: { type: 'object' } }],
+      });
+
+      expect(handle.includes.tools).toBe(true);
+      const createCall = mockClient.caches.create.mock.calls[0][0];
+      expect(createCall.config.tools).toBeDefined();
+    });
+
+    it('should use custom TTL from config', async () => {
+      const customController = new GoogleGenAICacheController(mockClient as any, { ttl: '7200s' });
+      await customController.prepare({
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text', content: 'prompt' }],
+      });
+
+      const createCall = mockClient.caches.create.mock.calls[0][0];
+      expect(createCall.config.ttl).toBe('7200s');
+    });
+
+    it('should handle empty instructions and data', async () => {
+      const handle = await controller.prepare({
+        model: 'gemini-2.5-flash',
+      });
+
+      expect(handle.includes.instructions).toBe(false);
+      expect(handle.includes.dataElementCount).toBe(0);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('should delete the cached content', async () => {
+      const handle = await controller.prepare({
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text', content: 'prompt' }],
+      });
+
+      await controller.invalidate(handle);
+      expect(mockClient.caches.delete).toHaveBeenCalledWith({ name: 'cachedContents/test-cache-123' });
+    });
+  });
+
+  describe('close', () => {
+    it('should delete all managed caches', async () => {
+      await controller.prepare({ model: 'gemini-2.5-flash', instructions: [{ type: 'text', content: 'a' }] });
+      await controller.prepare({ model: 'gemini-2.5-flash', instructions: [{ type: 'text', content: 'b' }] });
+
+      await controller.close();
+      expect(mockClient.caches.delete).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('GoogleGenAIDriver with CacheController', () => {
+  let driver: GoogleGenAIDriver;
+  let mockController: PromptCacheController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockController = {
+      prepare: vi.fn().mockResolvedValue({
+        ref: 'cachedContents/abc',
+        includes: { instructions: true, dataElementCount: 1, tools: false },
+      }),
+      invalidate: vi.fn(),
+      close: vi.fn(),
+    };
+    driver = new GoogleGenAIDriver({
+      apiKey: 'test-api-key',
+      model: 'gemini-2.5-flash',
+      cacheController: mockController,
+    });
+  });
+
+  it('should use cacheController when present', async () => {
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'Be helpful' }],
+      data: [
+        { type: 'material', id: 'm1', title: 'Doc', content: 'stable content' },
+        { type: 'chunk', partOf: 'doc', content: 'volatile part' },
+      ],
+      output: [{ type: 'text', content: 'respond' }],
+    };
+
+    await driver.query(prompt);
+
+    expect(mockController.prepare).toHaveBeenCalledWith({
+      model: 'gemini-2.5-flash',
+      instructions: [{ type: 'text', content: 'Be helpful' }],
+      data: [{ type: 'material', id: 'm1', title: 'Doc', content: 'stable content' }],
+      tools: undefined,
+    });
+
+    const generateContent = (driver as any).client.models.generateContent;
+    const callArgs = generateContent.mock.calls[0][0];
+    expect(callArgs.config.cachedContent).toBe('cachedContents/abc');
+    expect(callArgs.config.systemInstruction).toBeUndefined();
+  });
+
+  it('should not include systemInstruction when cached', async () => {
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'system' }],
+      data: [],
+      output: [{ type: 'text', content: 'go' }],
+    };
+
+    await driver.query(prompt);
+
+    const generateContent = (driver as any).client.models.generateContent;
+    const config = generateContent.mock.calls[0][0].config;
+    expect(config.cachedContent).toBe('cachedContents/abc');
+    expect(config.systemInstruction).toBeUndefined();
+  });
+
+  it('should include tools in API call when not cached', async () => {
+    const tools = [{ name: 'search', description: 'Search' }];
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'system' }],
+      data: [],
+      output: [{ type: 'text', content: 'go' }],
+    };
+
+    await driver.query(prompt, { tools });
+
+    const generateContent = (driver as any).client.models.generateContent;
+    const config = generateContent.mock.calls[0][0].config;
+    expect(config.tools).toBeDefined();
+  });
+
+  it('should pass volatile data and output as contents', async () => {
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'system' }],
+      data: [
+        { type: 'chunk', partOf: 'doc', content: 'volatile chunk' },
+      ],
+      output: [{ type: 'text', content: 'respond now' }],
+    };
+
+    await driver.query(prompt);
+
+    const generateContent = (driver as any).client.models.generateContent;
+    const contents = generateContent.mock.calls[0][0].contents;
+    expect(contents).toHaveLength(2);
+  });
+
+  it('should work with streamQuery', async () => {
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'system' }],
+      data: [{ type: 'material', id: 'm1', title: 'Doc', content: 'stable' }],
+      output: [{ type: 'text', content: 'go' }],
+    };
+
+    const { result } = await driver.streamQuery(prompt);
+    const queryResult = await result;
+
+    expect(mockController.prepare).toHaveBeenCalled();
+    expect(queryResult.content).toBe('Streamed');
+
+    const generateContentStream = (driver as any).client.models.generateContentStream;
+    const config = generateContentStream.mock.calls[0][0].config;
+    expect(config.cachedContent).toBe('cachedContents/abc');
+  });
+});

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -146,6 +146,30 @@ describe('GoogleGenAICacheController', () => {
       })).rejects.toThrow('returned a cache without a name');
     });
 
+    it('should re-create cache after TTL expiry', async () => {
+      const shortTtlController = new GoogleGenAICacheController(mockClient as any, { ttl: '1s' });
+      const params = {
+        model: 'gemini-2.5-flash',
+        instructions: [{ type: 'text' as const, content: 'prompt' }],
+      };
+
+      mockClient.caches.create.mockResolvedValueOnce({ name: 'cachedContents/first' });
+      const handle1 = await shortTtlController.prepare(params);
+      expect(handle1.ref).toBe('cachedContents/first');
+
+      // Simulate TTL expiry by advancing Date.now
+      const originalNow = Date.now;
+      Date.now = () => originalNow() + 2000;
+      try {
+        mockClient.caches.create.mockResolvedValueOnce({ name: 'cachedContents/second' });
+        const handle2 = await shortTtlController.prepare(params);
+        expect(handle2.ref).toBe('cachedContents/second');
+        expect(mockClient.caches.create).toHaveBeenCalledTimes(2);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+
     it('should coalesce concurrent calls with identical params', async () => {
       let resolveCreate: (val: { name: string }) => void;
       mockClient.caches.create.mockReturnValueOnce(
@@ -334,5 +358,21 @@ describe('GoogleGenAIDriver with CacheController', () => {
     const generateContentStream = (driver as any).client.models.generateContentStream;
     const config = generateContentStream.mock.calls[0][0].config;
     expect(config.cachedContent).toBe('cachedContents/abc');
+  });
+
+  it('should skip cache when all cacheable elements are empty', async () => {
+    const prompt: CompiledPrompt = {
+      instructions: [{ type: 'text', content: 'dynamic only', cacheHint: 'contextual' }],
+      data: [{ type: 'chunk', partOf: 'doc', content: 'volatile' }],
+      output: [{ type: 'text', content: 'go' }],
+    };
+
+    await driver.query(prompt);
+
+    expect(mockController.prepare).not.toHaveBeenCalled();
+    const generateContent = (driver as any).client.models.generateContent;
+    const config = generateContent.mock.calls[0][0].config;
+    expect(config.cachedContent).toBeUndefined();
+    expect(config.systemInstruction).toBeDefined();
   });
 });

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -1,0 +1,72 @@
+import type { GoogleGenAI } from '@google/genai';
+import type { PromptCacheController, CachePrepareParams, CacheHandle } from '../cache-controller.js';
+import { elementToPart, elementToContent, convertTools } from './element-converter.js';
+
+export interface GoogleGenAICacheControllerConfig {
+  ttl?: string;
+  displayName?: string;
+}
+
+export class GoogleGenAICacheController implements PromptCacheController {
+  private managedCaches: string[] = [];
+
+  constructor(
+    private client: GoogleGenAI,
+    private config?: GoogleGenAICacheControllerConfig
+  ) {}
+
+  async prepare(params: CachePrepareParams): Promise<CacheHandle> {
+    const cacheConfig: Record<string, unknown> = {
+      ttl: this.config?.ttl || '3600s',
+      displayName: this.config?.displayName,
+    };
+
+    if (params.instructions && params.instructions.length > 0) {
+      cacheConfig.systemInstruction = params.instructions.map(el => elementToPart(el));
+    }
+
+    if (params.data && params.data.length > 0) {
+      cacheConfig.contents = params.data.map(el => elementToContent(el));
+    }
+
+    if (params.tools && params.tools.length > 0) {
+      cacheConfig.tools = convertTools(params.tools);
+    }
+
+    Object.keys(cacheConfig).forEach(key => {
+      if (cacheConfig[key] === undefined) {
+        delete cacheConfig[key];
+      }
+    });
+
+    const cache = await this.client.caches.create({
+      model: params.model,
+      config: cacheConfig,
+    });
+
+    const ref = cache.name!;
+    this.managedCaches.push(ref);
+
+    return {
+      ref,
+      includes: {
+        instructions: (params.instructions?.length ?? 0) > 0,
+        dataElementCount: params.data?.length ?? 0,
+        tools: (params.tools?.length ?? 0) > 0,
+      },
+    };
+  }
+
+  async invalidate(handle: CacheHandle): Promise<void> {
+    await this.client.caches.delete({ name: handle.ref });
+    this.managedCaches = this.managedCaches.filter(n => n !== handle.ref);
+  }
+
+  async close(): Promise<void> {
+    const deletions = this.managedCaches.map(name =>
+      this.client.caches.delete({ name }).catch(() => {})
+    );
+    await Promise.all(deletions);
+    this.managedCaches = [];
+  }
+}

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { GoogleGenAI } from '@google/genai';
 import type { PromptCacheController, CachePrepareParams, CacheHandle } from '../cache-controller.js';
 import { elementToPart, elementToContent, convertTools } from './element-converter.js';
@@ -9,13 +10,30 @@ export interface GoogleGenAICacheControllerConfig {
 
 export class GoogleGenAICacheController implements PromptCacheController {
   private managedCaches: string[] = [];
+  private cacheByHash = new Map<string, CacheHandle>();
 
   constructor(
     private client: GoogleGenAI,
     private config?: GoogleGenAICacheControllerConfig
   ) {}
 
+  private computeCacheKey(params: CachePrepareParams): string {
+    const payload = {
+      model: params.model,
+      instructions: params.instructions,
+      data: params.data,
+      tools: params.tools,
+    };
+    return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+  }
+
   async prepare(params: CachePrepareParams): Promise<CacheHandle> {
+    const cacheKey = this.computeCacheKey(params);
+    const existing = this.cacheByHash.get(cacheKey);
+    if (existing) {
+      return existing;
+    }
+
     const cacheConfig: Record<string, unknown> = {
       ttl: this.config?.ttl || '3600s',
       displayName: this.config?.displayName,
@@ -44,10 +62,13 @@ export class GoogleGenAICacheController implements PromptCacheController {
       config: cacheConfig,
     });
 
-    const ref = cache.name!;
+    if (!cache.name) {
+      throw new Error('GoogleGenAI caches.create() returned a cache without a name');
+    }
+    const ref = cache.name;
     this.managedCaches.push(ref);
 
-    return {
+    const handle: CacheHandle = {
       ref,
       includes: {
         instructions: (params.instructions?.length ?? 0) > 0,
@@ -55,11 +76,20 @@ export class GoogleGenAICacheController implements PromptCacheController {
         tools: (params.tools?.length ?? 0) > 0,
       },
     };
+    this.cacheByHash.set(cacheKey, handle);
+
+    return handle;
   }
 
   async invalidate(handle: CacheHandle): Promise<void> {
     await this.client.caches.delete({ name: handle.ref });
     this.managedCaches = this.managedCaches.filter(n => n !== handle.ref);
+    for (const [key, cached] of this.cacheByHash) {
+      if (cached.ref === handle.ref) {
+        this.cacheByHash.delete(key);
+        break;
+      }
+    }
   }
 
   async close(): Promise<void> {
@@ -68,5 +98,6 @@ export class GoogleGenAICacheController implements PromptCacheController {
     );
     await Promise.all(deletions);
     this.managedCaches = [];
+    this.cacheByHash.clear();
   }
 }

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -8,15 +8,28 @@ export interface GoogleGenAICacheControllerConfig {
   displayName?: string;
 }
 
+interface CacheEntry {
+  handle: CacheHandle;
+  createdAt: number;
+}
+
+function parseTtlSeconds(ttl: string): number {
+  const match = ttl.match(/^(\d+)s$/);
+  return match ? Number(match[1]) : 3600;
+}
+
 export class GoogleGenAICacheController implements PromptCacheController {
   private managedCaches: string[] = [];
-  private cacheByHash = new Map<string, CacheHandle>();
+  private cacheByHash = new Map<string, CacheEntry>();
   private inflightRequests = new Map<string, Promise<CacheHandle>>();
+  private ttlSeconds: number;
 
   constructor(
     private client: GoogleGenAI,
     private config?: GoogleGenAICacheControllerConfig
-  ) {}
+  ) {
+    this.ttlSeconds = parseTtlSeconds(this.config?.ttl || '3600s');
+  }
 
   private computeCacheKey(params: CachePrepareParams): string {
     const payload = {
@@ -32,7 +45,12 @@ export class GoogleGenAICacheController implements PromptCacheController {
     const cacheKey = this.computeCacheKey(params);
     const existing = this.cacheByHash.get(cacheKey);
     if (existing) {
-      return existing;
+      const ageSeconds = (Date.now() - existing.createdAt) / 1000;
+      if (ageSeconds < this.ttlSeconds) {
+        return existing.handle;
+      }
+      this.cacheByHash.delete(cacheKey);
+      this.managedCaches = this.managedCaches.filter(n => n !== existing.handle.ref);
     }
 
     const inflight = this.inflightRequests.get(cacheKey);
@@ -92,7 +110,7 @@ export class GoogleGenAICacheController implements PromptCacheController {
         tools: (params.tools?.length ?? 0) > 0,
       },
     };
-    this.cacheByHash.set(cacheKey, handle);
+    this.cacheByHash.set(cacheKey, { handle, createdAt: Date.now() });
 
     return handle;
   }
@@ -100,8 +118,8 @@ export class GoogleGenAICacheController implements PromptCacheController {
   async invalidate(handle: CacheHandle): Promise<void> {
     await this.client.caches.delete({ name: handle.ref });
     this.managedCaches = this.managedCaches.filter(n => n !== handle.ref);
-    for (const [key, cached] of this.cacheByHash) {
-      if (cached.ref === handle.ref) {
+    for (const [key, entry] of this.cacheByHash) {
+      if (entry.handle.ref === handle.ref) {
         this.cacheByHash.delete(key);
         break;
       }

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -22,7 +22,7 @@ function parseTtlSeconds(ttl: string): number {
 }
 
 export class GoogleGenAICacheController implements PromptCacheController {
-  private managedCaches: string[] = [];
+  private managedCaches = new Set<string>();
   private cacheByHash = new Map<string, CacheEntry>();
   private inflightRequests = new Map<string, Promise<CacheHandle>>();
   private ttlSeconds: number;
@@ -55,7 +55,7 @@ export class GoogleGenAICacheController implements PromptCacheController {
     for (const [key, entry] of this.cacheByHash) {
       if ((now - entry.createdAt) / 1000 >= this.ttlSeconds) {
         this.cacheByHash.delete(key);
-        this.managedCaches = this.managedCaches.filter(n => n !== entry.handle.ref);
+        this.managedCaches.delete(entry.handle.ref);
       }
     }
   }
@@ -116,7 +116,7 @@ export class GoogleGenAICacheController implements PromptCacheController {
       throw new Error('GoogleGenAI caches.create() returned a cache without a name');
     }
     const ref = cache.name;
-    this.managedCaches.push(ref);
+    this.managedCaches.add(ref);
 
     const handle: CacheHandle = {
       ref,
@@ -133,7 +133,7 @@ export class GoogleGenAICacheController implements PromptCacheController {
 
   async invalidate(handle: CacheHandle): Promise<void> {
     await this.client.caches.delete({ name: handle.ref });
-    this.managedCaches = this.managedCaches.filter(n => n !== handle.ref);
+    this.managedCaches.delete(handle.ref);
     for (const [key, entry] of this.cacheByHash) {
       if (entry.handle.ref === handle.ref) {
         this.cacheByHash.delete(key);
@@ -145,11 +145,11 @@ export class GoogleGenAICacheController implements PromptCacheController {
   async close(): Promise<void> {
     await Promise.allSettled([...this.inflightRequests.values()]);
     this.inflightRequests.clear();
-    const deletions = this.managedCaches.map(name =>
+    const deletions = [...this.managedCaches].map(name =>
       this.client.caches.delete({ name }).catch(() => {})
     );
     await Promise.all(deletions);
-    this.managedCaches = [];
+    this.managedCaches.clear();
     this.cacheByHash.clear();
   }
 }

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -15,7 +15,10 @@ interface CacheEntry {
 
 function parseTtlSeconds(ttl: string): number {
   const match = ttl.match(/^(\d+)s$/);
-  return match ? Number(match[1]) : 3600;
+  if (!match) {
+    throw new Error(`Invalid TTL format "${ttl}": expected "<digits>s" (e.g. "3600s")`);
+  }
+  return Number(match[1]);
 }
 
 export class GoogleGenAICacheController implements PromptCacheController {

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -11,6 +11,7 @@ export interface GoogleGenAICacheControllerConfig {
 export class GoogleGenAICacheController implements PromptCacheController {
   private managedCaches: string[] = [];
   private cacheByHash = new Map<string, CacheHandle>();
+  private inflightRequests = new Map<string, Promise<CacheHandle>>();
 
   constructor(
     private client: GoogleGenAI,
@@ -34,6 +35,21 @@ export class GoogleGenAICacheController implements PromptCacheController {
       return existing;
     }
 
+    const inflight = this.inflightRequests.get(cacheKey);
+    if (inflight) {
+      return inflight;
+    }
+
+    const promise = this.createCache(params, cacheKey);
+    this.inflightRequests.set(cacheKey, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inflightRequests.delete(cacheKey);
+    }
+  }
+
+  private async createCache(params: CachePrepareParams, cacheKey: string): Promise<CacheHandle> {
     const cacheConfig: Record<string, unknown> = {
       ttl: this.config?.ttl || '3600s',
       displayName: this.config?.displayName,

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -34,25 +34,34 @@ export class GoogleGenAICacheController implements PromptCacheController {
   }
 
   private computeCacheKey(params: CachePrepareParams): string {
+    const normalize = <T>(arr: T[] | undefined): T[] | undefined =>
+      arr && arr.length > 0 ? arr : undefined;
     const payload = {
       model: params.model,
-      instructions: params.instructions,
-      data: params.data,
-      tools: params.tools,
+      instructions: normalize(params.instructions),
+      data: normalize(params.data),
+      tools: normalize(params.tools),
     };
     return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
   }
 
+  private sweepExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cacheByHash) {
+      if ((now - entry.createdAt) / 1000 >= this.ttlSeconds) {
+        this.cacheByHash.delete(key);
+        this.managedCaches = this.managedCaches.filter(n => n !== entry.handle.ref);
+      }
+    }
+  }
+
   async prepare(params: CachePrepareParams): Promise<CacheHandle> {
+    this.sweepExpired();
     const cacheKey = this.computeCacheKey(params);
+
     const existing = this.cacheByHash.get(cacheKey);
     if (existing) {
-      const ageSeconds = (Date.now() - existing.createdAt) / 1000;
-      if (ageSeconds < this.ttlSeconds) {
-        return existing.handle;
-      }
-      this.cacheByHash.delete(cacheKey);
-      this.managedCaches = this.managedCaches.filter(n => n !== existing.handle.ref);
+      return existing.handle;
     }
 
     const inflight = this.inflightRequests.get(cacheKey);

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -23,12 +23,14 @@ export class GoogleGenAICacheController implements PromptCacheController {
   private cacheByHash = new Map<string, CacheEntry>();
   private inflightRequests = new Map<string, Promise<CacheHandle>>();
   private ttlSeconds: number;
+  private normalizedTtl: string;
 
   constructor(
     private client: GoogleGenAI,
     private config?: GoogleGenAICacheControllerConfig
   ) {
     this.ttlSeconds = parseTtlSeconds(this.config?.ttl || '3600s');
+    this.normalizedTtl = `${this.ttlSeconds}s`;
   }
 
   private computeCacheKey(params: CachePrepareParams): string {
@@ -69,7 +71,7 @@ export class GoogleGenAICacheController implements PromptCacheController {
 
   private async createCache(params: CachePrepareParams, cacheKey: string): Promise<CacheHandle> {
     const cacheConfig: Record<string, unknown> = {
-      ttl: this.config?.ttl || '3600s',
+      ttl: this.normalizedTtl,
       displayName: this.config?.displayName,
     };
 
@@ -127,7 +129,7 @@ export class GoogleGenAICacheController implements PromptCacheController {
   }
 
   async close(): Promise<void> {
-    await Promise.all([...this.inflightRequests.values()]).catch(() => {});
+    await Promise.allSettled([...this.inflightRequests.values()]);
     this.inflightRequests.clear();
     const deletions = this.managedCaches.map(name =>
       this.client.caches.delete({ name }).catch(() => {})

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { GoogleGenAI } from '@google/genai';
 import type { PromptCacheController, CachePrepareParams, CacheHandle } from '../cache-controller.js';
-import { elementToPart, elementToContent, convertTools } from './element-converter.js';
+import { elementToPart, elementToContent, convertTools, mergeToolResultContents } from './element-converter.js';
 
 export interface GoogleGenAICacheControllerConfig {
   ttl?: string;
@@ -60,7 +60,7 @@ export class GoogleGenAICacheController implements PromptCacheController {
     }
 
     if (params.data && params.data.length > 0) {
-      cacheConfig.contents = params.data.map(el => elementToContent(el));
+      cacheConfig.contents = mergeToolResultContents(params.data.map(el => elementToContent(el)));
     }
 
     if (params.tools && params.tools.length > 0) {
@@ -109,6 +109,8 @@ export class GoogleGenAICacheController implements PromptCacheController {
   }
 
   async close(): Promise<void> {
+    await Promise.all([...this.inflightRequests.values()]).catch(() => {});
+    this.inflightRequests.clear();
     const deletions = this.managedCaches.map(name =>
       this.client.caches.delete({ name }).catch(() => {})
     );

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -37,14 +37,16 @@ export class GoogleGenAICacheController implements PromptCacheController {
   }
 
   private computeCacheKey(params: CachePrepareParams): string {
-    const normalize = <T>(arr: T[] | undefined): T[] | undefined =>
-      arr && arr.length > 0 ? arr : undefined;
-    const payload = {
-      model: params.model,
-      instructions: normalize(params.instructions),
-      data: normalize(params.data),
-      tools: normalize(params.tools),
-    };
+    const payload: Record<string, unknown> = { model: params.model };
+    if (params.instructions && params.instructions.length > 0) {
+      payload.systemInstruction = params.instructions.map(el => elementToPart(el));
+    }
+    if (params.data && params.data.length > 0) {
+      payload.contents = params.data.map(el => elementToContent(el));
+    }
+    if (params.tools && params.tools.length > 0) {
+      payload.tools = convertTools(params.tools);
+    }
     return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
   }
 

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -109,10 +109,18 @@ export class GoogleGenAIDriver implements AIDriver {
           data: partition.cacheable.data,
           tools: mergedOptions.tools,
         });
-        const uncachedInstructionParts = partition.volatile.instructions.length > 0
-          ? partition.volatile.instructions.map(el => elementToPart(el))
+
+        const instructionsForRequest = handle.includes.instructions
+          ? partition.volatile.instructions
+          : [...partition.cacheable.instructions, ...partition.volatile.instructions];
+        const uncachedInstructionParts = instructionsForRequest.length > 0
+          ? instructionsForRequest.map(el => elementToPart(el))
           : undefined;
-        const volatileElements = [...partition.volatile.data, ...partition.volatile.output];
+
+        const dataForRequest = handle.includes.dataElementCount > 0
+          ? partition.volatile.data
+          : [...partition.cacheable.data, ...partition.volatile.data];
+        const volatileElements = [...dataForRequest, ...partition.volatile.output];
         const contents = volatileElements.length > 0
           ? mergeToolResultContents(volatileElements.map(el => elementToContent(el)))
           : [{ parts: [{ text: 'Please process according to the instructions.' }] }];

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -97,20 +97,27 @@ export class GoogleGenAIDriver implements AIDriver {
   }> {
     if (this.cacheController) {
       const partition = partitionPrompt(prompt);
-      const handle = await this.cacheController.prepare({
-        model,
-        instructions: partition.cacheable.instructions,
-        data: partition.cacheable.data,
-        tools: mergedOptions.tools,
-      });
-      const uncachedInstructionParts = partition.volatile.instructions.length > 0
-        ? partition.volatile.instructions.map(el => elementToPart(el))
-        : undefined;
-      const volatileElements = [...partition.volatile.data, ...partition.volatile.output];
-      const contents = volatileElements.length > 0
-        ? mergeToolResultContents(volatileElements.map(el => elementToContent(el)))
-        : [{ parts: [{ text: 'Please process according to the instructions.' }] }];
-      return { systemInstructionParts: uncachedInstructionParts, contents, cacheHandle: handle };
+      const hasCacheableContent =
+        partition.cacheable.instructions.length > 0 ||
+        partition.cacheable.data.length > 0 ||
+        (mergedOptions.tools && mergedOptions.tools.length > 0);
+
+      if (hasCacheableContent) {
+        const handle = await this.cacheController.prepare({
+          model,
+          instructions: partition.cacheable.instructions,
+          data: partition.cacheable.data,
+          tools: mergedOptions.tools,
+        });
+        const uncachedInstructionParts = partition.volatile.instructions.length > 0
+          ? partition.volatile.instructions.map(el => elementToPart(el))
+          : undefined;
+        const volatileElements = [...partition.volatile.data, ...partition.volatile.output];
+        const contents = volatileElements.length > 0
+          ? mergeToolResultContents(volatileElements.map(el => elementToContent(el)))
+          : [{ parts: [{ text: 'Please process according to the instructions.' }] }];
+        return { systemInstructionParts: uncachedInstructionParts, contents, cacheHandle: handle };
+      }
     }
 
     const systemInstructionParts = prompt.instructions?.map(el => elementToPart(el));

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -1,10 +1,13 @@
 import { GoogleGenAI, FunctionCallingConfigMode } from '@google/genai';
-import type { Part, Content, FunctionDeclaration, FunctionCallingConfig } from '@google/genai';
-import type { CompiledPrompt, Element } from '@modular-prompt/core';
-import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolDefinition, ToolChoice, ToolCall, ChatMessage } from '../types.js';
+import type { Part, Content, FunctionCallingConfig } from '@google/genai';
+import type { CompiledPrompt } from '@modular-prompt/core';
+import type { AIDriver, QueryOptions, QueryResult, StreamResult, ToolChoice, ToolCall, ChatMessage } from '../types.js';
 import { hasToolCalls, isToolResult } from '../types.js';
 import { contentToString } from '../content-utils.js';
 import { QueryLogger } from '../query-logger.js';
+import type { PromptCacheController, CacheHandle } from '../cache-controller.js';
+import { partitionPrompt } from '../cache-utils.js';
+import { elementToPart, elementToContent, toFunctionResponsePayload, convertTools, mergeToolResultContents } from './element-converter.js';
 
 /**
  * GoogleGenAI driver configuration
@@ -14,6 +17,7 @@ export interface GoogleGenAIDriverConfig {
   model?: string;
   temperature?: number;
   defaultOptions?: Partial<GoogleGenAIQueryOptions>;
+  cacheController?: PromptCacheController;
 }
 
 /**
@@ -58,6 +62,7 @@ export class GoogleGenAIDriver implements AIDriver {
   private defaultTemperature: number;
   private _defaultOptions: Partial<GoogleGenAIQueryOptions>;
   private queryLogger = new QueryLogger('GoogleGenAI');
+  private cacheController?: PromptCacheController;
 
   get defaultOptions(): Partial<GoogleGenAIQueryOptions> {
     return this._defaultOptions;
@@ -78,145 +83,43 @@ export class GoogleGenAIDriver implements AIDriver {
     this.defaultModel = config.model || 'gemma-3-27b';
     this.defaultTemperature = config.temperature ?? 0.7;
     this._defaultOptions = config.defaultOptions || {};
+    this.cacheController = config.cacheController;
   }
 
-  /**
-   * Convert Element to Part (flat text conversion)
-   * Used for systemInstruction and simple data
-   */
-  private elementToPart(element: Element | string): Part {
-    if (typeof element === 'string') {
-      return { text: element };
+  private async buildPromptPayload(
+    prompt: CompiledPrompt,
+    mergedOptions: GoogleGenAIQueryOptions,
+    model: string
+  ): Promise<{
+    systemInstructionParts: ReturnType<typeof elementToPart>[] | undefined;
+    contents: Content[];
+    cacheHandle: CacheHandle | null;
+  }> {
+    if (this.cacheController) {
+      const partition = partitionPrompt(prompt);
+      const handle = await this.cacheController.prepare({
+        model,
+        instructions: partition.cacheable.instructions,
+        data: partition.cacheable.data,
+        tools: mergedOptions.tools,
+      });
+      const volatileElements = [...partition.volatile.data, ...partition.volatile.output];
+      const contents = volatileElements.length > 0
+        ? mergeToolResultContents(volatileElements.map(el => elementToContent(el)))
+        : [{ parts: [{ text: 'Please process according to the instructions.' }] }];
+      return { systemInstructionParts: undefined, contents, cacheHandle: handle };
     }
 
-    switch (element.type) {
-      case 'text':
-        return { text: element.content };
-
-      case 'message': {
-        // Flatten message as text
-        if (element.role === 'tool') {
-          // ToolResultMessageElement doesn't have content property
-          const toolResultEl = element as { role: 'tool'; toolCallId: string; name: string; kind: string; value: unknown };
-          const textValue = toolResultEl.kind === 'text' ? String(toolResultEl.value) : JSON.stringify(toolResultEl.value);
-          return { text: `${element.role}: ${textValue}` };
-        }
-        const messageContent = contentToString(element.content);
-        return { text: `${element.role}: ${messageContent}` };
-      }
-
-      case 'material': {
-        const materialContent = contentToString(element.content);
-        return { text: `# ${element.title}\n${materialContent}` };
-      }
-
-      case 'chunk': {
-        const chunkContent = contentToString(element.content);
-        const chunkHeader = element.index !== undefined && element.total !== undefined
-          ? `[Chunk ${element.index + 1}/${element.total} of ${element.partOf}]`
-          : `[Chunk of ${element.partOf}]`;
-        return { text: `${chunkHeader}\n${chunkContent}` };
-      }
-
-      case 'section':
-      case 'subsection': {
-        // Section/SubSection elements should be compiled before reaching here
-        // If they do reach here, flatten their items recursively
-        const flattenItems = (items: unknown[]): string => {
-          return items.map(item => {
-            if (typeof item === 'string') return item;
-            if (typeof item === 'function') return ''; // DynamicContent should be resolved before this point
-            return this.elementToPart(item as Element).text || '';
-          }).filter(Boolean).join('\n');
-        };
-        return { text: flattenItems(element.items) };
-      }
-
-      case 'json':
-        return { text: typeof element.content === 'string' ? element.content : JSON.stringify(element.content, null, 2) };
-
-      default:
-        return { text: JSON.stringify(element) };
-    }
+    const systemInstructionParts = prompt.instructions?.map(el => elementToPart(el));
+    const allDataElements = [...(prompt.data || []), ...(prompt.output || [])];
+    const contents = allDataElements.length > 0
+      ? mergeToolResultContents(allDataElements.map(el => elementToContent(el)))
+      : [{ parts: [{ text: 'Please process according to the instructions.' }] }];
+    return { systemInstructionParts, contents, cacheHandle: null };
   }
 
-  /**
-   * Convert kind+value to GoogleGenAI functionResponse
-   */
-  private toFunctionResponsePayload(kind: string, value: unknown): Record<string, unknown> {
-    if (kind === 'text') {
-      return { output: String(value) };
-    } else if (kind === 'data') {
-      // Check if value is a plain object
-      if (value !== null && typeof value === 'object' && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype) {
-        return value as Record<string, unknown>;
-      }
-      return { output: value };
-    } else { // 'error'
-      return { error: value };
-    }
-  }
-
-  /**
-   * Convert Element to Content (structure-preserving conversion)
-   * Used for conversation history where role matters
-   */
-  private elementToContent(element: Element | string): Content {
-    if (typeof element === 'string') {
-      return { parts: [{ text: element }] };
-    }
-
-    if (element.type === 'message') {
-      if (element.role === 'tool') {
-        // ToolResultMessageElement
-        const toolResultEl = element as { role: 'tool'; toolCallId: string; name: string; kind: string; value: unknown };
-        return {
-          role: 'user',
-          parts: [{
-            functionResponse: {
-              name: toolResultEl.name,
-              response: this.toFunctionResponsePayload(toolResultEl.kind, toolResultEl.value)
-            }
-          }]
-        };
-      } else if ('toolCalls' in element && element.toolCalls) {
-        const parts: Part[] = [];
-        const content = contentToString(element.content);
-        if (content) parts.push({ text: content });
-        for (const tc of element.toolCalls) {
-          const part: Part = { functionCall: { name: tc.name, args: tc.arguments as Record<string, unknown> } };
-          if (typeof tc.metadata?.thoughtSignature === 'string') {
-            part.thoughtSignature = tc.metadata.thoughtSignature;
-          }
-          parts.push(part);
-        }
-        return { role: 'model', parts };
-      } else {
-        // Role conversion:
-        // - assistant → model
-        // - system → user (Gemini API doesn't support system role in contents)
-        // - user → user
-        const role = element.role === 'assistant' ? 'model' : 'user';
-        const messageContent = contentToString(element.content);
-        return {
-          role,
-          parts: [{ text: messageContent }]
-        };
-      }
-    }
-
-    // Non-message elements: convert to Part and wrap in Content without role
-    return {
-      parts: [this.elementToPart(element)]
-    };
-  }
-
-  /**
-   * Convert ChatMessage to GoogleGenAI Content format
-   */
   private chatMessageToContent(message: ChatMessage): Content {
     if (hasToolCalls(message)) {
-      // AssistantToolCallMessage
       const parts: Part[] = [];
       const textContent = contentToString(message.content);
       if (textContent) {
@@ -233,18 +136,16 @@ export class GoogleGenAIDriver implements AIDriver {
       }
       return { role: 'model', parts };
     } else if (isToolResult(message)) {
-      // ToolResultMessage
       return {
         role: 'user',
         parts: [{
           functionResponse: {
             name: message.name,
-            response: this.toFunctionResponsePayload(message.kind, message.value)
+            response: toFunctionResponsePayload(message.kind, message.value)
           }
         }]
       };
     } else {
-      // StandardChatMessage
       return {
         role: message.role === 'assistant' ? 'model' : 'user',
         parts: [{ text: contentToString(message.content) }]
@@ -252,51 +153,9 @@ export class GoogleGenAIDriver implements AIDriver {
     }
   }
 
-
-  /**
-   * Merge consecutive tool result Contents into a single user message.
-   * Gemini API requires multiple functionResponses in one user message.
-   */
-  private mergeToolResultContents(contents: Content[]): Content[] {
-    const merged: Content[] = [];
-    for (const c of contents) {
-      const prev = merged[merged.length - 1];
-      if (
-        prev &&
-        c.role === 'user' &&
-        prev.role === 'user' &&
-        c.parts?.length === 1 && c.parts[0].functionResponse &&
-        prev.parts && prev.parts.length > 0 && prev.parts[0].functionResponse
-      ) {
-        prev.parts!.push(c.parts[0]);
-      } else {
-        merged.push(c);
-      }
-    }
-    return merged;
-  }
-
-  /**
-   * Convert JSON Schema to GoogleGenAI Schema format
-   */
   private convertJsonSchema(schema: unknown): unknown {
     if (!schema || typeof schema !== 'object') return undefined;
-
-    // GoogleGenAI uses a specific schema format
-    // For now, we'll pass it through and let the API handle it
     return schema;
-  }
-
-  /**
-   * Convert ToolDefinition[] to GoogleGenAI tools format
-   */
-  private convertTools(tools: ToolDefinition[]): { functionDeclarations: FunctionDeclaration[] }[] {
-    const functionDeclarations: FunctionDeclaration[] = tools.map(tool => ({
-      name: tool.name,
-      description: tool.description,
-      parametersJsonSchema: tool.parameters,
-    }));
-    return [{ functionDeclarations }];
   }
 
   /**
@@ -353,16 +212,10 @@ export class GoogleGenAIDriver implements AIDriver {
       // Merge options with defaults
       const mergedOptions = { ...this.defaultOptions, ...options };
       this.queryLogger.mark(mergedOptions);
+      const model = mergedOptions.model || this.defaultModel;
 
-      // Convert prompt to GoogleGenAI format
-      // Instructions → systemInstruction (Part[])
-      const systemInstructionParts = prompt.instructions?.map(el => this.elementToPart(el));
-
-      // Data + Output → contents (Content[])
-      const allDataElements = [...(prompt.data || []), ...(prompt.output || [])];
-      const contents = allDataElements.length > 0
-        ? this.mergeToolResultContents(allDataElements.map(el => this.elementToContent(el)))
-        : [{ parts: [{ text: 'Please process according to the instructions.' }] }];
+      const { systemInstructionParts, contents, cacheHandle } =
+        await this.buildPromptPayload(prompt, mergedOptions, model);
 
       // Create generation config
       const config: Record<string, unknown> = {
@@ -376,9 +229,21 @@ export class GoogleGenAIDriver implements AIDriver {
           (mergedOptions.mode === 'thinking' ? { thinkingLevel: 'HIGH' } : undefined),
       };
 
-      // Add system instruction if present
-      if (systemInstructionParts && systemInstructionParts.length > 0) {
-        config.systemInstruction = systemInstructionParts;
+      if (cacheHandle) {
+        config.cachedContent = cacheHandle.ref;
+        if (!cacheHandle.includes.instructions && systemInstructionParts && systemInstructionParts.length > 0) {
+          config.systemInstruction = systemInstructionParts;
+        }
+        if (!cacheHandle.includes.tools && mergedOptions.tools && mergedOptions.tools.length > 0) {
+          config.tools = convertTools(mergedOptions.tools);
+        }
+      } else {
+        if (systemInstructionParts && systemInstructionParts.length > 0) {
+          config.systemInstruction = systemInstructionParts;
+        }
+        if (mergedOptions.tools && mergedOptions.tools.length > 0) {
+          config.tools = convertTools(mergedOptions.tools);
+        }
       }
 
       // Handle structured outputs
@@ -387,10 +252,6 @@ export class GoogleGenAIDriver implements AIDriver {
         config.responseSchema = this.convertJsonSchema(prompt.metadata.outputSchema);
       }
 
-      // Add tools configuration
-      if (mergedOptions.tools && mergedOptions.tools.length > 0) {
-        config.tools = this.convertTools(mergedOptions.tools);
-      }
       if (mergedOptions.toolChoice) {
         config.toolConfig = {
           functionCallingConfig: this.convertToolChoice(mergedOptions.toolChoice),
@@ -403,9 +264,6 @@ export class GoogleGenAIDriver implements AIDriver {
           delete config[key];
         }
       });
-
-      // Get model name
-      const model = mergedOptions.model || this.defaultModel;
 
       // Generate content
       const response = await this.client.models.generateContent({
@@ -473,16 +331,10 @@ export class GoogleGenAIDriver implements AIDriver {
   ): Promise<StreamResult> {
     const mergedOptions = { ...this.defaultOptions, ...options };
     this.queryLogger.mark(mergedOptions);
+    const model = mergedOptions.model || this.defaultModel;
 
-    // Convert prompt to GoogleGenAI format
-    // Instructions → systemInstruction (Part[])
-    const systemInstructionParts = prompt.instructions?.map(el => this.elementToPart(el));
-
-    // Data + Output → contents (Content[])
-    const allDataElements = [...(prompt.data || []), ...(prompt.output || [])];
-    const contents = allDataElements.length > 0
-      ? allDataElements.map(el => this.elementToContent(el))
-      : [{ parts: [{ text: 'Please process according to the instructions.' }] }];
+    const { systemInstructionParts, contents, cacheHandle } =
+      await this.buildPromptPayload(prompt, mergedOptions, model);
 
     // Create generation config
     const config: Record<string, unknown> = {
@@ -496,9 +348,21 @@ export class GoogleGenAIDriver implements AIDriver {
         (mergedOptions.mode === 'thinking' ? { thinkingLevel: 'HIGH' } : undefined),
     };
 
-    // Add system instruction if present
-    if (systemInstructionParts && systemInstructionParts.length > 0) {
-      config.systemInstruction = systemInstructionParts;
+    if (cacheHandle) {
+      config.cachedContent = cacheHandle.ref;
+      if (!cacheHandle.includes.instructions && systemInstructionParts && systemInstructionParts.length > 0) {
+        config.systemInstruction = systemInstructionParts;
+      }
+      if (!cacheHandle.includes.tools && mergedOptions.tools && mergedOptions.tools.length > 0) {
+        config.tools = convertTools(mergedOptions.tools);
+      }
+    } else {
+      if (systemInstructionParts && systemInstructionParts.length > 0) {
+        config.systemInstruction = systemInstructionParts;
+      }
+      if (mergedOptions.tools && mergedOptions.tools.length > 0) {
+        config.tools = convertTools(mergedOptions.tools);
+      }
     }
 
     // Handle structured outputs
@@ -507,10 +371,6 @@ export class GoogleGenAIDriver implements AIDriver {
       config.responseSchema = this.convertJsonSchema(prompt.metadata.outputSchema);
     }
 
-    // Add tools configuration
-    if (mergedOptions.tools && mergedOptions.tools.length > 0) {
-      config.tools = this.convertTools(mergedOptions.tools);
-    }
     if (mergedOptions.toolChoice) {
       config.toolConfig = {
         functionCallingConfig: this.convertToolChoice(mergedOptions.toolChoice),
@@ -523,9 +383,6 @@ export class GoogleGenAIDriver implements AIDriver {
         delete config[key];
       }
     });
-
-    // Get model name
-    const model = mergedOptions.model || this.defaultModel;
 
     // Generate content stream
     const streamResponse = await this.client.models.generateContentStream({

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -117,7 +117,7 @@ export class GoogleGenAIDriver implements AIDriver {
           ? instructionsForRequest.map(el => elementToPart(el))
           : undefined;
 
-        const dataForRequest = handle.includes.dataElementCount > 0
+        const dataForRequest = handle.includes.dataElementCount >= partition.cacheable.data.length
           ? partition.volatile.data
           : [...partition.cacheable.data, ...partition.volatile.data];
         const volatileElements = [...dataForRequest, ...partition.volatile.output];

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -103,11 +103,14 @@ export class GoogleGenAIDriver implements AIDriver {
         data: partition.cacheable.data,
         tools: mergedOptions.tools,
       });
+      const uncachedInstructionParts = partition.volatile.instructions.length > 0
+        ? partition.volatile.instructions.map(el => elementToPart(el))
+        : undefined;
       const volatileElements = [...partition.volatile.data, ...partition.volatile.output];
       const contents = volatileElements.length > 0
         ? mergeToolResultContents(volatileElements.map(el => elementToContent(el)))
         : [{ parts: [{ text: 'Please process according to the instructions.' }] }];
-      return { systemInstructionParts: undefined, contents, cacheHandle: handle };
+      return { systemInstructionParts: uncachedInstructionParts, contents, cacheHandle: handle };
     }
 
     const systemInstructionParts = prompt.instructions?.map(el => elementToPart(el));
@@ -500,6 +503,6 @@ export class GoogleGenAIDriver implements AIDriver {
    * Close the client
    */
   async close(): Promise<void> {
-    // GoogleGenAI client doesn't need explicit closing
+    await this.cacheController?.close();
   }
 }

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -136,6 +136,58 @@ export class GoogleGenAIDriver implements AIDriver {
     return { systemInstructionParts, contents, cacheHandle: null };
   }
 
+  private buildGenerationConfig(
+    mergedOptions: GoogleGenAIQueryOptions,
+    cacheHandle: CacheHandle | null,
+    systemInstructionParts: ReturnType<typeof elementToPart>[] | undefined,
+    prompt: CompiledPrompt
+  ): Record<string, unknown> {
+    const config: Record<string, unknown> = {
+      temperature: mergedOptions.temperature ?? this.defaultTemperature,
+      maxOutputTokens: mergedOptions.maxTokens,
+      topP: mergedOptions.topP,
+      topK: mergedOptions.topK,
+      candidateCount: mergedOptions.candidateCount,
+      stopSequences: mergedOptions.stopSequences,
+      thinkingConfig: mergedOptions.thinkingConfig ??
+        (mergedOptions.mode === 'thinking' ? { thinkingLevel: 'HIGH' } : undefined),
+    };
+
+    if (cacheHandle) {
+      config.cachedContent = cacheHandle.ref;
+      if (!cacheHandle.includes.tools && mergedOptions.tools && mergedOptions.tools.length > 0) {
+        config.tools = convertTools(mergedOptions.tools);
+      }
+    } else {
+      if (mergedOptions.tools && mergedOptions.tools.length > 0) {
+        config.tools = convertTools(mergedOptions.tools);
+      }
+    }
+
+    if (systemInstructionParts && systemInstructionParts.length > 0) {
+      config.systemInstruction = systemInstructionParts;
+    }
+
+    if (prompt.metadata?.outputSchema) {
+      config.responseMimeType = 'application/json';
+      config.responseSchema = this.convertJsonSchema(prompt.metadata.outputSchema);
+    }
+
+    if (mergedOptions.toolChoice) {
+      config.toolConfig = {
+        functionCallingConfig: this.convertToolChoice(mergedOptions.toolChoice),
+      };
+    }
+
+    Object.keys(config).forEach(key => {
+      if (config[key] === undefined) {
+        delete config[key];
+      }
+    });
+
+    return config;
+  }
+
   private chatMessageToContent(message: ChatMessage): Content {
     if (hasToolCalls(message)) {
       const parts: Part[] = [];
@@ -235,53 +287,8 @@ export class GoogleGenAIDriver implements AIDriver {
       const { systemInstructionParts, contents, cacheHandle } =
         await this.buildPromptPayload(prompt, mergedOptions, model);
 
-      // Create generation config
-      const config: Record<string, unknown> = {
-        temperature: mergedOptions.temperature ?? this.defaultTemperature,
-        maxOutputTokens: mergedOptions.maxTokens,
-        topP: mergedOptions.topP,
-        topK: mergedOptions.topK,
-        candidateCount: mergedOptions.candidateCount,
-        stopSequences: mergedOptions.stopSequences,
-        thinkingConfig: mergedOptions.thinkingConfig ??
-          (mergedOptions.mode === 'thinking' ? { thinkingLevel: 'HIGH' } : undefined),
-      };
+      const config = this.buildGenerationConfig(mergedOptions, cacheHandle, systemInstructionParts, prompt);
 
-      if (cacheHandle) {
-        config.cachedContent = cacheHandle.ref;
-        if (!cacheHandle.includes.tools && mergedOptions.tools && mergedOptions.tools.length > 0) {
-          config.tools = convertTools(mergedOptions.tools);
-        }
-      } else {
-        if (mergedOptions.tools && mergedOptions.tools.length > 0) {
-          config.tools = convertTools(mergedOptions.tools);
-        }
-      }
-
-      if (systemInstructionParts && systemInstructionParts.length > 0) {
-        config.systemInstruction = systemInstructionParts;
-      }
-
-      // Handle structured outputs
-      if (prompt.metadata?.outputSchema) {
-        config.responseMimeType = 'application/json';
-        config.responseSchema = this.convertJsonSchema(prompt.metadata.outputSchema);
-      }
-
-      if (mergedOptions.toolChoice) {
-        config.toolConfig = {
-          functionCallingConfig: this.convertToolChoice(mergedOptions.toolChoice),
-        };
-      }
-
-      // Remove undefined values
-      Object.keys(config).forEach(key => {
-        if (config[key] === undefined) {
-          delete config[key];
-        }
-      });
-
-      // Generate content
       const response = await this.client.models.generateContent({
         model,
         contents,
@@ -352,53 +359,8 @@ export class GoogleGenAIDriver implements AIDriver {
     const { systemInstructionParts, contents, cacheHandle } =
       await this.buildPromptPayload(prompt, mergedOptions, model);
 
-    // Create generation config
-    const config: Record<string, unknown> = {
-      temperature: mergedOptions.temperature ?? this.defaultTemperature,
-      maxOutputTokens: mergedOptions.maxTokens,
-      topP: mergedOptions.topP,
-      topK: mergedOptions.topK,
-      candidateCount: mergedOptions.candidateCount,
-      stopSequences: mergedOptions.stopSequences,
-      thinkingConfig: mergedOptions.thinkingConfig ??
-        (mergedOptions.mode === 'thinking' ? { thinkingLevel: 'HIGH' } : undefined),
-    };
+    const config = this.buildGenerationConfig(mergedOptions, cacheHandle, systemInstructionParts, prompt);
 
-    if (cacheHandle) {
-      config.cachedContent = cacheHandle.ref;
-      if (!cacheHandle.includes.tools && mergedOptions.tools && mergedOptions.tools.length > 0) {
-        config.tools = convertTools(mergedOptions.tools);
-      }
-    } else {
-      if (mergedOptions.tools && mergedOptions.tools.length > 0) {
-        config.tools = convertTools(mergedOptions.tools);
-      }
-    }
-
-    if (systemInstructionParts && systemInstructionParts.length > 0) {
-      config.systemInstruction = systemInstructionParts;
-    }
-
-    // Handle structured outputs
-    if (prompt.metadata?.outputSchema) {
-      config.responseMimeType = 'application/json';
-      config.responseSchema = this.convertJsonSchema(prompt.metadata.outputSchema);
-    }
-
-    if (mergedOptions.toolChoice) {
-      config.toolConfig = {
-        functionCallingConfig: this.convertToolChoice(mergedOptions.toolChoice),
-      };
-    }
-
-    // Remove undefined values
-    Object.keys(config).forEach(key => {
-      if (config[key] === undefined) {
-        delete config[key];
-      }
-    });
-
-    // Generate content stream
     const streamResponse = await this.client.models.generateContentStream({
       model,
       contents,

--- a/packages/driver/src/google-genai/google-genai-driver.ts
+++ b/packages/driver/src/google-genai/google-genai-driver.ts
@@ -234,19 +234,17 @@ export class GoogleGenAIDriver implements AIDriver {
 
       if (cacheHandle) {
         config.cachedContent = cacheHandle.ref;
-        if (!cacheHandle.includes.instructions && systemInstructionParts && systemInstructionParts.length > 0) {
-          config.systemInstruction = systemInstructionParts;
-        }
         if (!cacheHandle.includes.tools && mergedOptions.tools && mergedOptions.tools.length > 0) {
           config.tools = convertTools(mergedOptions.tools);
         }
       } else {
-        if (systemInstructionParts && systemInstructionParts.length > 0) {
-          config.systemInstruction = systemInstructionParts;
-        }
         if (mergedOptions.tools && mergedOptions.tools.length > 0) {
           config.tools = convertTools(mergedOptions.tools);
         }
+      }
+
+      if (systemInstructionParts && systemInstructionParts.length > 0) {
+        config.systemInstruction = systemInstructionParts;
       }
 
       // Handle structured outputs
@@ -353,19 +351,17 @@ export class GoogleGenAIDriver implements AIDriver {
 
     if (cacheHandle) {
       config.cachedContent = cacheHandle.ref;
-      if (!cacheHandle.includes.instructions && systemInstructionParts && systemInstructionParts.length > 0) {
-        config.systemInstruction = systemInstructionParts;
-      }
       if (!cacheHandle.includes.tools && mergedOptions.tools && mergedOptions.tools.length > 0) {
         config.tools = convertTools(mergedOptions.tools);
       }
     } else {
-      if (systemInstructionParts && systemInstructionParts.length > 0) {
-        config.systemInstruction = systemInstructionParts;
-      }
       if (mergedOptions.tools && mergedOptions.tools.length > 0) {
         config.tools = convertTools(mergedOptions.tools);
       }
+    }
+
+    if (systemInstructionParts && systemInstructionParts.length > 0) {
+      config.systemInstruction = systemInstructionParts;
     }
 
     // Handle structured outputs

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -18,6 +18,19 @@ export type {
 
 export { hasToolCalls, isToolResult } from './types.js';
 
+// Cache utilities
+export type {
+  PromptCacheController,
+  CachePrepareParams,
+  CacheHandle
+} from './cache-controller.js';
+
+export {
+  isElementCacheable,
+  partitionPrompt,
+  type PromptPartition
+} from './cache-utils.js';
+
 // Query Logger
 export { QueryLogger } from './query-logger.js';
 
@@ -94,6 +107,11 @@ export {
   type GoogleGenAIDriverConfig,
   type GoogleGenAIQueryOptions
 } from './google-genai/google-genai-driver.js';
+
+export {
+  GoogleGenAICacheController,
+  type GoogleGenAICacheControllerConfig
+} from './google-genai/google-genai-cache-controller.js';
 
 // Formatter exports (moved from utils to avoid circular dependency)
 export type {


### PR DESCRIPTION
## Summary

- 明示的なキャッシュ管理が必要なプロバイダー（Google GenAI, MLX等）向けの`PromptCacheController`インターフェースを導入
- Google GenAI向けの`GoogleGenAICacheController`実装を提供
- Element変換ロジックを`element-converter.ts`に抽出し、ドライバーとCacheControllerで共有

## 設計

### CacheControllerパターン

| プロバイダー | キャッシュ方式 | CacheController |
|---|---|---|
| Anthropic | インライン（`cache_control`） | 不要 |
| Google GenAI | 明示的オブジェクト（`caches.create()`） | **必要** |
| MLX | KV-cache（`make_prompt_cache()`） | 必要（将来対応） |

### 使い方

```typescript
import { GoogleGenAI } from '@google/genai';
import { GoogleGenAIDriver, GoogleGenAICacheController } from '@modular-prompt/driver';

const client = new GoogleGenAI({ apiKey });
const driver = new GoogleGenAIDriver({
  apiKey,
  cacheController: new GoogleGenAICacheController(client, { ttl: '3600s' })
});

// キャッシュは透過的に適用される
await driver.query(compiledPrompt);
```

- CacheControllerの有無がキャッシュのスイッチ（`cache: true`フラグは不要）
- キャッシュの作成・再利用・無効化は全てCacheController内部で管理

### 新規ファイル

- `cache-controller.ts` — PromptCacheController/CacheHandle/CachePrepareParams型定義
- `cache-utils.ts` — isElementCacheable/partitionPromptユーティリティ（cacheHintベース）
- `google-genai/element-converter.ts` — Element→Google GenAI形式の変換関数（ドライバーから抽出）
- `google-genai/google-genai-cache-controller.ts` — GoogleGenAICacheController実装

## Test plan

- [x] cache-utils: isElementCacheable/partitionPromptの14テスト
- [x] GoogleGenAICacheController: prepare/invalidate/closeの6テスト
- [x] GoogleGenAIDriver統合: CacheController有効時の5テスト
- [x] 既存テスト全512通過（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)