### PR TITLE
feat: MLXドライバーにPromptCacheController対応を追加

### DIFF
--- a/.changeset/mlx-prompt-caching.md
+++ b/.changeset/mlx-prompt-caching.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/driver": minor
+---
+
+MLXドライバーにPromptCacheController対応を追加。PromptCacheControllerインターフェースを実装したMlxCacheControllerにより、cacheable要素のKVキャッシュプレフィルと再利用が可能に。

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MlxCacheController } from './mlx-cache-controller.js';
+
+function createMockProcess() {
+  return {
+    cachePrefill: vi.fn().mockResolvedValue({ cache_id: 'mlx-cache-abc' }),
+    cacheDelete: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+describe('MlxCacheController', () => {
+  let mockProcess: ReturnType<typeof createMockProcess>;
+  let controller: MlxCacheController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcess = createMockProcess();
+    controller = new MlxCacheController(mockProcess as any);
+  });
+
+  describe('prepare', () => {
+    it('should create cache with instructions', async () => {
+      const handle = await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'Be helpful' }],
+      });
+
+      expect(handle.ref).toMatch(/^mlx-cache-/);
+      expect(handle.includes.instructions).toBe(true);
+      expect(handle.includes.dataElementCount).toBe(0);
+      expect(handle.includes.tools).toBe(false);
+      expect(mockProcess.cachePrefill).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create cache with instructions and data', async () => {
+      const handle = await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'Be helpful' }],
+        data: [{ type: 'material', id: 'm1', title: 'Doc', content: 'reference text' }],
+      });
+
+      expect(handle.includes.instructions).toBe(true);
+      expect(handle.includes.dataElementCount).toBe(1);
+      expect(mockProcess.cachePrefill).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reuse cache for identical params', async () => {
+      const params = {
+        model: 'test-model',
+        instructions: [{ type: 'text' as const, content: 'Be helpful' }],
+      };
+
+      const handle1 = await controller.prepare(params);
+      const handle2 = await controller.prepare(params);
+
+      expect(handle1.ref).toBe(handle2.ref);
+      expect(mockProcess.cachePrefill).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create separate caches for different params', async () => {
+      const handle1 = await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text' as const, content: 'prompt A' }],
+      });
+      const handle2 = await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text' as const, content: 'prompt B' }],
+      });
+
+      expect(handle1.ref).not.toBe(handle2.ref);
+      expect(mockProcess.cachePrefill).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle empty instructions and data', async () => {
+      const handle = await controller.prepare({
+        model: 'test-model',
+      });
+
+      expect(handle.includes.instructions).toBe(false);
+      expect(handle.includes.dataElementCount).toBe(0);
+    });
+
+    it('should coalesce concurrent calls with identical params', async () => {
+      let resolvePrefill: (val: { cache_id: string }) => void;
+      mockProcess.cachePrefill.mockReturnValueOnce(
+        new Promise(resolve => { resolvePrefill = resolve; })
+      );
+
+      const params = {
+        model: 'test-model',
+        instructions: [{ type: 'text' as const, content: 'prompt' }],
+      };
+
+      const p1 = controller.prepare(params);
+      const p2 = controller.prepare(params);
+
+      resolvePrefill!({ cache_id: 'mlx-cache-coalesced' });
+
+      const [h1, h2] = await Promise.all([p1, p2]);
+      expect(h1.ref).toBe(h2.ref);
+      expect(mockProcess.cachePrefill).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass formatted messages to process.cachePrefill', async () => {
+      await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'system prompt' }],
+        data: [{ type: 'material', id: 'm1', title: 'Doc', content: 'content' }],
+      });
+
+      const [cacheId, messages] = mockProcess.cachePrefill.mock.calls[0];
+      expect(cacheId).toMatch(/^mlx-cache-/);
+      expect(Array.isArray(messages)).toBe(true);
+      expect(messages.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('should delete the cached content', async () => {
+      const handle = await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'prompt' }],
+      });
+
+      await controller.invalidate(handle);
+      expect(mockProcess.cacheDelete).toHaveBeenCalledWith(handle.ref);
+    });
+
+    it('should allow re-creation after invalidation', async () => {
+      const params = {
+        model: 'test-model',
+        instructions: [{ type: 'text' as const, content: 'prompt' }],
+      };
+
+      const handle1 = await controller.prepare(params);
+      await controller.invalidate(handle1);
+
+      const handle2 = await controller.prepare(params);
+      expect(mockProcess.cachePrefill).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('close', () => {
+    it('should delete all managed caches', async () => {
+      await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'a' }],
+      });
+      await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'b' }],
+      });
+
+      await controller.close();
+      expect(mockProcess.cacheDelete).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.ts
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto';
+import type { PromptCacheController, CachePrepareParams, CacheHandle } from '../cache-controller.js';
+import type { FormatterOptions } from '../formatter/types.js';
+import { formatPromptAsMessages } from '../formatter/converter.js';
+import type { CompiledPrompt } from '@modular-prompt/core';
+import type { MlxProcess } from './process/index.js';
+import { convertMessages } from './mlx-driver.js';
+
+export class MlxCacheController implements PromptCacheController {
+  private cacheByHash = new Map<string, CacheHandle>();
+  private inflightRequests = new Map<string, Promise<CacheHandle>>();
+
+  constructor(
+    private process: MlxProcess,
+    private formatterOptions: FormatterOptions = {}
+  ) {}
+
+  private computeCacheKey(params: CachePrepareParams): string {
+    const payload: Record<string, unknown> = { model: params.model };
+    if (params.instructions && params.instructions.length > 0) {
+      payload.instructions = params.instructions;
+    }
+    if (params.data && params.data.length > 0) {
+      payload.data = params.data;
+    }
+    return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+  }
+
+  async prepare(params: CachePrepareParams): Promise<CacheHandle> {
+    const cacheKey = this.computeCacheKey(params);
+
+    const existing = this.cacheByHash.get(cacheKey);
+    if (existing) {
+      return existing;
+    }
+
+    const inflight = this.inflightRequests.get(cacheKey);
+    if (inflight) {
+      return inflight;
+    }
+
+    const promise = this.createCache(params, cacheKey);
+    this.inflightRequests.set(cacheKey, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inflightRequests.delete(cacheKey);
+    }
+  }
+
+  private async createCache(params: CachePrepareParams, cacheKey: string): Promise<CacheHandle> {
+    const prefillPrompt: CompiledPrompt = {
+      instructions: params.instructions || [],
+      data: params.data || [],
+      output: [],
+    };
+
+    const chatMessages = formatPromptAsMessages(prefillPrompt, this.formatterOptions);
+    const mlxMessages = convertMessages(chatMessages);
+
+    const cacheId = `mlx-cache-${cacheKey.slice(0, 16)}`;
+    await this.process.cachePrefill(cacheId, mlxMessages);
+
+    const handle: CacheHandle = {
+      ref: cacheId,
+      includes: {
+        instructions: (params.instructions?.length ?? 0) > 0,
+        dataElementCount: params.data?.length ?? 0,
+        tools: false,
+      },
+    };
+    this.cacheByHash.set(cacheKey, handle);
+    return handle;
+  }
+
+  async invalidate(handle: CacheHandle): Promise<void> {
+    await this.process.cacheDelete(handle.ref);
+    for (const [key, entry] of this.cacheByHash) {
+      if (entry.ref === handle.ref) {
+        this.cacheByHash.delete(key);
+        break;
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    await Promise.allSettled([...this.inflightRequests.values()]);
+    this.inflightRequests.clear();
+    const refs = [...new Set([...this.cacheByHash.values()].map(h => h.ref))];
+    await Promise.all(refs.map(ref => this.process.cacheDelete(ref).catch(() => {})));
+    this.cacheByHash.clear();
+  }
+}

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -14,6 +14,8 @@ import { extractJSON } from '@modular-prompt/utils';
 import { formatToolDefinitionsAsText } from './tool-call-parser.js';
 import { contentToString, extractImagePaths } from '../content-utils.js';
 import { QueryLogger } from '../query-logger.js';
+import type { PromptCacheController, CacheHandle } from '../cache-controller.js';
+import { partitionPrompt } from '../cache-utils.js';
 
 // ========================================================================
 // Utility Functions (exported for testing)
@@ -128,6 +130,8 @@ export interface MlxDriverConfig {
   textOnly?: boolean;
   /** Speculative decoding用のdrafter model名 */
   drafterModel?: string;
+  /** Prompt cache controller */
+  cacheController?: PromptCacheController;
 }
 
 /**
@@ -178,6 +182,7 @@ export class MlxDriver implements AIDriver {
   private formatterOptions: FormatterOptions;
   private maxImageSize: number;
   private queryLogger = new QueryLogger('MLX');
+  private cacheController?: PromptCacheController;
 
   get defaultOptions(): Partial<MlxMlModelOptions> {
     return this._defaultOptions;
@@ -194,6 +199,7 @@ export class MlxDriver implements AIDriver {
     this.maxImageSize = config.maxImageSize ?? 768;
     this.process = new MlxProcess(config.model, { textOnly: config.textOnly, drafterModel: config.drafterModel });
     this.modelProcessor = createModelSpecificProcessor(config.model);
+    this.cacheController = config.cacheController;
     if (config.drafterModel) {
       this.queryLogger.log.info(`Drafter model: ${config.drafterModel}`);
     }
@@ -278,7 +284,6 @@ export class MlxDriver implements AIDriver {
         this.runtimeInfo?.special_tokens,
         this.runtimeInfo?.features?.chat_template?.tool_call_format
       );
-      // instructions の末尾にTextElementとして追加
       augmentedPrompt = {
         ...prompt,
         instructions: [
@@ -288,28 +293,39 @@ export class MlxDriver implements AIDriver {
       };
     }
 
+    // Cache: cacheable部分をプレフィルし、cacheIdを取得
+    let cacheId: string | undefined;
+    if (this.cacheController) {
+      const partition = partitionPrompt(augmentedPrompt);
+      const hasCacheableContent =
+        partition.cacheable.instructions.length > 0 ||
+        partition.cacheable.data.length > 0;
+
+      if (hasCacheableContent) {
+        const handle = await this.cacheController.prepare({
+          model: this.model,
+          instructions: partition.cacheable.instructions,
+          data: partition.cacheable.data,
+        });
+        cacheId = handle.ref;
+      }
+    }
+
     let stream: Readable;
     if (api === 'completion') {
-      // completion APIを使用 - 標準フォーマッターを使用
-      // completion APIではtools非対応
       let formattedPrompt = formatCompletionPrompt(augmentedPrompt, this.formatterOptions);
-      // モデル固有の後処理を適用
       formattedPrompt = this.modelProcessor.applyCompletionSpecificProcessing(formattedPrompt);
-      stream = await this.process.completion(formattedPrompt, mlxOptions);
+      stream = await this.process.completion(formattedPrompt, mlxOptions, undefined, undefined, cacheId);
     } else {
-      // chat APIを使用 - メッセージ変換して処理
       const messages = formatPromptAsMessages(augmentedPrompt, this.formatterOptions);
       const vlm = this.isVLM();
       let mlxMessages = convertMessages(messages, vlm);
-      // chat APIではチャット処理を適用
       mlxMessages = this.modelProcessor.applyChatSpecificProcessing(mlxMessages);
-      // nativeツール対応の場合のみPythonにtoolsを渡す
       const nativeTools = this.hasNativeToolSupport() ? tools : undefined;
-      // VLMの場合は画像パスを抽出（ファイル読み込み用）
       const images = vlm
         ? messages.flatMap(m => 'content' in m && !isToolResult(m) ? extractImagePaths(m.content) : [])
         : [];
-      stream = await this.process.chat(mlxMessages, undefined, mlxOptions, nativeTools, images.length > 0 ? images : undefined, images.length > 0 ? this.maxImageSize : undefined, options?.reasoningEffort);
+      stream = await this.process.chat(mlxMessages, undefined, mlxOptions, nativeTools, images.length > 0 ? images : undefined, images.length > 0 ? this.maxImageSize : undefined, options?.reasoningEffort, cacheId);
     }
 
     return stream;
@@ -449,6 +465,7 @@ export class MlxDriver implements AIDriver {
    * Close the process
    */
   async close(): Promise<void> {
+    await this.cacheController?.close();
     await this.process.exit();
   }
 }

--- a/packages/driver/src/mlx-ml/process/index.ts
+++ b/packages/driver/src/mlx-ml/process/index.ts
@@ -12,6 +12,8 @@ import type {
   MlxMessage,
   MlxRuntimeInfo,
   MlxFormatTestResult,
+  MlxCachePrefillResult,
+  MlxCacheDeleteResult,
   MlxToolDefinition
 } from './types.js';
 import { QueueManager, QueueManagerCallbacks } from './queue.js';
@@ -25,6 +27,8 @@ export type {
   MlxMessage,
   MlxRuntimeInfo,
   MlxFormatTestResult,
+  MlxCachePrefillResult,
+  MlxCacheDeleteResult,
   MlxToolDefinition
 };
 
@@ -84,16 +88,23 @@ export class MlxProcess {
     return this.queueManager.addFormatTestRequest(messages, options);
   }
 
-  // API v2.0 Chat - chat APIを直接使用
-  async chat(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number, reasoningEffort?: 'low' | 'medium' | 'high'): Promise<Readable> {
-    // chat APIを直接使用（前処理はドライバーで実施済み）
-    return this.queueManager.addChatRequest(messages, primer, options, tools, images, maxImageSize, reasoningEffort);
+  // Cache operations
+  async cachePrefill(cacheId: string, messages: MlxMessage[]): Promise<MlxCachePrefillResult> {
+    return this.queueManager.addCachePrefillRequest(cacheId, messages);
   }
 
-  // API v2.0 Completion - completion APIを直接使用
-  async completion(prompt: string, options?: MlxMlModelOptions, images?: string[], maxImageSize?: number): Promise<Readable> {
-    // completion APIを直接使用（前処理はドライバーで実施済み）
-    return this.queueManager.addCompletionRequest(prompt, options, images, maxImageSize);
+  async cacheDelete(cacheId: string): Promise<MlxCacheDeleteResult> {
+    return this.queueManager.addCacheDeleteRequest(cacheId);
+  }
+
+  // API v2.0 Chat
+  async chat(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number, reasoningEffort?: 'low' | 'medium' | 'high', cacheId?: string): Promise<Readable> {
+    return this.queueManager.addChatRequest(messages, primer, options, tools, images, maxImageSize, reasoningEffort, cacheId);
+  }
+
+  // API v2.0 Completion
+  async completion(prompt: string, options?: MlxMlModelOptions, images?: string[], maxImageSize?: number, cacheId?: string): Promise<Readable> {
+    return this.queueManager.addCompletionRequest(prompt, options, images, maxImageSize, cacheId);
   }
 
 

--- a/packages/driver/src/mlx-ml/process/queue.ts
+++ b/packages/driver/src/mlx-ml/process/queue.ts
@@ -11,15 +11,21 @@ import type {
   QueueItem,
   CapabilitiesQueueItem,
   FormatTestQueueItem,
+  CachePrefillQueueItem,
+  CacheDeleteQueueItem,
   StreamingQueueItem,
   MlxCapabilitiesRequest,
   MlxFormatTestRequest,
   MlxChatRequest,
   MlxCompletionRequest,
+  MlxCachePrefillRequest,
+  MlxCacheDeleteRequest,
   MlxMessage,
   MlxMlModelOptions,
   MlxRuntimeInfo,
   MlxFormatTestResult,
+  MlxCachePrefillResult,
+  MlxCacheDeleteResult,
   MlxToolDefinition
 } from './types.js';
 
@@ -69,7 +75,7 @@ export class QueueManager {
     });
   }
 
-  addChatRequest(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number, reasoningEffort?: 'low' | 'medium' | 'high'): Promise<Readable> {
+  addChatRequest(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number, reasoningEffort?: 'low' | 'medium' | 'high', cacheId?: string): Promise<Readable> {
     return new Promise((resolve, reject) => {
       try {
         const request: MlxChatRequest = {
@@ -77,9 +83,10 @@ export class QueueManager {
           messages,
           primer,
           tools,
-          options: mapOptionsToPython(options, true),  // strict mode: true
+          options: mapOptionsToPython(options, true),
           ...(images?.length ? { images, maxImageSize } : {}),
           ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+          ...(cacheId ? { cache_id: cacheId } : {}),
         };
         this.queue.push({
           request,
@@ -93,14 +100,48 @@ export class QueueManager {
     });
   }
 
-  addCompletionRequest(prompt: string, options?: MlxMlModelOptions, images?: string[], maxImageSize?: number): Promise<Readable> {
+  addCachePrefillRequest(cacheId: string, messages: MlxMessage[]): Promise<MlxCachePrefillResult> {
+    return new Promise((resolve, reject) => {
+      const request: MlxCachePrefillRequest = {
+        method: 'cache_prefill',
+        cache_id: cacheId,
+        messages,
+      };
+      this.queue.push({
+        request,
+        resolve,
+        reject,
+        expectJsonResponse: true,
+      } as CachePrefillQueueItem);
+      this.processNext();
+    });
+  }
+
+  addCacheDeleteRequest(cacheId: string): Promise<MlxCacheDeleteResult> {
+    return new Promise((resolve, reject) => {
+      const request: MlxCacheDeleteRequest = {
+        method: 'cache_delete',
+        cache_id: cacheId,
+      };
+      this.queue.push({
+        request,
+        resolve,
+        reject,
+        expectJsonResponse: true,
+      } as CacheDeleteQueueItem);
+      this.processNext();
+    });
+  }
+
+  addCompletionRequest(prompt: string, options?: MlxMlModelOptions, images?: string[], maxImageSize?: number, cacheId?: string): Promise<Readable> {
     return new Promise((resolve, reject) => {
       try {
         const request: MlxCompletionRequest = {
           method: 'completion',
           prompt,
-          options: mapOptionsToPython(options, true),  // strict mode: true
-          ...(images?.length ? { images, maxImageSize } : {})
+          options: mapOptionsToPython(options, true),
+          ...(images?.length ? { images, maxImageSize } : {}),
+          ...(cacheId ? { cache_id: cacheId } : {}),
         };
         this.queue.push({
           request,
@@ -146,9 +187,12 @@ export class QueueManager {
             (queueItem as CapabilitiesQueueItem).resolve(jsonResponse);
           } else if (queueItem.request.method === 'format_test') {
             (queueItem as FormatTestQueueItem).resolve(jsonResponse);
+          } else if (queueItem.request.method === 'cache_prefill') {
+            (queueItem as CachePrefillQueueItem).resolve(jsonResponse);
+          } else if (queueItem.request.method === 'cache_delete') {
+            (queueItem as CacheDeleteQueueItem).resolve(jsonResponse);
           }
         } catch (e) {
-          // エラー時のフォールバック処理
           if (queueItem.request.method === 'capabilities') {
             (queueItem as CapabilitiesQueueItem).resolve({
               methods: [],
@@ -162,13 +206,18 @@ export class QueueManager {
               model_specific_processing: null,
               error: e instanceof Error ? e.message : 'Unknown error'
             });
+          } else if (queueItem.request.method === 'cache_prefill') {
+            (queueItem as CachePrefillQueueItem).reject(
+              e instanceof Error ? e : new Error(String(e))
+            );
+          } else if (queueItem.request.method === 'cache_delete') {
+            (queueItem as CacheDeleteQueueItem).reject(
+              e instanceof Error ? e : new Error(String(e))
+            );
           }
         }
       }
     }
-    // 注: isProcessing/processNext は onRequestCompleted() に一元化
-    // handleJsonResponse と onRequestCompleted の二重呼び出しによる
-    // isProcessing フラグの不整合を防止
   }
 
   onRequestCompleted(): void {

--- a/packages/driver/src/mlx-ml/process/types.ts
+++ b/packages/driver/src/mlx-ml/process/types.ts
@@ -43,7 +43,7 @@ export type MlxMessage = MlxStandardMessage | MlxAssistantToolCallMessage | MlxT
 
 // API v2.0 リクエスト型定義
 export interface MlxBaseRequest {
-  method: 'capabilities' | 'format_test' | 'chat' | 'completion';
+  method: 'capabilities' | 'format_test' | 'chat' | 'completion' | 'cache_prefill' | 'cache_delete';
 }
 
 export interface MlxCapabilitiesRequest extends MlxBaseRequest {
@@ -74,20 +74,41 @@ export interface MlxChatRequest extends MlxBaseRequest {
   primer?: string;
   tools?: MlxToolDefinition[];
   options?: MlxMlModelOptions;
-  images?: string[];  // ファイルパス配列（VLM用）
-  maxImageSize?: number;  // 画像の最大辺ピクセル数
+  images?: string[];
+  maxImageSize?: number;
   reasoning_effort?: 'low' | 'medium' | 'high';
+  cache_id?: string;
 }
 
 export interface MlxCompletionRequest extends MlxBaseRequest {
   method: 'completion';
   prompt: string;
   options?: MlxMlModelOptions;
-  images?: string[];  // ファイルパス配列（VLM用）
-  maxImageSize?: number;  // 画像の最大辺ピクセル数
+  images?: string[];
+  maxImageSize?: number;
+  cache_id?: string;
 }
 
-export type MlxRequest = MlxCapabilitiesRequest | MlxFormatTestRequest | MlxChatRequest | MlxCompletionRequest;
+export interface MlxCachePrefillRequest extends MlxBaseRequest {
+  method: 'cache_prefill';
+  cache_id: string;
+  messages: MlxMessage[];
+}
+
+export interface MlxCacheDeleteRequest extends MlxBaseRequest {
+  method: 'cache_delete';
+  cache_id: string;
+}
+
+export interface MlxCachePrefillResult {
+  cache_id: string;
+}
+
+export interface MlxCacheDeleteResult {
+  ok: boolean;
+}
+
+export type MlxRequest = MlxCapabilitiesRequest | MlxFormatTestRequest | MlxChatRequest | MlxCompletionRequest | MlxCachePrefillRequest | MlxCacheDeleteRequest;
 
 /** MLX-LMが認識するtool_parser_type */
 export type KnownToolParserType =
@@ -178,6 +199,20 @@ export interface FormatTestQueueItem extends BaseQueueItem {
   expectJsonResponse: true;
 }
 
+export interface CachePrefillQueueItem extends BaseQueueItem {
+  request: MlxCachePrefillRequest;
+  resolve: (value: MlxCachePrefillResult) => void;
+  reject: (reason: Error) => void;
+  expectJsonResponse: true;
+}
+
+export interface CacheDeleteQueueItem extends BaseQueueItem {
+  request: MlxCacheDeleteRequest;
+  resolve: (value: MlxCacheDeleteResult) => void;
+  reject: (reason: Error) => void;
+  expectJsonResponse: true;
+}
+
 export interface StreamingQueueItem extends BaseQueueItem {
   request: MlxChatRequest | MlxCompletionRequest | LegacyMlxRequest;
   resolve: (value: Readable) => void;
@@ -185,7 +220,7 @@ export interface StreamingQueueItem extends BaseQueueItem {
   expectJsonResponse?: false;
 }
 
-export type QueueItem = CapabilitiesQueueItem | FormatTestQueueItem | StreamingQueueItem;
+export type QueueItem = CapabilitiesQueueItem | FormatTestQueueItem | CachePrefillQueueItem | CacheDeleteQueueItem | StreamingQueueItem;
 
 // Node.js stream import
 import { Readable } from 'stream';

--- a/packages/driver/src/mlx-ml/python/backends/base.py
+++ b/packages/driver/src/mlx-ml/python/backends/base.py
@@ -42,3 +42,19 @@ class ModelBackend(ABC):
     def has_drafter(self) -> bool:
         """Return whether a drafter model is loaded."""
         return False
+
+    def cache_prefill(self, cache_id: str, prompt: str) -> dict:
+        """Build a KV cache from a prompt prefix."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support prompt caching"
+        )
+
+    def cache_delete(self, cache_id: str) -> None:
+        """Delete a cached KV cache entry."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support prompt caching"
+        )
+
+    def cache_get(self, cache_id: str) -> list | None:
+        """Return the prompt cache for the given ID, or None."""
+        return None

--- a/packages/driver/src/mlx-ml/python/backends/mlx_lm.py
+++ b/packages/driver/src/mlx-ml/python/backends/mlx_lm.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import sys
 from typing import Any, Iterator
 
 from mlx_lm import load as mlx_lm_load
 from mlx_lm import stream_generate as mlx_lm_stream_generate
+from mlx_lm.models.cache import make_prompt_cache
 from mlx_lm.sample_utils import make_sampler
 
 from backends.base import ModelBackend
@@ -16,6 +18,7 @@ class MlxLmBackend(ModelBackend):
     def __init__(self) -> None:
         self.model: Any | None = None
         self.tokenizer: Any | None = None
+        self._caches: dict[str, list] = {}
 
     def load(self, model_name: str) -> None:
         self.model, self.tokenizer = mlx_lm_load(model_name)
@@ -24,7 +27,11 @@ class MlxLmBackend(ModelBackend):
         return self.tokenizer
 
     def stream_generate(
-        self, prompt: str | list[int], options: dict, images: list | None = None
+        self,
+        prompt: str | list[int],
+        options: dict,
+        images: list | None = None,
+        prompt_cache: list | None = None,
     ) -> Iterator[Any]:
         if self.model is None or self.tokenizer is None:
             raise RuntimeError("Model is not loaded")
@@ -39,6 +46,9 @@ class MlxLmBackend(ModelBackend):
             top_k=top_k,
         )
 
+        if prompt_cache is not None:
+            final_options["prompt_cache"] = prompt_cache
+
         for response in mlx_lm_stream_generate(
             self.model,
             self.tokenizer,
@@ -48,6 +58,28 @@ class MlxLmBackend(ModelBackend):
             if is_eod_token(response, self.tokenizer):
                 break
             yield response
+
+    def cache_prefill(self, cache_id: str, prompt: str) -> dict:
+        if self.model is None or self.tokenizer is None:
+            raise RuntimeError("Model is not loaded")
+
+        prompt_cache = make_prompt_cache(self.model)
+        for _ in mlx_lm_stream_generate(
+            self.model, self.tokenizer, prompt,
+            prompt_cache=prompt_cache, max_tokens=1,
+        ):
+            pass
+        self._caches[cache_id] = prompt_cache
+        sys.stderr.write(f"Cache created: {cache_id}\n")
+        return {"cache_id": cache_id}
+
+    def cache_delete(self, cache_id: str) -> None:
+        removed = self._caches.pop(cache_id, None)
+        if removed is not None:
+            sys.stderr.write(f"Cache deleted: {cache_id}\n")
+
+    def cache_get(self, cache_id: str) -> list | None:
+        return self._caches.get(cache_id)
 
     def supports_vision(self) -> bool:
         return False

--- a/packages/driver/src/mlx-ml/python/handlers/__init__.py
+++ b/packages/driver/src/mlx-ml/python/handlers/__init__.py
@@ -1,3 +1,4 @@
+from handlers.cache import handle_cache_prefill, handle_cache_delete
 from handlers.capabilities import handle_capabilities
 from handlers.chat import handle_chat
 from handlers.completion import handle_completion

--- a/packages/driver/src/mlx-ml/python/handlers/cache.py
+++ b/packages/driver/src/mlx-ml/python/handlers/cache.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import sys
+
+from backends.base import ModelBackend
+from utils.prompt_builder import generate_merged_prompt, supports_chat_template
+
+
+def handle_cache_prefill(
+    backend: ModelBackend,
+    capabilities: dict,
+    cache_id: str,
+    messages: list,
+) -> None:
+    tokenizer = backend.get_tokenizer()
+
+    if supports_chat_template(tokenizer):
+        try:
+            prompt = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=False,
+                tokenize=False,
+            )
+        except TypeError:
+            prompt = tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=False,
+                tokenize=False,
+            )
+    else:
+        prompt = generate_merged_prompt(messages, capabilities)
+
+    sys.stderr.write(f"--- cache_prefill {cache_id}\n")
+    result = backend.cache_prefill(cache_id, prompt)
+    print(json.dumps(result), end="\0", flush=True)
+
+
+def handle_cache_delete(
+    backend: ModelBackend,
+    cache_id: str,
+) -> None:
+    backend.cache_delete(cache_id)
+    print(json.dumps({"ok": True}), end="\0", flush=True)

--- a/packages/driver/src/mlx-ml/python/handlers/chat.py
+++ b/packages/driver/src/mlx-ml/python/handlers/chat.py
@@ -13,11 +13,12 @@ def _stream_to_stdout(
     options: dict,
     images: list | None = None,
     primer: str | None = None,
+    prompt_cache: list | None = None,
 ) -> None:
     if primer is not None:
         print(primer, end="", flush=True)
 
-    for response in backend.stream_generate(prompt, options, images):
+    for response in backend.stream_generate(prompt, options, images, prompt_cache=prompt_cache):
         print(response.text.replace("\0", ""), end="", flush=True)
 
     print("\n", end="\0", flush=True)
@@ -33,6 +34,7 @@ def handle_chat(
     images: list | None = None,
     max_image_size: int = 768,
     reasoning_effort: str | None = None,
+    cache_id: str | None = None,
 ) -> None:
     """chat API の処理"""
     if options is None:
@@ -78,9 +80,11 @@ def handle_chat(
         )
         return
 
+    prompt_cache = backend.cache_get(cache_id) if cache_id else None
+
     if not supports_chat_template(tokenizer):
         prompt = generate_merged_prompt(messages, capabilities)
-        _stream_to_stdout(backend, prompt, options, primer=primer)
+        _stream_to_stdout(backend, prompt, options, primer=primer, prompt_cache=prompt_cache)
         return
 
     add_generation_prompt = True
@@ -134,4 +138,4 @@ def handle_chat(
 
     final_options = dict(options)
     final_options.pop("trust_remote_code", None)
-    _stream_to_stdout(backend, prompt, final_options, primer=primer)
+    _stream_to_stdout(backend, prompt, final_options, primer=primer, prompt_cache=prompt_cache)

--- a/packages/driver/src/mlx-ml/python/handlers/completion.py
+++ b/packages/driver/src/mlx-ml/python/handlers/completion.py
@@ -12,10 +12,13 @@ def handle_completion(
     options: dict | None = None,
     images: list | None = None,
     max_image_size: int = 768,
+    cache_id: str | None = None,
 ) -> None:
     """completion API の処理"""
     if options is None:
         options = {}
+
+    prompt_cache = backend.cache_get(cache_id) if cache_id else None
 
     final_options = dict(options)
     if images:
@@ -28,7 +31,7 @@ def handle_completion(
         else:
             sys.stderr.write(f"--- prompt\n{prompt}\n")
 
-    for response in backend.stream_generate(prompt, final_options, images):
+    for response in backend.stream_generate(prompt, final_options, images, prompt_cache=prompt_cache):
         print(response.text.replace("\0", ""), end="", flush=True)
 
     print("\n", end="\0", flush=True)

--- a/packages/driver/src/mlx-ml/python/server.py
+++ b/packages/driver/src/mlx-ml/python/server.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 from backends.base import ModelBackend
-from handlers import handle_capabilities, handle_chat, handle_completion, handle_format_test
+from handlers import handle_cache_prefill, handle_cache_delete, handle_capabilities, handle_chat, handle_completion, handle_format_test
 
 
 MAX_READ_LINES = 10000
@@ -57,6 +57,23 @@ class Server:
                     return
                 handle_format_test(self.backend, self.capabilities, messages, req.get('options', {}), req.get('tools'))
 
+            elif method == 'cache_prefill':
+                cache_id = req.get('cache_id')
+                messages = req.get('messages')
+                if not cache_id or not messages:
+                    sys.stderr.write("Error: 'cache_id' and 'messages' fields are required for cache_prefill\n")
+                    print('\n', end='\0', flush=True)
+                    return
+                handle_cache_prefill(self.backend, self.capabilities, cache_id, messages)
+
+            elif method == 'cache_delete':
+                cache_id = req.get('cache_id')
+                if not cache_id:
+                    sys.stderr.write("Error: 'cache_id' field is required for cache_delete\n")
+                    print('\n', end='\0', flush=True)
+                    return
+                handle_cache_delete(self.backend, cache_id)
+
             elif method == 'chat':
                 messages = req.get('messages')
                 if not messages:
@@ -73,6 +90,7 @@ class Server:
                     images=req.get('images', []),
                     max_image_size=req.get('maxImageSize', 768),
                     reasoning_effort=req.get('reasoning_effort'),
+                    cache_id=req.get('cache_id'),
                 )
 
             elif method == 'completion':
@@ -88,6 +106,7 @@ class Server:
                     options=req.get('options', {}),
                     images=images if images else None,
                     max_image_size=req.get('maxImageSize', 768),
+                    cache_id=req.get('cache_id'),
                 )
 
             else:


### PR DESCRIPTION
## Summary
- `MlxCacheController`を新規実装（`PromptCacheController`インターフェース準拠）
- Python側に`make_prompt_cache`によるKVキャッシュ構築・保持・利用機構を追加
- `MlxDriver.executeQuery()`で`partitionPrompt()`によるcacheable/volatile分離→プレフィル→cacheId付きクエリを統合

## 設計
- **TS側が厚い**: キャッシュ判定（`partitionPrompt`）、重複検知（SHA-256ハッシュ）、inflight coalescing、ライフサイクル管理をTS側で実施
- **Python側は薄い**: TS指示に従い`cache_prefill`/`cache_delete`/`cache_get`を実行するだけ
- cacheHint情報がElement段階で生きているうちに処理を分岐し、フォーマット後の自動検出には頼らない

## 変更ファイル
### 新規
- `mlx-cache-controller.ts` — MlxCacheController実装
- `mlx-cache-controller.test.ts` — 10テスト
- `python/handlers/cache.py` — cache_prefill/cache_deleteハンドラ

### 変更（Python）
- `backends/base.py` — cache_prefill/cache_delete/cache_getインターフェース
- `backends/mlx_lm.py` — KVキャッシュ実装、stream_generateにprompt_cache引数
- `handlers/chat.py`, `handlers/completion.py` — cache_id対応
- `server.py` — cache系コマンドディスパッチ

### 変更（TypeScript）
- `process/types.ts` — cache系リクエスト/レスポンス型
- `process/queue.ts` — cache系キューメソッド
- `process/index.ts` — cachePrefill/cacheDeleteメソッド
- `mlx-driver.ts` — cacheController統合

## Test plan
- [x] MlxCacheControllerユニットテスト（10テスト通過）
- [x] 既存cache-utils/GoogleGenAI cacheテスト通過
- [x] 型チェック通過
- [ ] MLXモデルでの統合テスト（要実機）

🤖 Generated with [Claude Code](https://claude.com/claude-code)