### PR TITLE
feat: CacheHandleにsupersedesフィールドを追加

### DIFF
--- a/.changeset/cache-handle-supersedes.md
+++ b/.changeset/cache-handle-supersedes.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/driver": patch
+---
+
+feat: CacheHandleにsupersedesフィールドを追加。incrementalプリフィル時に置き換え元キャッシュのrefを返すことで、呼び出し側での古いキャッシュ削除を可能にした。

--- a/packages/driver/src/cache-controller.ts
+++ b/packages/driver/src/cache-controller.ts
@@ -19,6 +19,8 @@ export interface CacheHandle {
     dataElementCount: number;
     tools: boolean;
   };
+  /** ref of the cache that was replaced by incremental prefill */
+  supersedes?: string;
 }
 
 export interface PromptCacheController {

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
@@ -400,6 +400,39 @@ describe('MlxCacheController', () => {
       expect(basePath2).toBe(handle1.ref);
     });
 
+    it('should set supersedes to base cache ref on incremental prefill', async () => {
+      const handle1 = await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'system prompt' }],
+      });
+
+      vi.mocked(existsSync).mockImplementation((path: any) => {
+        return path === handle1.ref || path === handle1.ref + '.meta.json';
+      });
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        token_count: 100,
+        prefix_offsets: [100],
+        prefix_hashes: [testPrefixHash(100)],
+      }));
+
+      const handle2 = await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text' as const, content: 'system prompt' }],
+        data: [{ type: 'text' as const, content: 'message 1' }],
+      });
+
+      expect(handle2.supersedes).toBe(handle1.ref);
+    });
+
+    it('should leave supersedes undefined on fresh prefill', async () => {
+      const handle = await controller.prepare({
+        model: 'test-model',
+        instructions: [{ type: 'text', content: 'system prompt' }],
+      });
+
+      expect(handle.supersedes).toBeUndefined();
+    });
+
     it('should fall back to index when lastHandle file is missing', async () => {
       const externalController = new MlxCacheController({ cacheDir: '/cache' });
       externalController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.ts
@@ -546,6 +546,7 @@ export class MlxCacheController implements PromptCacheController {
 
     const cachePath = this.generateCachePath(cacheKey);
     const elementHashes = this.computeElementHashes(params);
+    let supersededRef: string | undefined;
 
     // Disk hit check (exact same cache already exists)
     if (existsSync(cachePath) && existsSync(cachePath + '.meta.json') && this.readMetaTokenCount(cachePath) > 0) {
@@ -643,6 +644,7 @@ export class MlxCacheController implements PromptCacheController {
       if (base) {
         this.stats.incremental++;
         this.stats.prefillReusedTokens += base.trimTokens ?? this.readMetaTokenCount(base.path);
+        supersededRef = base.path;
       } else {
         this.stats.fresh++;
       }
@@ -663,6 +665,7 @@ export class MlxCacheController implements PromptCacheController {
         dataElementCount: params.data?.length ?? 0,
         tools: (params.tools?.length ?? 0) > 0,
       },
+      supersedes: supersededRef,
     };
     this.cacheByHash.set(cacheKey, handle);
     this.updateLastCache(handle, elementHashes, params);


### PR DESCRIPTION
## Summary

- `CacheHandle` に `supersedes?: string` フィールドを追加
- incrementalプリフィル時に置き換え元キャッシュの `ref` を返すことで、呼び出し側での古いキャッシュ削除を可能にした
- gemma-4-26Bで1エントリ約600MBのKVキャッシュがディスクを圧迫する問題への対応

## 変更内容

- `packages/driver/src/cache-controller.ts`: `CacheHandle` に `supersedes` フィールド追加
- `packages/driver/src/mlx-ml/mlx-cache-controller.ts`: incrementalプリフィル成功時に `base.path` を設定
- テスト2件追加（incremental時にsupersedes設定 / fresh時にundefined）

## Test plan

- [x] ビルド通過
- [x] ユニットテスト全40件通過（`mlx-cache-controller.test.ts`）
- [ ] sprite-claude側での古いキャッシュ削除フローの動作確認

closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)