### PR TITLE
fix: --quietモードでモデル応答を表示

### DIFF
--- a/.changeset/simple-chat-quiet-output.md
+++ b/.changeset/simple-chat-quiet-output.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/simple-chat": patch
+---
+
+fix: --quietモードでモデルの応答コンテンツが表示されるように修正

--- a/packages/simple-chat/src/ai-chat.ts
+++ b/packages/simple-chat/src/ai-chat.ts
@@ -194,7 +194,8 @@ async function executeDirect(
 
   // Fallback to non-streaming
   const result = await driver.query(compiledPrompt, options);
-  logger.info(chalk.cyan('Assistant: ') + result.content);
+  logger.info(chalk.cyan('Assistant:'));
+  process.stdout.write(result.content + '\n\n');
   return result.content;
 }
 
@@ -213,7 +214,7 @@ async function executeDefault(
   const result = await defaultProcess(driver, chatModule, context, {
     queryOptions: options,
   });
-  logger.info(chalk.cyan('Assistant: ') + result.output);
+  process.stdout.write(result.output + '\n\n');
   return result.output;
 }
 
@@ -234,7 +235,7 @@ async function executeAgentic(
     maxTasks: processOptions?.maxTasks ?? 10,
     includeThinking: processOptions?.includeThinking ?? false,
   });
-  logger.info(chalk.cyan('Assistant: ') + result.output);
+  process.stdout.write(result.output + '\n\n');
   return result.output;
 }
 

--- a/packages/simple-chat/src/ai-chat.ts
+++ b/packages/simple-chat/src/ai-chat.ts
@@ -214,6 +214,7 @@ async function executeDefault(
   const result = await defaultProcess(driver, chatModule, context, {
     queryOptions: options,
   });
+  logger.info(chalk.cyan('Assistant:'));
   process.stdout.write(result.output + '\n\n');
   return result.output;
 }
@@ -235,6 +236,7 @@ async function executeAgentic(
     maxTasks: processOptions?.maxTasks ?? 10,
     includeThinking: processOptions?.includeThinking ?? false,
   });
+  logger.info(chalk.cyan('Assistant:'));
   process.stdout.write(result.output + '\n\n');
   return result.output;
 }


### PR DESCRIPTION
## Summary
- `--quiet`モードで`logger.info()`経由の出力が全て抑制され、モデルの応答テキストまで表示されなかった問題を修正
- default/agenticモードの応答出力を`process.stdout.write()`に変更し、quietでも応答コンテンツは表示されるように
- directモード(non-streaming)も同様に統一

## Test plan
- [ ] `--quiet`付きでdefault/agenticモードを実行し、モデル応答が表示されることを確認
- [ ] `--quiet`なしで「Assistant:」ラベル+応答が従来通り表示されることを確認
- [ ] directモード(streaming/non-streaming)でも同様に動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)