### PR TITLE
feat: MlxCacheController外部注入化 + キャッシュディレクトリ外部指定

### DIFF
--- a/.changeset/mlx-cache-controller-injection.md
+++ b/.changeset/mlx-cache-controller-injection.md
@@ -1,0 +1,6 @@
+---
+"@modular-prompt/driver": minor
+"@modular-prompt/simple-chat": minor
+---
+
+MlxCacheControllerを外部注入パターンに統一。enableCachingフラグを廃止し、cacheController外部注入に変更。キャッシュディレクトリの外部指定に対応し、simple-chatプロファイルからcacheDirで設定可能に。

--- a/packages/driver/src/driver-registry/config-based-factory.ts
+++ b/packages/driver/src/driver-registry/config-based-factory.ts
@@ -11,6 +11,7 @@ import type { ModelSpec, MlxModelDriverOptions } from './types.js';
 
 // 個別ドライバーのインポート
 import { MlxDriver } from '../mlx-ml/mlx-driver.js';
+import { MlxCacheController } from '../mlx-ml/mlx-cache-controller.js';
 import { OpenAIDriver } from '../openai/openai-driver.js';
 import { AnthropicDriver } from '../anthropic/anthropic-driver.js';
 import { VertexAIDriver } from '../vertexai/vertexai-driver.js';
@@ -102,12 +103,16 @@ export function registerFactories(
   // MLX Driver Factory
   registry.registerFactory('mlx', (spec) => {
     const driverOpts = spec.driverOptions as MlxModelDriverOptions | undefined;
+    const cacheController = driverOpts?.cacheDir
+      ? new MlxCacheController({ cacheDir: driverOpts.cacheDir })
+      : undefined;
     return new MlxDriver({
       model: spec.model,
       defaultOptions: mergeDefaults(spec),
       textOnly: driverOpts?.textOnly,
       maxImageSize: driverOpts?.maxImageSize,
       drafterModel: driverOpts?.drafterModel,
+      cacheController,
     });
   });
 

--- a/packages/driver/src/driver-registry/types.ts
+++ b/packages/driver/src/driver-registry/types.ts
@@ -50,6 +50,8 @@ export interface MlxModelDriverOptions {
   maxImageSize?: number;
   /** Speculative decoding用のdrafter model名 */
   drafterModel?: string;
+  /** KVキャッシュディレクトリ。指定するとプロンプトキャッシュが有効になる */
+  cacheDir?: string;
 }
 
 /** ドライバー固有オプションのunion（将来拡張） */

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
@@ -147,6 +147,28 @@ describe('MlxCacheController', () => {
         instructions: [{ type: 'text', content: 'test' }],
       })).rejects.toThrow('MlxCacheController is not bound to a process');
     });
+
+    it('should produce different cache keys for different formatterOptions', async () => {
+      const controllerA = new MlxCacheController();
+      controllerA.bind(mockProcess as any, { specialTokens: { bosToken: '<s>' } });
+
+      const controllerB = new MlxCacheController();
+      controllerB.bind(mockProcess as any, { specialTokens: { bosToken: '<bos>' } });
+
+      const params = {
+        model: 'test-model',
+        instructions: [{ type: 'text' as const, content: 'prompt' }],
+      };
+
+      const handleA = await controllerA.prepare(params);
+      const handleB = await controllerB.prepare(params);
+
+      expect(handleA.ref).not.toBe(handleB.ref);
+      expect(mockProcess.cachePrefill).toHaveBeenCalledTimes(2);
+
+      await controllerA.close();
+      await controllerB.close();
+    });
   });
 
   describe('invalidate', () => {
@@ -244,6 +266,15 @@ describe('MlxCacheController', () => {
       });
       expect(handle.ref).toBe('');
       expect(handle.includes.instructions).toBe(false);
+    });
+  });
+
+  describe('bind', () => {
+    it('should throw when bind is called twice', () => {
+      const ctrl = new MlxCacheController();
+      ctrl.bind(mockProcess as any, {});
+      expect(() => ctrl.bind(mockProcess as any, {}))
+        .toThrow('MlxCacheController is already bound to a process');
     });
   });
 

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
@@ -3,6 +3,7 @@ import { MlxCacheController } from './mlx-cache-controller.js';
 
 vi.mock('node:fs', () => ({
   rmSync: vi.fn(),
+  existsSync: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock('node:fs/promises', () => ({
@@ -12,6 +13,7 @@ vi.mock('node:fs/promises', () => ({
 }));
 
 import { unlink, mkdir, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 
 function createMockProcess() {
   return {
@@ -26,7 +28,8 @@ describe('MlxCacheController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProcess = createMockProcess();
-    controller = new MlxCacheController(mockProcess as any);
+    controller = new MlxCacheController();
+    controller.bind(mockProcess as any, {});
   });
 
   afterEach(async () => {
@@ -136,6 +139,14 @@ describe('MlxCacheController', () => {
       expect(Array.isArray(messages)).toBe(true);
       expect(messages.length).toBeGreaterThan(0);
     });
+
+    it('should throw when not bound to a process', async () => {
+      const unboundController = new MlxCacheController();
+      await expect(unboundController.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'test' }],
+      })).rejects.toThrow('MlxCacheController is not bound to a process');
+    });
   });
 
   describe('invalidate', () => {
@@ -233,6 +244,52 @@ describe('MlxCacheController', () => {
       });
       expect(handle.ref).toBe('');
       expect(handle.includes.instructions).toBe(false);
+    });
+  });
+
+  describe('external cacheDir', () => {
+    let externalController: MlxCacheController;
+
+    beforeEach(() => {
+      externalController = new MlxCacheController({ cacheDir: '/custom/cache/dir' });
+      externalController.bind(mockProcess as any, {});
+    });
+
+    afterEach(async () => {
+      await externalController.close();
+    });
+
+    it('should use specified cacheDir for cache paths', async () => {
+      const handle = await externalController.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'test' }],
+      });
+
+      expect(handle.ref).toMatch(/^\/custom\/cache\/dir\//);
+      expect(handle.ref).toMatch(/\.safetensors$/);
+    });
+
+    it('should not remove directory on close', async () => {
+      await externalController.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'test' }],
+      });
+
+      await externalController.close();
+      expect(rm).not.toHaveBeenCalled();
+    });
+
+    it('should skip prefill when cache file already exists', async () => {
+      vi.mocked(existsSync).mockReturnValueOnce(true);
+
+      const handle = await externalController.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'test' }],
+      });
+
+      expect(handle.ref).toMatch(/\.safetensors$/);
+      expect(handle.includes.instructions).toBe(true);
+      expect(mockProcess.cachePrefill).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.ts
@@ -1,35 +1,66 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { rmSync } from 'node:fs';
+import { rmSync, existsSync } from 'node:fs';
 import { unlink, mkdir, rm } from 'node:fs/promises';
 import type { PromptCacheController, CachePrepareParams, CacheHandle } from '../cache-controller.js';
 import type { FormatterOptions } from '../formatter/types.js';
 import { formatPromptAsMessages } from '../formatter/converter.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
 import type { MlxProcess } from './process/index.js';
+import type { MlxMessage } from './process/index.js';
 import { convertMessages } from './mlx-message-utils.js';
 import { Logger } from '@modular-prompt/utils';
 
 const logger = new Logger({ prefix: 'MLX', context: 'cache' });
 
+export interface MlxCacheControllerOptions {
+  /** 固定キャッシュディレクトリ。指定時はauto-cleanupが無効になる */
+  cacheDir?: string;
+}
+
 export class MlxCacheController implements PromptCacheController {
   private cacheByHash = new Map<string, CacheHandle>();
   private inflightRequests = new Map<string, Promise<CacheHandle>>();
+  private process?: MlxProcess;
   private cacheDir: string;
+  private managedDir: boolean;
   private cacheDirReady = false;
   private closed = false;
-  private cleanupHandler: () => void;
+  private bound = false;
+  private cleanupHandler?: () => void;
+  private messageProcessor?: (messages: MlxMessage[]) => MlxMessage[];
+  private formatterOptions: FormatterOptions;
 
-  constructor(
-    private process: MlxProcess,
-    private formatterOptions: FormatterOptions = {},
-  ) {
-    this.cacheDir = join(tmpdir(), `mlx-prompt-cache-${randomBytes(6).toString('hex')}`);
-    this.cleanupHandler = () => {
-      try { rmSync(this.cacheDir, { recursive: true, force: true }); } catch { /* best-effort */ }
-    };
-    globalThis.process.on('exit', this.cleanupHandler);
+  constructor(options?: MlxCacheControllerOptions) {
+    this.formatterOptions = {};
+    if (options?.cacheDir) {
+      this.cacheDir = options.cacheDir;
+      this.managedDir = false;
+    } else {
+      this.cacheDir = '';
+      this.managedDir = true;
+    }
+  }
+
+  bind(
+    process: MlxProcess,
+    formatterOptions: FormatterOptions,
+    messageProcessor?: (messages: MlxMessage[]) => MlxMessage[],
+  ): void {
+    this.process = process;
+    this.formatterOptions = formatterOptions;
+    this.messageProcessor = messageProcessor;
+    if (!this.cacheDir) {
+      this.cacheDir = join(tmpdir(), `mlx-prompt-cache-${randomBytes(6).toString('hex')}`);
+    }
+    if (this.managedDir) {
+      this.cleanupHandler = () => {
+        try { rmSync(this.cacheDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+      };
+      globalThis.process.on('exit', this.cleanupHandler);
+    }
+    this.bound = true;
   }
 
   private async ensureCacheDir(): Promise<void> {
@@ -54,6 +85,9 @@ export class MlxCacheController implements PromptCacheController {
   }
 
   async prepare(params: CachePrepareParams): Promise<CacheHandle> {
+    if (!this.bound) {
+      throw new Error('MlxCacheController is not bound to a process');
+    }
     if (params.tools && params.tools.length > 0) {
       throw new Error('MlxCacheController does not support tool-aware caching');
     }
@@ -99,27 +133,36 @@ export class MlxCacheController implements PromptCacheController {
       return MlxCacheController.EMPTY_HANDLE;
     }
 
-    const prefillPrompt: CompiledPrompt = {
-      instructions: params.instructions || [],
-      data: params.data || [],
-      output: [],
-    };
-
-    const chatMessages = formatPromptAsMessages(prefillPrompt, this.formatterOptions);
-    const mlxMessages = convertMessages(chatMessages);
-
     const cachePath = this.generateCachePath(cacheKey);
-    logger.debug('prefill', cachePath);
-    try {
-      await this.process.cachePrefill(cachePath, mlxMessages);
-    } catch (e) {
-      logger.verbose('prefill failed, skipping cache:', e instanceof Error ? e.message : String(e));
-      return MlxCacheController.EMPTY_HANDLE;
-    }
 
-    if (this.closed) {
-      await unlink(cachePath).catch(() => {});
-      return MlxCacheController.EMPTY_HANDLE;
+    // 既存キャッシュファイルがあればprefillをスキップ
+    if (existsSync(cachePath)) {
+      logger.verbose('reusing existing cache file', cacheKey.slice(0, 12));
+    } else {
+      const prefillPrompt: CompiledPrompt = {
+        instructions: params.instructions || [],
+        data: params.data || [],
+        output: [],
+      };
+
+      const chatMessages = formatPromptAsMessages(prefillPrompt, this.formatterOptions);
+      let mlxMessages = convertMessages(chatMessages);
+      if (this.messageProcessor) {
+        mlxMessages = this.messageProcessor(mlxMessages);
+      }
+
+      logger.debug('prefill', cachePath);
+      try {
+        await this.process!.cachePrefill(cachePath, mlxMessages);
+      } catch (e) {
+        logger.verbose('prefill failed, skipping cache:', e instanceof Error ? e.message : String(e));
+        return MlxCacheController.EMPTY_HANDLE;
+      }
+
+      if (this.closed) {
+        await unlink(cachePath).catch(() => {});
+        return MlxCacheController.EMPTY_HANDLE;
+      }
     }
 
     const handle: CacheHandle = {
@@ -158,8 +201,12 @@ export class MlxCacheController implements PromptCacheController {
     ]);
     this.inflightRequests.clear();
     this.cacheByHash.clear();
-    await rm(this.cacheDir, { recursive: true, force: true }).catch(() => {});
+    if (this.managedDir && this.cacheDir) {
+      await rm(this.cacheDir, { recursive: true, force: true }).catch(() => {});
+    }
     this.cacheDirReady = false;
-    globalThis.process.removeListener('exit', this.cleanupHandler);
+    if (this.cleanupHandler) {
+      globalThis.process.removeListener('exit', this.cleanupHandler);
+    }
   }
 }

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.ts
@@ -48,6 +48,9 @@ export class MlxCacheController implements PromptCacheController {
     formatterOptions: FormatterOptions,
     messageProcessor?: (messages: MlxMessage[]) => MlxMessage[],
   ): void {
+    if (this.bound) {
+      throw new Error('MlxCacheController is already bound to a process');
+    }
     this.process = process;
     this.formatterOptions = formatterOptions;
     this.messageProcessor = messageProcessor;
@@ -76,6 +79,9 @@ export class MlxCacheController implements PromptCacheController {
     }
     if (params.data && params.data.length > 0) {
       payload.data = params.data;
+    }
+    if (this.formatterOptions && Object.keys(this.formatterOptions).length > 0) {
+      payload.formatterOptions = this.formatterOptions;
     }
     return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
   }

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -70,8 +70,8 @@ export interface MlxDriverConfig {
   textOnly?: boolean;
   /** Speculative decoding用のdrafter model名 */
   drafterModel?: string;
-  /** KVキャッシュによるプロンプトプレフィルを有効化（LMバックエンドのみ） */
-  enableCaching?: boolean;
+  /** 外部で生成したキャッシュコントローラー */
+  cacheController?: PromptCacheController;
 }
 
 /**
@@ -123,7 +123,7 @@ export class MlxDriver implements AIDriver {
   private maxImageSize: number;
   private queryLogger = new QueryLogger('MLX');
   private cacheController?: PromptCacheController;
-  private enableCaching: boolean;
+  private cacheControllerBound = false;
 
   get defaultOptions(): Partial<MlxMlModelOptions> {
     return this._defaultOptions;
@@ -140,7 +140,7 @@ export class MlxDriver implements AIDriver {
     this.maxImageSize = config.maxImageSize ?? 768;
     this.process = new MlxProcess(config.model, { textOnly: config.textOnly, drafterModel: config.drafterModel });
     this.modelProcessor = createModelSpecificProcessor(config.model);
-    this.enableCaching = config.enableCaching ?? false;
+    this.cacheController = config.cacheController;
     if (config.drafterModel) {
       this.queryLogger.log.info(`Drafter model: ${config.drafterModel}`);
     }
@@ -169,19 +169,14 @@ export class MlxDriver implements AIDriver {
           modelKind: this.runtimeInfo.model_kind,
         });
 
-        // Initialize cache controller after runtime info is available
-        // Skip: VLM, models requiring system message merge, models with model-specific chat processors,
-        // models requiring user-last (cacheable prefix may end in assistant message)
-        if (this.enableCaching && !this.cacheController
-          && this.runtimeInfo.model_kind !== 'vlm'
-          && !this.runtimeInfo.chat_restrictions?.single_system_at_start
-          && !this.runtimeInfo.chat_restrictions?.requires_user_last
-          && !this.modelProcessor.hasChatProcessor()
-        ) {
-          this.cacheController = new MlxCacheController(
+        // Bind cache controller if provided and not yet bound
+        if (this.cacheController instanceof MlxCacheController && !this.cacheControllerBound) {
+          this.cacheController.bind(
             this.process,
             this.formatterOptions,
+            (msgs) => this.modelProcessor.applyChatSpecificProcessing(msgs),
           );
+          this.cacheControllerBound = true;
         }
       } catch (error) {
         this.queryLogger.log.error('Failed to get MLX runtime info:', error instanceof Error ? error.message : String(error));

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -171,12 +171,17 @@ export class MlxDriver implements AIDriver {
 
         // Bind cache controller if provided and not yet bound
         if (this.cacheController instanceof MlxCacheController && !this.cacheControllerBound) {
-          this.cacheController.bind(
-            this.process,
-            this.formatterOptions,
-            (msgs) => this.modelProcessor.applyChatSpecificProcessing(msgs),
-          );
-          this.cacheControllerBound = true;
+          if (this.runtimeInfo.model_kind === 'vlm') {
+            this.queryLogger.log.info('VLM models do not support prompt caching — cacheController disabled');
+            this.cacheController = undefined;
+          } else {
+            this.cacheController.bind(
+              this.process,
+              this.formatterOptions,
+              (msgs) => this.modelProcessor.applyChatSpecificProcessing(msgs),
+            );
+            this.cacheControllerBound = true;
+          }
         }
       } catch (error) {
         this.queryLogger.log.error('Failed to get MLX runtime info:', error instanceof Error ? error.message : String(error));

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -170,6 +170,9 @@ export class MlxDriver implements AIDriver {
         });
 
         // Bind cache controller if provided and not yet bound
+        // NOTE: instanceof guard means VLM check only covers MlxCacheController.
+        // A custom PromptCacheController on a VLM model would bypass this — add a
+        // model-kind guard here if another implementation is introduced.
         if (this.cacheController instanceof MlxCacheController && !this.cacheControllerBound) {
           if (this.runtimeInfo.model_kind === 'vlm') {
             this.queryLogger.log.info('VLM models do not support prompt caching — cacheController disabled');

--- a/packages/driver/src/mlx-ml/python/backends/mlx_lm.py
+++ b/packages/driver/src/mlx-ml/python/backends/mlx_lm.py
@@ -65,9 +65,9 @@ class MlxLmBackend(ModelBackend):
         prompt_cache = make_prompt_cache(self.model)
         for _ in mlx_lm_stream_generate(
             self.model, self.tokenizer, prompt,
-            prompt_cache=prompt_cache, max_tokens=0,
+            prompt_cache=prompt_cache, max_tokens=1,
         ):
-            pass
+            break
         save_prompt_cache(cache_path, prompt_cache)
         sys.stderr.write(f"Cache created: {cache_path}\n")
         return {"cache_path": cache_path}

--- a/packages/driver/test/integration/mlx-cache.integration.test.ts
+++ b/packages/driver/test/integration/mlx-cache.integration.test.ts
@@ -1,0 +1,284 @@
+/**
+ * MLX Driver KVキャッシュ統合テスト
+ *
+ * enableCaching: true で実MLXモデルに対してキャッシュが正常動作することを検証する。
+ * PromptModule + compile を使用してプロンプトを構築（simple-chatパターン）。
+ *
+ * - テストケース群1: 会話履歴（messages）のキャッシュ
+ *   静的な会話履歴はcacheable prefix、動的な最新メッセージはvolatile
+ * - テストケース群2: state/materials構成でのキャッシュ
+ *   state (Current State section) がdata内のcacheable prefixを遮断する挙動
+ *
+ * test-drivers.yaml に mlx.nativeModel の設定が必要。
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { MlxDriver } from '../../src/mlx-ml/mlx-driver.js';
+import { MlxCacheController } from '../../src/mlx-ml/mlx-cache-controller.js';
+import { hasDriverConfig, getDriverConfig } from './test-config.js';
+import type { PromptModule } from '@modular-prompt/core';
+import { compile, createContext } from '@modular-prompt/core';
+import { extractCacheablePrefix } from '../../src/cache-utils.js';
+import { platform } from 'os';
+
+const isMacOS = platform() === 'darwin';
+
+interface ChatContext {
+  userMessage: string;
+}
+
+interface DocContext {
+  stateInfo: string;
+  userMessage: string;
+}
+
+describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Cache Integration', () => {
+  let driver: MlxDriver;
+  let cacheController: MlxCacheController;
+  let model: string;
+
+  beforeAll(async () => {
+    const config = getDriverConfig('mlx')!;
+    model = config.nativeModel!;
+
+    cacheController = new MlxCacheController();
+    driver = new MlxDriver({ model, cacheController });
+
+    const warmup: PromptModule = {
+      messages: [{ type: 'message', role: 'user', content: 'hello' }],
+    };
+    await driver.query(compile(warmup), { maxTokens: 1 });
+  }, 120_000);
+
+  afterAll(async () => {
+    await driver.close();
+  });
+
+  // ================================================================
+  // テストケース群1: MessageElementsのキャッシュ
+  // simple-chatパターン: instructions + messages (static history + dynamic latest)
+  //
+  // compile が静的要素に cacheHint: 'static'、DynamicContent由来の要素に
+  // cacheHint: 'contextual' を自動付与する。extractCacheablePrefix は
+  // 'contextual' で途切れるため、静的な会話履歴がキャッシュ対象になる。
+  // ================================================================
+  describe('MessageElements caching', () => {
+    const chatModule: PromptModule<ChatContext> = {
+      createContext: () => ({ userMessage: '' }),
+      instructions: ['You are a helpful assistant. Respond concisely in one sentence.'],
+      messages: [
+        { type: 'message', role: 'user', content: 'What is TypeScript?' },
+        { type: 'message', role: 'assistant', content: 'TypeScript is a typed superset of JavaScript that adds static type checking.' },
+        { type: 'message', role: 'user', content: 'What about its type system?' },
+        { type: 'message', role: 'assistant', content: 'It uses structural typing with interfaces, generics, and union types.' },
+        (ctx) => ({ type: 'message' as const, role: 'user' as const, content: ctx.userMessage }),
+      ],
+    };
+
+    it('should cache static history and handle different latest messages', async () => {
+      const ctx1 = createContext(chatModule);
+      ctx1.userMessage = 'How do I define an interface?';
+      const compiled1 = compile(chatModule, ctx1);
+
+      // キャッシュ構造の検証: instructions + Messages section + 4つの静的メッセージ
+      const prefix = extractCacheablePrefix(compiled1);
+      expect(prefix.instructions.length).toBeGreaterThan(0);
+      expect(prefix.data.length).toBe(5); // Messages SectionElement + 4 static MessageElements
+
+      // cacheControllerのprepare()でhandle.includesを検証
+      const handle = await cacheController.prepare({
+        model,
+        instructions: prefix.instructions,
+        data: prefix.data,
+      });
+      expect(handle.includes.instructions).toBe(true);
+      expect(handle.includes.dataElementCount).toBe(5);
+      expect(handle.includes.tools).toBe(false);
+
+      const result1 = await driver.query(compiled1, { maxTokens: 100, temperature: 0 });
+      expect(result1.content).toBeTruthy();
+      expect(result1.finishReason).toBeDefined();
+
+      // 同じ会話履歴で異なる最新メッセージ → キャッシュ再利用
+      const ctx2 = createContext(chatModule);
+      ctx2.userMessage = 'What are mapped types?';
+      const result2 = await driver.query(compile(chatModule, ctx2), { maxTokens: 100, temperature: 0 });
+      expect(result2.content).toBeTruthy();
+      expect(result2.finishReason).toBeDefined();
+
+      console.log('[cache-messages] result1:', result1.content?.slice(0, 80));
+      console.log('[cache-messages] result2:', result2.content?.slice(0, 80));
+    }, 60_000);
+
+    it('should handle conversation history growth (cache key changes)', async () => {
+      const extendedModule: PromptModule<ChatContext> = {
+        createContext: () => ({ userMessage: '' }),
+        instructions: ['You are a helpful assistant. Respond concisely in one sentence.'],
+        messages: [
+          { type: 'message', role: 'user', content: 'What is TypeScript?' },
+          { type: 'message', role: 'assistant', content: 'TypeScript is a typed superset of JavaScript that adds static type checking.' },
+          { type: 'message', role: 'user', content: 'What about its type system?' },
+          { type: 'message', role: 'assistant', content: 'It uses structural typing with interfaces, generics, and union types.' },
+          { type: 'message', role: 'user', content: 'Can you explain generics?' },
+          { type: 'message', role: 'assistant', content: 'Generics let you write reusable code that works with multiple types.' },
+          (ctx) => ({ type: 'message' as const, role: 'user' as const, content: ctx.userMessage }),
+        ],
+      };
+
+      const ctx = createContext(extendedModule);
+      ctx.userMessage = 'Show me a generic function example.';
+      const compiled = compile(extendedModule, ctx);
+
+      // 履歴が増えた分、キャッシュ対象のdata要素も増える
+      const prefix = extractCacheablePrefix(compiled);
+      expect(prefix.data.length).toBe(7); // Messages SectionElement + 6 static MessageElements
+
+      const result = await driver.query(compiled, { maxTokens: 100, temperature: 0 });
+      expect(result.content).toBeTruthy();
+      console.log('[cache-messages-extended]:', result.content?.slice(0, 80));
+    }, 60_000);
+
+    it('should work with streamQuery', async () => {
+      const ctx = createContext(chatModule);
+      ctx.userMessage = 'What is a union type in one sentence?';
+      const { stream, result } = await driver.streamQuery(
+        compile(chatModule, ctx),
+        { maxTokens: 100, temperature: 0 },
+      );
+
+      const chunks: string[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      const queryResult = await result;
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(queryResult.content).toBeTruthy();
+      console.log('[cache-messages-stream]:', queryResult.content?.slice(0, 80));
+    }, 60_000);
+  });
+
+  // ================================================================
+  // テストケース群2: State-aware caching
+  //
+  // STANDARD_SECTIONSの配置順: state → inputs → materials → chunks → messages
+  // state (title: 'Current State') は extractCacheablePrefix で非キャッシュと判定
+  // されるため、data 内の cacheable prefix は state で遮断される。
+  //
+  // stateなしの場合は materials が cacheable prefix に含まれる。
+  // ================================================================
+  describe('State-aware caching', () => {
+    const docModule: PromptModule<DocContext> = {
+      createContext: () => ({ stateInfo: '', userMessage: '' }),
+      instructions: [
+        'You are a documentation assistant. Answer questions based on the provided reference materials. Respond concisely.',
+      ],
+      materials: [
+        { type: 'material', id: 'doc1', title: 'API Reference',
+          content: 'The createUser function accepts a name (string) and age (number). It returns a User object with an auto-generated id.' },
+        { type: 'material', id: 'doc2', title: 'Best Practices',
+          content: 'Always validate input parameters before calling createUser. Use TypeScript strict mode for better type safety.' },
+      ],
+      state: [(ctx) => ctx.stateInfo],
+      messages: [
+        (ctx) => ({ type: 'message' as const, role: 'user' as const, content: ctx.userMessage }),
+      ],
+    };
+
+    it('should block data prefix at state section while queries still work', async () => {
+      const ctx1 = createContext(docModule);
+      ctx1.stateInfo = 'User is reading the API reference';
+      ctx1.userMessage = 'What parameters does createUser accept?';
+      const compiled1 = compile(docModule, ctx1);
+
+      // state が data 先頭に来るため、data の cacheable prefix は空
+      const prefix = extractCacheablePrefix(compiled1);
+      expect(prefix.instructions.length).toBeGreaterThan(0);
+      expect(prefix.data.length).toBe(0);
+
+      // stateがprefixを遮断するため、キャッシュはinstructionsのみ
+      const handle = await cacheController.prepare({
+        model,
+        instructions: prefix.instructions,
+        data: prefix.data,
+      });
+      expect(handle.includes.instructions).toBe(true);
+      expect(handle.includes.dataElementCount).toBe(0);
+
+      const result1 = await driver.query(compiled1, { maxTokens: 100, temperature: 0 });
+      expect(result1.content).toBeTruthy();
+
+      const ctx2 = createContext(docModule);
+      ctx2.stateInfo = 'User is reading best practices';
+      ctx2.userMessage = 'What should I do before calling createUser?';
+      const result2 = await driver.query(compile(docModule, ctx2), { maxTokens: 100, temperature: 0 });
+      expect(result2.content).toBeTruthy();
+
+      console.log('[cache-state] result1:', result1.content?.slice(0, 80));
+      console.log('[cache-state] result2:', result2.content?.slice(0, 80));
+    }, 60_000);
+
+    it('should include materials in cacheable prefix when state is absent', async () => {
+      const noStateModule: PromptModule<DocContext> = {
+        createContext: () => ({ stateInfo: '', userMessage: '' }),
+        instructions: [
+          'You are a documentation assistant. Answer questions based on the provided reference materials. Respond concisely.',
+        ],
+        materials: [
+          { type: 'material', id: 'doc1', title: 'API Reference',
+            content: 'The createUser function accepts a name (string) and age (number). It returns a User object with an auto-generated id.' },
+          { type: 'material', id: 'doc2', title: 'Best Practices',
+            content: 'Always validate input parameters before calling createUser. Use TypeScript strict mode for better type safety.' },
+        ],
+        messages: [
+          (ctx) => ({ type: 'message' as const, role: 'user' as const, content: ctx.userMessage }),
+        ],
+      };
+
+      const ctx = createContext(noStateModule);
+      ctx.userMessage = 'Summarize the API reference.';
+      const compiled = compile(noStateModule, ctx);
+
+      // stateなし → materials が cacheable prefix に入る
+      const prefix = extractCacheablePrefix(compiled);
+      expect(prefix.instructions.length).toBeGreaterThan(0);
+      expect(prefix.data.length).toBe(4); // Prepared Materials SectionElement + 2 MaterialElements + Messages SectionElement
+
+      const result = await driver.query(compiled, { maxTokens: 100, temperature: 0 });
+      expect(result.content).toBeTruthy();
+      console.log('[cache-no-state]:', result.content?.slice(0, 80));
+    }, 60_000);
+
+    it('should break cacheable prefix when guidelines have dynamic content', async () => {
+      // DynamicContent由来のguidelinesセクションは cacheHint: 'contextual' になり、
+      // instructions 内の cacheable prefix を遮断する
+      const dynamicGuidelinesModule: PromptModule<DocContext> = {
+        createContext: () => ({ stateInfo: '', userMessage: '' }),
+        instructions: ['You are a helpful assistant.'],
+        guidelines: [
+          () => 'Current session context: user is testing.',
+        ],
+        materials: [
+          { type: 'material', id: 'doc1', title: 'API Reference',
+            content: 'The createUser function accepts a name (string) and age (number).' },
+        ],
+        messages: [
+          (ctx) => ({ type: 'message' as const, role: 'user' as const, content: ctx.userMessage }),
+        ],
+      };
+
+      const ctx = createContext(dynamicGuidelinesModule);
+      ctx.userMessage = 'What is createUser?';
+      const compiled = compile(dynamicGuidelinesModule, ctx);
+
+      // guidelines が contextual → instructions prefix が途切れる → data は prefix に入らない
+      const prefix = extractCacheablePrefix(compiled);
+      expect(prefix.instructions.length).toBe(1); // Instructions section のみ
+      expect(prefix.data.length).toBe(0);
+
+      const result = await driver.query(compiled, { maxTokens: 100, temperature: 0 });
+      expect(result.content).toBeTruthy();
+      console.log('[cache-dynamic-guidelines]:', result.content?.slice(0, 80));
+    }, 60_000);
+  });
+});

--- a/packages/simple-chat/README.md
+++ b/packages/simple-chat/README.md
@@ -87,6 +87,9 @@ options:
   temperature: 0.7      # 生成の創造性（0.0-2.0）
   maxTokens: 4000      # 最大トークン数
   topP: 0.9            # トップP サンプリング
+
+# KVキャッシュ（MLX専用、オプション）
+cacheDir: ".cache/mlx-kv"  # プロンプトの静的部分をキャッシュして推論を高速化
 ```
 
 ### デフォルトプロファイル
@@ -163,6 +166,24 @@ options:
   temperature: 1.2  # 創造性を高めるため高めに設定
   maxTokens: 8000  # 長い文章生成に対応
 ```
+
+### KVキャッシュの活用（MLX専用）
+
+`cacheDir`を指定すると、プロンプトの静的部分（システムプロンプト、会話履歴、資料など）のKV状態をファイルに保存し、2回目以降の推論を高速化できます。
+
+```yaml
+model: "mlx-community/gemma-3-270m-it-qat-4bit"
+cacheDir: ".cache/mlx-kv"  # キャッシュファイルの保存先
+options:
+  temperature: 0.7
+  maxTokens: 4000
+```
+
+#### 特徴
+- MLXドライバー専用（他のプロバイダーでは無視されます）
+- 会話履歴や資料が多い場合に効果が大きい
+- キャッシュファイル（.safetensors）は手動管理（`rm -rf <cacheDir>`でクリア）
+- ディレクトリが存在しない場合は自動作成される
 
 ## 実装のポイント
 

--- a/packages/simple-chat/default-profile.yaml
+++ b/packages/simple-chat/default-profile.yaml
@@ -60,3 +60,7 @@ options:
 # resourceFiles:
 #   - ./knowledge.md
 #   - ./guidelines.txt
+
+# KVキャッシュ（MLX専用、オプション）
+# プロンプトの静的部分をキャッシュして推論を高速化
+# cacheDir: .cache/mlx-kv

--- a/packages/simple-chat/src/ai-chat.ts
+++ b/packages/simple-chat/src/ai-chat.ts
@@ -97,10 +97,11 @@ export async function createDriver(profile: DialogProfile): Promise<AIDriver> {
   registerFactories(registry, appConfig);
 
   const driverOptions =
-    (profile.textOnly || profile.drafterModel)
+    (profile.textOnly || profile.drafterModel || profile.cacheDir)
       ? {
           ...(profile.textOnly && { textOnly: true }),
           ...(profile.drafterModel && { drafterModel: profile.drafterModel }),
+          ...(profile.cacheDir && { cacheDir: profile.cacheDir }),
         }
       : undefined;
 

--- a/packages/simple-chat/src/types.ts
+++ b/packages/simple-chat/src/types.ts
@@ -26,6 +26,8 @@ export interface DialogProfile {
   textOnly?: boolean;
   /** Speculative decoding用のdrafter model名 */
   drafterModel?: string;
+  /** KVキャッシュディレクトリ。指定するとプロンプトキャッシュが有効になる */
+  cacheDir?: string;
   /** Options */
   options?: {
     /** Temperature (0.0-2.0) */


### PR DESCRIPTION
## Summary

- MlxDriverの`enableCaching`フラグを廃止し、GoogleGenAIDriverと同じ`cacheController`外部注入パターンに統一
- MlxCacheControllerにキャッシュディレクトリの外部指定機能を追加（永続キャッシュ・手動管理対応）
- simple-chatプロファイルから`cacheDir`でKVキャッシュを有効化可能に
- Python cache_prefillの`max_tokens=0`クラッシュを修正（mlx-lm 0.31.3バグ回避）
- MlxCacheControllerにmodelProcessor.applyChatSpecificProcessingを適用（single_system_at_start対応）

## 変更内容

### driverパッケージ
- `MlxCacheController`: コンストラクタ+`bind()`パターン、`messageProcessor`引数、外部`cacheDir`対応
- `MlxDriver`: `enableCaching: boolean` → `cacheController?: PromptCacheController`
- `MlxModelDriverOptions`: `cacheDir`フィールド追加
- MLXファクトリー: `cacheDir`指定時に`MlxCacheController`を自動生成
- Python `cache_prefill`: `max_tokens=0`→`1`に変更

### simple-chatパッケージ
- `DialogProfile`: `cacheDir`フィールド追加
- `createDriver`: `cacheDir`をドライバーオプションに伝搬

### テスト
- ユニットテスト19件（外部cacheDir含む）全パス
- 統合テスト6件（PromptModule+compileパターン、handle.includes検証）全パス

## 使い方

```yaml
# simple-chat プロファイル
cacheDir: .cache/mlx-kv
```

```typescript
// プログラム的に使用
const cacheController = new MlxCacheController({ cacheDir: '/path/to/cache' });
const driver = new MlxDriver({ model: 'mlx-community/...', cacheController });
```

## Test plan

- [x] ユニットテスト: `npx vitest run src/mlx-ml/mlx-cache-controller.test.ts` (19件)
- [x] 統合テスト: `npx vitest run test/integration/mlx-cache.integration.test.ts` (6件)
- [x] 型チェック: driver, simple-chat両パッケージ
- [ ] simple-chatでcacheDirを指定してキャッシュファイル生成を確認
- [ ] 2回目実行で既存キャッシュの再利用を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)