### PR TITLE
feat: cache-index.jsonのファイルロックとrelease()ヒント機構

### DIFF
--- a/.changeset/cache-lock-and-release-hint.md
+++ b/.changeset/cache-lock-and-release-hint.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/driver": minor
+---
+
+feat: cache-index.jsonのファイルロック機構を追加し、invalidate()をrelease()ヒント機構に置き換え。proper-lockfileによるアドバイザリロックで外部プロセスとの安全な共有を実現。release()はキャッシュの「もう要らない」ヒントを送るだけで、実際の削除はclose()時またはキャッシュクリーンプロセスに委ねる設計に変更。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ npm run lint
 - `@modular-prompt/driver` - AIモデルドライバー
   - OpenAI、Anthropic、VertexAI、GoogleGenAI、Ollama、MLX、vLLM
   - 統一インターフェースとストリーミングサポート
+  - プロンプトキャッシュ管理（PromptCacheController）
   - StreamResult型: stream（AsyncIterable<string>）+ result（Promise<QueryResult>）
 
 ### ユーティリティパッケージ

--- a/docs/CACHE_DESIGN.md
+++ b/docs/CACHE_DESIGN.md
@@ -1,0 +1,337 @@
+# プロンプトキャッシュ設計
+
+プロンプトキャッシュシステムの設計思想とキャッシュライフサイクル管理の仕様。
+
+## 目次
+
+- [概要](#概要)
+- [対象読者](#対象読者)
+- [PromptCacheControllerインターフェース](#promptcachecontrollerインターフェース)
+- [CacheHandle](#cachehandle)
+- [retain / release ヒント機構](#retain--release-ヒント機構)
+- [実装](#実装)
+  - [MlxCacheController](#mlxcachecontroller)
+  - [GoogleGenAICacheController](#googlegenaicachecontroller)
+- [ファイルロック機構](#ファイルロック機構)
+- [Incremental Prefillとsupersedes](#incremental-prefillとsupersedes)
+- [関連ドキュメント](#関連ドキュメント)
+
+## 概要
+
+PromptCacheControllerは、プロンプトキャッシュのライフサイクルを管理するインターフェースです。キャッシュの準備・再利用・削除を統一的に扱い、各AIサービスの特性に応じた実装を提供します。
+
+対応実装:
+- **MlxCacheController** - KVキャッシュファイルを管理（Apple Silicon最適化）
+- **GoogleGenAICacheController** - GoogleGenAI APIのキャッシュ機能を管理
+
+## 対象読者
+
+- **フレームワーク利用者** - PromptCacheControllerを使ってキャッシュを活用する開発者
+- **フレームワーク貢献者** - キャッシュコントローラーを実装する開発者
+
+## PromptCacheControllerインターフェース
+
+```typescript
+export interface PromptCacheController {
+  recordQuery?(): void;
+  prepare(params: CachePrepareParams): Promise<CacheHandle>;
+  release(ref: string): void;
+  close(): Promise<void>;
+}
+```
+
+### prepare(params)
+
+キャッシュを準備し、`CacheHandle`を返します。同一パラメータの場合は既存キャッシュを再利用します。
+
+```typescript
+export interface CachePrepareParams {
+  model: string;
+  instructions?: Element[];
+  data?: Element[];
+  tools?: ToolDefinition[];
+  reasoningEffort?: 'low' | 'medium' | 'high';
+}
+```
+
+**動作**:
+- 同じパラメータで呼ばれた場合、メモリまたはディスクから既存キャッシュを返す
+- 新規の場合、キャッシュを作成してCacheHandleを返す
+- incremental prefillが可能な場合、既存キャッシュをベースに差分のみをprefill
+
+**戻り値**: `Promise<CacheHandle>`
+
+### release(ref)
+
+「もう要らない」というヒントを送ります。即座の削除を保証しません。
+
+**動作**:
+- メモリキャッシュから即座に除外（再利用候補から外れる）
+- ファイルやAPIリソースの削除タイミングは実装依存
+- MlxCacheController: `close()`時にrelease済みエントリを削除
+- GoogleGenAICacheController: 即座にAPIサーバー側リソースを削除
+
+**パラメータ**:
+- `ref` - CacheHandle.refの値
+
+### close()
+
+リソースのクリーンアップを行います。
+
+**動作**:
+- インフライトリクエストの完了を待つ
+- 管理対象キャッシュの削除
+- release済みエントリの実際の削除（MlxCacheController）
+
+**戻り値**: `Promise<void>`
+
+### recordQuery() (オプション)
+
+クエリ統計の記録。ドライバーがquery実行時に呼び出します。
+
+## CacheHandle
+
+キャッシュの参照と、キャッシュに含まれる内容を示すメタデータ。
+
+```typescript
+export interface CacheHandle {
+  ref: string;
+  trimTokens?: number;
+  includes: {
+    instructions: boolean;
+    dataElementCount: number;
+    tools: boolean;
+  };
+  supersedes?: string;
+}
+```
+
+### フィールド
+
+**ref**
+
+キャッシュの一意な参照。
+- MlxCacheController: ファイルパス（例: `/tmp/mlx-prompt-cache-abc123/def456.safetensors`）
+- GoogleGenAICacheController: API名（例: `cachedContents/xyz789`）
+
+**trimTokens**
+
+KVキャッシュを指定トークン数にトリムして読み込む（incremental prefill用）。
+
+- 指定時、キャッシュファイルの先頭N個のトークンのみを使用
+- incremental prefillでベースキャッシュとの共通プレフィックス長を指定
+
+**includes**
+
+キャッシュに含まれる内容のフラグ。ドライバーが重複コンテンツ送信を避けるために使用。
+
+- `instructions` - システムプロンプト等が含まれるか
+- `dataElementCount` - データ要素の個数
+- `tools` - ツール定義が含まれるか
+
+**supersedes**
+
+incremental prefillで置き換えられた元キャッシュのref。
+
+- 新しいキャッシュ作成時にベースとして使われた古いキャッシュを示す
+- このフィールドが設定されると、元キャッシュは自動的に`release()`される
+
+## retain / release ヒント機構
+
+キャッシュの保守に「ヒント（意図表明）モデル」を採用しています。
+
+### 設計の背景
+
+キャッシュは「あってもなくてもよい」性質を持ちます。この特性から:
+
+- **作成は自動的** - 必要に応じてフレームワークが自動生成
+- **削除を利用側に明示的に設計させるのは非対称で負担が大きい**
+- **利用側は「もう要らない」という意図を伝えるだけでよい**
+- **実際の削除タイミングはコントローラーの責務**
+
+### 2つの状態
+
+**retain（デフォルト）**
+
+キャッシュを保持する状態。`prepare()`の再利用候補となります。
+
+**release**
+
+「もう要らない」というヒント。以下の効果があります:
+
+- メモリキャッシュから即座に除外される
+- `prepare()`の再利用候補から外れる
+- ファイルやAPIリソースの削除タイミングは実装依存
+
+### release()を呼んでも
+
+**MlxCacheController**:
+- ファイルは即座に削除されない
+- `cache-index.json`のエントリに`hint: 'release'`が記録される
+- `close()`時にrelease済みエントリのファイルが削除される
+- 外部プロセス（`sprite-claude cache clean`等）もrelease済みエントリを削除対象にできる
+
+**GoogleGenAICacheController**:
+- APIサーバー側リソースが即座に削除される（課金対象の可能性があるため）
+
+## 実装
+
+### MlxCacheController
+
+Apple Siliconに最適化されたMLXモデル用のKVキャッシュファイル管理。
+
+**特徴**:
+- `.safetensors`形式でKVキャッシュをファイル保存
+- incremental prefillサポート（既存キャッシュをベースに差分のみprefill）
+- トークンレベルのプレフィックス照合（prefix_hashes）
+- 固定キャッシュディレクトリモードとmanaged一時ディレクトリモード
+
+**キャッシュディレクトリモード**:
+
+| モード | `managedDir` | `cacheDir` | 説明 |
+|--------|-------------|-----------|------|
+| 一時ディレクトリ | `true` | 未指定 | プロセス終了時に自動削除 |
+| 固定ディレクトリ | `false` | 指定あり | `close()`でrelease済みのみ削除。`cache-index.json`で状態管理 |
+
+**cache-index.json**:
+
+固定ディレクトリモード時、以下の情報を記録:
+
+```typescript
+interface CacheIndexEntry {
+  key: string;
+  model: string;
+  formatterOptionsHash: string;
+  elementHashes: string[];
+  toolsHash?: string;
+  reasoningEffort?: string;
+  createdAt: string;
+  hint?: 'retain' | 'release';
+}
+```
+
+**incremental prefillフロー**:
+
+1. 新しい`prepare()`呼び出し
+2. `findBestBase()` - 要素ハッシュの前方一致でベースキャッシュを選定
+3. トークンレベルのプレフィックス照合（prefix_hashes）で共通トークン数を確認
+4. ベースキャッシュのKV値を再利用し、差分のみprefill
+5. 新キャッシュの`supersedes`にベースキャッシュのrefを記録
+6. ベースキャッシュを自動的に`release()`
+
+### GoogleGenAICacheController
+
+GoogleGenAI APIのキャッシュ機能を管理。
+
+**特徴**:
+- APIサーバー側でキャッシュを管理
+- TTL（有効期限）ベースの自動削除
+- release時に即座にサーバー側リソースを削除
+
+**設定**:
+
+```typescript
+interface GoogleGenAICacheControllerConfig {
+  ttl?: string;  // デフォルト: '3600s'
+  displayName?: string;
+}
+```
+
+**TTL管理**:
+- キャッシュ作成時にTTLを指定
+- ローカルで期限切れキャッシュを掃除（`sweepExpired()`）
+- サーバー側でも自動削除される
+
+## ファイルロック機構
+
+MlxCacheControllerは、固定キャッシュディレクトリモード（`managedDir: false`）時に`cache-index.json`の読み書きに対してファイルロックを使用します。
+
+### 目的
+
+- 同一マシン上で複数プロセスが同じキャッシュディレクトリを共有する場合の安全性確保
+- 外部プロセス（`sprite-claude cache clean`等）からの安全なキャッシュ操作
+
+### 実装
+
+`proper-lockfile`ライブラリによるアドバイザリロックを使用:
+
+```typescript
+import { lock as lockFile } from 'proper-lockfile';
+
+// 読み込み時
+const release = await lockFile(this.indexPath, { realpath: false });
+try {
+  const raw = await readFile(this.indexPath, 'utf-8');
+  // ... parse and use
+} finally {
+  await release();
+}
+
+// 書き込み時
+const release = await lockFile(this.indexPath, { realpath: false });
+try {
+  await writeFile(this.indexPath, JSON.stringify(this.cacheIndex, null, 2));
+} finally {
+  await release();
+}
+```
+
+### 対象
+
+- **固定ディレクトリモード**（`managedDir: false`）のみ
+- **一時ディレクトリモード**（`managedDir: true`）はプロセス間共有がないためロック不要
+
+## Incremental Prefillとsupersedes
+
+MlxCacheControllerは、既存キャッシュをベースに差分のみをprefillする「incremental prefill」をサポートします。
+
+### フロー
+
+1. **新しいprepare()呼び出し**
+   - 新しいプロンプトに対してキャッシュを準備
+
+2. **ベース選定（findBestBase）**
+   - 要素ハッシュ（elementHashes）の前方一致でベースキャッシュ候補を抽出
+   - トークンレベルのプレフィックス照合（prefix_hashes）で最長一致を確認
+   - 最も多くのトークンを再利用できるキャッシュを選定
+
+3. **incremental prefill実行**
+   - ベースキャッシュのKV値をロード
+   - `trimTokens`で共通プレフィックス長を指定
+   - 差分のみをprefillして新キャッシュを作成
+
+4. **supersedes記録**
+   - 新キャッシュの`supersedes`フィールドにベースキャッシュのrefを記録
+
+5. **自動release**
+   - ベースキャッシュを自動的に`release()`
+   - メモリキャッシュから除外され、`cache-index.json`に`hint: 'release'`が記録される
+
+### prefix_hashes
+
+各キャッシュファイルには、トークンプレフィックスのハッシュ情報が`.meta.json`として保存されます:
+
+```typescript
+interface PrefixMeta {
+  token_count: number;
+  prefix_offsets: number[];  // [100, 200, 500] など
+  prefix_hashes: string[];   // 各offsetまでのトークン列のSHA-256ハッシュ
+}
+```
+
+これにより、要素ハッシュが部分一致する場合でも、実際のトークン列での共通プレフィックス長を正確に検証できます。
+
+### 利点
+
+- **プロンプトが段階的に拡張される場合に効率的**
+  - 例: instructions固定、dataが増加
+- **prefillコストの削減**
+  - 共通部分のprefillを省略し、差分のみ処理
+- **自動クリーンアップ**
+  - 古いキャッシュが自動的にreleaseされる
+
+## 関連ドキュメント
+
+- [Driver APIリファレンス](./DRIVER_API.md) - AIDriverインターフェースとドライバー一覧
+- [ローカルモデルセットアップガイド](./LOCAL_MODEL_SETUP.md) - MLXとOllamaのセットアップ
+- [packages/driver/README.md](../packages/driver/README.md) - ドライバーパッケージの詳細

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Moduler Promptのドキュメント集へようこそ。このディレクトリ
 - **[Structured Outputs仕様](./STRUCTURED_OUTPUTS.md)** - 構造化出力の仕様と実装ガイド
 - **[テスト用ドライバーガイド](./TEST_DRIVERS.md)** - TestDriverとEchoDriverの使い方
 - **[Formatter仕様](./FORMATTER_SPEC.md)** - CompiledPromptのレンダリング仕様とFormatterOptions
+- **[プロンプトキャッシュ設計](./CACHE_DESIGN.md)** - PromptCacheControllerの設計思想とキャッシュライフサイクル管理
 
 ### モデル固有の挙動
 

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -42,12 +42,12 @@
     "google-auth-library": "9.15.1",
     "js-yaml": "4.1.1",
     "openai": "5.23.2",
-    "proper-lockfile": "^4.1.2"
+    "proper-lockfile": "4.1.2"
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",
     "@types/node": "20.19.27",
-    "@types/proper-lockfile": "^4.1.4",
+    "@types/proper-lockfile": "4.1.4",
     "@typescript-eslint/eslint-plugin": "8.50.0",
     "@typescript-eslint/parser": "8.50.0",
     "eslint": "9.39.2",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -41,11 +41,13 @@
     "@types/js-yaml": "4.0.9",
     "google-auth-library": "9.15.1",
     "js-yaml": "4.1.1",
-    "openai": "5.23.2"
+    "openai": "5.23.2",
+    "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",
     "@types/node": "20.19.27",
+    "@types/proper-lockfile": "^4.1.4",
     "@typescript-eslint/eslint-plugin": "8.50.0",
     "@typescript-eslint/parser": "8.50.0",
     "eslint": "9.39.2",

--- a/packages/driver/src/cache-controller.ts
+++ b/packages/driver/src/cache-controller.ts
@@ -27,6 +27,7 @@ export interface PromptCacheController {
   /** Record that a query was issued (regardless of cache usage) */
   recordQuery?(): void;
   prepare(params: CachePrepareParams): Promise<CacheHandle>;
-  invalidate(handle: CacheHandle): Promise<void>;
+  /** Hint that this cache entry is no longer needed. Actual deletion timing is implementation-defined. */
+  release(ref: string): void;
   close(): Promise<void>;
 }

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -197,24 +197,24 @@ describe('GoogleGenAICacheController', () => {
     });
   });
 
-  describe('invalidate', () => {
+  describe('release', () => {
     it('should delete the cached content', async () => {
       const handle = await controller.prepare({
         model: 'gemini-2.5-flash',
         instructions: [{ type: 'text', content: 'prompt' }],
       });
 
-      await controller.invalidate(handle);
+      controller.release(handle.ref);
       expect(mockClient.caches.delete).toHaveBeenCalledWith({ name: 'cachedContents/test-cache-123' });
     });
 
-    it('should allow re-creation after invalidation', async () => {
+    it('should allow re-creation after release', async () => {
       const params = {
         model: 'gemini-2.5-flash',
         instructions: [{ type: 'text' as const, content: 'prompt' }],
       };
       const handle1 = await controller.prepare(params);
-      await controller.invalidate(handle1);
+      controller.release(handle1.ref);
 
       mockClient.caches.create.mockResolvedValueOnce({ name: 'cachedContents/new-cache' });
       const handle2 = await controller.prepare(params);

--- a/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.test.ts
@@ -251,7 +251,7 @@ describe('GoogleGenAIDriver with CacheController', () => {
         ref: 'cachedContents/abc',
         includes: { instructions: true, dataElementCount: 1, tools: false },
       }),
-      invalidate: vi.fn(),
+      release: vi.fn(),
       close: vi.fn(),
     };
     driver = new GoogleGenAIDriver({
@@ -377,7 +377,7 @@ describe('GoogleGenAIDriver with CacheController', () => {
         ref: 'cachedContents/partial',
         includes: { instructions: false, dataElementCount: 1, tools: false },
       }),
-      invalidate: vi.fn(),
+      release: vi.fn(),
       close: vi.fn(),
     };
     const partialDriver = new GoogleGenAIDriver({
@@ -409,7 +409,7 @@ describe('GoogleGenAIDriver with CacheController', () => {
         ref: 'cachedContents/no-data',
         includes: { instructions: true, dataElementCount: 0, tools: false },
       }),
-      invalidate: vi.fn(),
+      release: vi.fn(),
       close: vi.fn(),
     };
     const noDataDriver = new GoogleGenAIDriver({

--- a/packages/driver/src/google-genai/google-genai-cache-controller.ts
+++ b/packages/driver/src/google-genai/google-genai-cache-controller.ts
@@ -135,11 +135,11 @@ export class GoogleGenAICacheController implements PromptCacheController {
     return handle;
   }
 
-  async invalidate(handle: CacheHandle): Promise<void> {
-    await this.client.caches.delete({ name: handle.ref });
-    this.managedCaches.delete(handle.ref);
+  release(ref: string): void {
+    this.client.caches.delete({ name: ref }).catch(() => {});
+    this.managedCaches.delete(ref);
     for (const [key, entry] of this.cacheByHash) {
-      if (entry.handle.ref === handle.ref) {
+      if (entry.handle.ref === ref) {
         this.cacheByHash.delete(key);
         break;
       }

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
@@ -207,38 +207,35 @@ describe('MlxCacheController', () => {
     });
   });
 
-  describe('invalidate', () => {
-    it('should delete the cache file', async () => {
+  describe('release', () => {
+    it('should not delete the cache file immediately', async () => {
       const handle = await controller.prepare({
         model: 'test-model',
         instructions: [{ type: 'text', content: 'prompt' }],
       });
 
-      await controller.invalidate(handle);
-      expect(unlink).toHaveBeenCalledWith(handle.ref);
+      controller.release(handle.ref);
+      // release はファイルを削除しない
+      expect(unlink).not.toHaveBeenCalledWith(handle.ref);
     });
 
-    it('should allow re-creation after invalidation', async () => {
+    it('should remove from memory cache so prepare creates new prefill', async () => {
       const params = {
         model: 'test-model',
         instructions: [{ type: 'text' as const, content: 'prompt' }],
       };
 
       const handle1 = await controller.prepare(params);
-      await controller.invalidate(handle1);
+      controller.release(handle1.ref);
 
+      // release 後に同じ params で prepare すると新規 prefill が走る
       await controller.prepare(params);
       expect(mockProcess.cachePrefill).toHaveBeenCalledTimes(2);
     });
 
-    it('should suppress errors when file does not exist', async () => {
-      vi.mocked(unlink).mockRejectedValueOnce(new Error('ENOENT'));
-      const handle = await controller.prepare({
-        model: 'test-model',
-        instructions: [{ type: 'text', content: 'prompt' }],
-      });
-
-      await expect(controller.invalidate(handle)).resolves.toBeUndefined();
+    it('should not throw for unknown ref', () => {
+      // 存在しない ref を release しても問題ない
+      expect(() => controller.release('/nonexistent/path.safetensors')).not.toThrow();
     });
   });
 

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
@@ -1044,15 +1044,18 @@ describe('MlxCacheController', () => {
 
     describe('bind with async loadIndex', () => {
       it('should acquire lock when loading index (managedDir=false)', async () => {
+        const { readFile } = await import('node:fs/promises');
+
         // indexファイルが存在するケース
         vi.mocked(existsSync).mockReturnValueOnce(true); // indexPath check
-        vi.mocked(readFileSync).mockReturnValueOnce(JSON.stringify({
+        vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify({
           version: 1,
           entries: [],
         }));
 
         await lockedController.bind(mockProcess as any, {});
 
+        expect(readFile).toHaveBeenCalledWith('/custom/cache/dir/cache-index.json', 'utf-8');
         // lockが呼ばれたことを確認
         expect(lock).toHaveBeenCalledWith(
           '/custom/cache/dir/cache-index.json',

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
@@ -1044,8 +1044,6 @@ describe('MlxCacheController', () => {
 
     describe('bind with async loadIndex', () => {
       it('should acquire lock when loading index (managedDir=false)', async () => {
-        const { readFile } = await import('node:fs/promises');
-
         // indexファイルが存在するケース
         vi.mocked(existsSync).mockReturnValueOnce(true); // indexPath check
         vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify({

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.test.ts
@@ -13,10 +13,21 @@ vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn().mockResolvedValue(undefined),
   rm: vi.fn().mockResolvedValue(undefined),
   writeFile: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue(''),
 }));
 
-import { unlink, mkdir, rm, writeFile } from 'node:fs/promises';
+const { mockRelease } = vi.hoisted(() => {
+  const mockRelease = vi.fn().mockResolvedValue(undefined);
+  return { mockRelease };
+});
+vi.mock('proper-lockfile', () => ({
+  lock: vi.fn().mockResolvedValue(mockRelease),
+  unlock: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { unlink, mkdir, rm, writeFile, readFile } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
+import { lock } from 'proper-lockfile';
 
 /** Sequential token IDs [0, 1, 2, ...] for consistent mock data */
 const MOCK_TOKEN_COUNT = 5000;
@@ -44,13 +55,13 @@ describe('MlxCacheController', () => {
   let mockProcess: ReturnType<typeof createMockProcess>;
   let controller: MlxCacheController;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.mocked(existsSync).mockReturnValue(false);
     vi.mocked(readFileSync).mockReturnValue('');
     mockProcess = createMockProcess();
     controller = new MlxCacheController();
-    controller.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+    await controller.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
   });
 
   afterEach(async () => {
@@ -175,10 +186,10 @@ describe('MlxCacheController', () => {
 
     it('should produce different cache keys for different formatterOptions', async () => {
       const controllerA = new MlxCacheController();
-      controllerA.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, { specialTokens: { bosToken: { text: '<s>', id: 1 } } });
+      await controllerA.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, { specialTokens: { bosToken: { text: '<s>', id: 1 } } });
 
       const controllerB = new MlxCacheController();
-      controllerB.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, { specialTokens: { bosToken: { text: '<bos>', id: 1 } } });
+      await controllerB.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, { specialTokens: { bosToken: { text: '<bos>', id: 1 } } });
 
       const params = {
         model: 'test-model',
@@ -295,20 +306,20 @@ describe('MlxCacheController', () => {
   });
 
   describe('bind', () => {
-    it('should throw when bind is called twice', () => {
+    it('should throw when bind is called twice', async () => {
       const ctrl = new MlxCacheController();
-      ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
-      expect(() => ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {}))
-        .toThrow('MlxCacheController is already bound to a process');
+      await ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await expect(ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {}))
+        .rejects.toThrow('MlxCacheController is already bound to a process');
     });
   });
 
   describe('external cacheDir', () => {
     let externalController: MlxCacheController;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       externalController = new MlxCacheController({ cacheDir: '/custom/cache/dir' });
-      externalController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await externalController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
     });
 
     afterEach(async () => {
@@ -435,7 +446,7 @@ describe('MlxCacheController', () => {
 
     it('should fall back to index when lastHandle file is missing', async () => {
       const externalController = new MlxCacheController({ cacheDir: '/cache' });
-      externalController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await externalController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
 
       // 1回目
       await externalController.prepare({
@@ -482,11 +493,17 @@ describe('MlxCacheController', () => {
         }],
       };
 
-      // readFileSyncでインデックスまたはmeta.jsonを返す
+      // readFileSyncでmeta.jsonを返す
       vi.mocked(readFileSync).mockImplementation((path: any) => {
         const pathStr = String(path);
         if (pathStr.endsWith('.meta.json')) return JSON.stringify({ token_count: 100, prefix_offsets: [100], prefix_hashes: [testPrefixHash(100)] });
         return JSON.stringify(indexData);
+      });
+      // readFile（async）でインデックスを返す（loadIndexが使用）
+      vi.mocked(readFile).mockImplementation(async (path: any) => {
+        const pathStr = String(path);
+        if (pathStr.endsWith('cache-index.json')) return JSON.stringify(indexData);
+        return '';
       });
       // existsSyncの設定: indexPathとキャッシュファイルは存在する
       vi.mocked(existsSync).mockImplementation((path: any) => {
@@ -498,7 +515,7 @@ describe('MlxCacheController', () => {
       });
 
       const freshController = new MlxCacheController({ cacheDir: '/cache' });
-      freshController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await freshController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
 
       // 新しいprepare: instructionsは同じ + data追加 → インデックスからbase cache発見
       await freshController.prepare({
@@ -516,7 +533,7 @@ describe('MlxCacheController', () => {
 
     it('should save index to file after cache creation for external dir', async () => {
       const externalController = new MlxCacheController({ cacheDir: '/cache' });
-      externalController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await externalController.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
 
       await externalController.prepare({
         model: 'test-model',
@@ -725,6 +742,11 @@ describe('MlxCacheController', () => {
         if (p.endsWith('.meta.json')) return JSON.stringify(metaData);
         return '';
       });
+      vi.mocked(readFile).mockImplementation(async (path: any) => {
+        const p = String(path);
+        if (p.endsWith('cache-index.json')) return JSON.stringify(indexData);
+        return '';
+      });
       vi.mocked(existsSync).mockImplementation((path: any) => {
         const p = String(path);
         if (p.endsWith('cache-index.json')) return true;
@@ -733,7 +755,7 @@ describe('MlxCacheController', () => {
       });
 
       const ctrl = new MlxCacheController({ cacheDir: '/cache' });
-      ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
 
       // Request only first 2 elements (inst A, inst B) — subset of superset
       const handle = await ctrl.prepare({
@@ -793,6 +815,11 @@ describe('MlxCacheController', () => {
         if (p.endsWith('.meta.json')) return JSON.stringify(metaData);
         return '';
       });
+      vi.mocked(readFile).mockImplementation(async (path: any) => {
+        const p = String(path);
+        if (p.endsWith('cache-index.json')) return JSON.stringify(indexData);
+        return '';
+      });
       vi.mocked(existsSync).mockImplementation((path: any) => {
         const p = String(path);
         if (p.endsWith('cache-index.json')) return true;
@@ -801,7 +828,7 @@ describe('MlxCacheController', () => {
       });
 
       const ctrl = new MlxCacheController({ cacheDir: '/cache' });
-      ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
 
       // Request with different data[1] — first 2 elements match (inst + data 0)
       await ctrl.prepare({
@@ -851,6 +878,11 @@ describe('MlxCacheController', () => {
         if (p.endsWith('.meta.json')) return JSON.stringify(metaData);
         return '';
       });
+      vi.mocked(readFile).mockImplementation(async (path: any) => {
+        const p = String(path);
+        if (p.endsWith('cache-index.json')) return JSON.stringify(indexData);
+        return '';
+      });
       vi.mocked(existsSync).mockImplementation((path: any) => {
         const p = String(path);
         if (p.endsWith('cache-index.json')) return true;
@@ -859,7 +891,7 @@ describe('MlxCacheController', () => {
       });
 
       const ctrl = new MlxCacheController({ cacheDir: '/cache' });
-      ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
 
       // inst matches but data differs — partial match, no offsets → cannot trim
       await ctrl.prepare({
@@ -914,6 +946,11 @@ describe('MlxCacheController', () => {
         if (p.endsWith('cache-index.json')) return JSON.stringify(indexData);
         return '';
       });
+      vi.mocked(readFile).mockImplementation(async (path: any) => {
+        const p = String(path);
+        if (p.endsWith('cache-index.json')) return JSON.stringify(indexData);
+        return '';
+      });
       vi.mocked(existsSync).mockImplementation((path: any) => {
         const p = String(path);
         if (p.endsWith('cache-index.json')) return true;
@@ -922,7 +959,7 @@ describe('MlxCacheController', () => {
       });
 
       const ctrl = new MlxCacheController({ cacheDir: '/cache' });
-      ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
 
       await ctrl.prepare({
         model: 'test-model',
@@ -968,6 +1005,11 @@ describe('MlxCacheController', () => {
         if (p.endsWith('cache-index.json')) return JSON.stringify(indexData);
         return '';
       });
+      vi.mocked(readFile).mockImplementation(async (path: any) => {
+        const p = String(path);
+        if (p.endsWith('cache-index.json')) return JSON.stringify(indexData);
+        return '';
+      });
       vi.mocked(existsSync).mockImplementation((path: any) => {
         const p = String(path);
         if (p.endsWith('cache-index.json')) return true;
@@ -976,7 +1018,7 @@ describe('MlxCacheController', () => {
       });
 
       const ctrl = new MlxCacheController({ cacheDir: '/cache' });
-      ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
+      await ctrl.bind(mockProcess as unknown as import('./process/index.js').MlxProcess, {});
 
       await ctrl.prepare({
         model: 'test-model',
@@ -988,6 +1030,120 @@ describe('MlxCacheController', () => {
       expect(basePath).toBeUndefined();
 
       await ctrl.close();
+    });
+  });
+
+  describe('file locking', () => {
+    // テスト用のコントローラ（managedDir=false、ロックが有効な状態）
+    let lockedController: MlxCacheController;
+
+    beforeEach(() => {
+      lockedController = new MlxCacheController({ cacheDir: '/custom/cache/dir' });
+    });
+
+    afterEach(async () => {
+      await lockedController.close();
+    });
+
+    describe('bind with async loadIndex', () => {
+      it('should acquire lock when loading index (managedDir=false)', async () => {
+        // indexファイルが存在するケース
+        vi.mocked(existsSync).mockReturnValueOnce(true); // indexPath check
+        vi.mocked(readFileSync).mockReturnValueOnce(JSON.stringify({
+          version: 1,
+          entries: [],
+        }));
+
+        await lockedController.bind(mockProcess as any, {});
+
+        // lockが呼ばれたことを確認
+        expect(lock).toHaveBeenCalledWith(
+          '/custom/cache/dir/cache-index.json',
+          expect.objectContaining({ realpath: false })
+        );
+        // release関数が呼ばれたことを確認
+        expect(mockRelease).toHaveBeenCalled();
+      });
+
+      it('should not acquire lock when managedDir=true', async () => {
+        const managedController = new MlxCacheController(); // managedDir=true
+        await managedController.bind(mockProcess as any, {});
+
+        expect(lock).not.toHaveBeenCalled();
+        await managedController.close();
+      });
+    });
+
+    describe('saveIndex with lock', () => {
+      it('should acquire lock when saving index', async () => {
+        await lockedController.bind(mockProcess as any, {});
+        vi.mocked(lock).mockClear();
+        vi.mocked(mockRelease).mockClear();
+
+        await lockedController.prepare({
+          model: 'test-model',
+          instructions: [{ type: 'text', content: 'test' }],
+        });
+
+        // saveIndexがロック付きで呼ばれたことを確認
+        expect(lock).toHaveBeenCalledWith(
+          '/custom/cache/dir/cache-index.json',
+          expect.objectContaining({ realpath: false })
+        );
+        expect(mockRelease).toHaveBeenCalled();
+      });
+
+      it('should not acquire lock when managedDir=true', async () => {
+        // managedDirのcontrollerではsaveIndexがスキップされるのでlockも不要
+        await controller.prepare({
+          model: 'test-model',
+          instructions: [{ type: 'text', content: 'test' }],
+        });
+
+        expect(lock).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('lock error handling', () => {
+      it('should handle lock acquisition failure gracefully in loadIndex', async () => {
+        vi.mocked(lock).mockRejectedValueOnce(new Error('ELOCKED'));
+
+        // bind should not throw even if lock fails
+        await expect(
+          lockedController.bind(mockProcess as any, {})
+        ).resolves.not.toThrow();
+      });
+
+      it('should handle lock acquisition failure gracefully in saveIndex', async () => {
+        await lockedController.bind(mockProcess as any, {});
+        vi.mocked(lock).mockClear();
+        vi.mocked(lock).mockRejectedValue(new Error('ELOCKED'));
+
+        // prepare should not throw even if saveIndex lock fails
+        await expect(
+          lockedController.prepare({
+            model: 'test-model',
+            instructions: [{ type: 'text', content: 'test' }],
+          })
+        ).resolves.toBeDefined();
+      });
+    });
+
+    describe('close with lock', () => {
+      it('should acquire lock when saving index on close (managedDir=false)', async () => {
+        await lockedController.bind(mockProcess as any, {});
+        vi.mocked(lock).mockReset();
+        vi.mocked(lock).mockResolvedValue(mockRelease);
+        vi.mocked(mockRelease).mockClear();
+
+        await lockedController.close();
+
+        expect(lock).toHaveBeenCalledWith(
+          '/custom/cache/dir/cache-index.json',
+          expect.objectContaining({ realpath: false })
+        );
+        expect(mockRelease).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import { rmSync, existsSync, readFileSync } from 'node:fs';
 import { unlink, mkdir, rm, writeFile, readFile } from 'node:fs/promises';
 import { lock as lockFile } from 'proper-lockfile';
@@ -24,6 +24,7 @@ interface CacheIndexEntry {
   toolsHash?: string;
   reasoningEffort?: string;
   createdAt: string;
+  hint?: 'retain' | 'release';
 }
 
 interface CacheIndex {
@@ -328,6 +329,7 @@ export class MlxCacheController implements PromptCacheController {
     const staleKeys: string[] = [];
 
     for (const entry of this.cacheIndex.entries) {
+      if (entry.hint === 'release') continue;
       if (entry.model !== params.model || entry.formatterOptionsHash !== fmtHash) continue;
       if ((entry.toolsHash ?? '') !== newToolsHash) continue;
       if ((entry.reasoningEffort ?? '') !== (params.reasoningEffort ?? '')) continue;
@@ -449,11 +451,6 @@ export class MlxCacheController implements PromptCacheController {
       reasoningEffort: params.reasoningEffort,
       createdAt: new Date().toISOString(),
     });
-  }
-
-  private removeFromIndex(cachePath: string): void {
-    const key = basename(cachePath, '.safetensors');
-    this.cacheIndex.entries = this.cacheIndex.entries.filter(e => e.key !== key);
   }
 
   private computeCacheKey(params: CachePrepareParams): string {
@@ -681,25 +678,31 @@ export class MlxCacheController implements PromptCacheController {
     this.updateLastCache(handle, elementHashes, params);
 
     this.addToIndex(params, cacheKey);
+    if (supersededRef) {
+      this.release(supersededRef);
+    }
     await this.saveIndex();
 
     return handle;
   }
 
-  async invalidate(handle: CacheHandle): Promise<void> {
-    logger.debug('invalidate', handle.ref);
-    this.removeFromIndex(handle.ref);
-    await unlink(handle.ref).catch(() => {});
-    await unlink(handle.ref + '.meta.json').catch(() => {});
-    for (const [key, entry] of this.cacheByHash) {
-      if (entry.ref === handle.ref) {
+  release(ref: string): void {
+    logger.debug('release', ref);
+    const entry = this.cacheIndex.entries.find(
+      e => this.generateCachePath(e.key) === ref,
+    );
+    if (entry) {
+      entry.hint = 'release';
+    }
+    for (const [key, handle] of this.cacheByHash) {
+      if (handle.ref === ref) {
         this.cacheByHash.delete(key);
       }
     }
-    if (this.lastHandle?.ref === handle.ref) {
+    if (this.lastHandle?.ref === ref) {
       this.clearLastCache();
     }
-    await this.saveIndex();
+    this.saveIndex().catch(() => {});
   }
 
   async close(): Promise<void> {
@@ -718,6 +721,13 @@ export class MlxCacheController implements PromptCacheController {
     if (this.managedDir && this.cacheDir) {
       await rm(this.cacheDir, { recursive: true, force: true }).catch(() => {});
     } else {
+      const released = this.cacheIndex.entries.filter(e => e.hint === 'release');
+      for (const entry of released) {
+        const path = this.generateCachePath(entry.key);
+        await unlink(path).catch(() => {});
+        await unlink(path + '.meta.json').catch(() => {});
+      }
+      this.cacheIndex.entries = this.cacheIndex.entries.filter(e => e.hint !== 'release');
       await this.saveIndex();
     }
     this.cacheDirReady = false;

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.ts
@@ -722,11 +722,10 @@ export class MlxCacheController implements PromptCacheController {
       await rm(this.cacheDir, { recursive: true, force: true }).catch(() => {});
     } else {
       const released = this.cacheIndex.entries.filter(e => e.hint === 'release');
-      for (const entry of released) {
+      await Promise.allSettled(released.flatMap(entry => {
         const path = this.generateCachePath(entry.key);
-        await unlink(path).catch(() => {});
-        await unlink(path + '.meta.json').catch(() => {});
-      }
+        return [unlink(path), unlink(path + '.meta.json')];
+      }));
       this.cacheIndex.entries = this.cacheIndex.entries.filter(e => e.hint !== 'release');
       await this.saveIndex();
     }

--- a/packages/driver/src/mlx-ml/mlx-cache-controller.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-controller.ts
@@ -2,7 +2,8 @@ import { createHash, randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import { rmSync, existsSync, readFileSync } from 'node:fs';
-import { unlink, mkdir, rm, writeFile } from 'node:fs/promises';
+import { unlink, mkdir, rm, writeFile, readFile } from 'node:fs/promises';
+import { lock as lockFile } from 'proper-lockfile';
 import type { PromptCacheController, CachePrepareParams, CacheHandle } from '../cache-controller.js';
 import type { ToolDefinition } from '../types.js';
 import type { FormatterOptions } from '../formatter/types.js';
@@ -83,11 +84,11 @@ export class MlxCacheController implements PromptCacheController {
     }
   }
 
-  bind(
+  async bind(
     process: MlxProcess,
     formatterOptions: FormatterOptions,
     messageProcessor?: (messages: MlxMessage[]) => MlxMessage[],
-  ): void {
+  ): Promise<void> {
     if (this.bound) {
       throw new Error('MlxCacheController is already bound to a process');
     }
@@ -104,7 +105,7 @@ export class MlxCacheController implements PromptCacheController {
       globalThis.process.on('exit', this.cleanupHandler);
     }
     if (!this.managedDir) {
-      this.loadIndexSync();
+      await this.loadIndex();
     }
     this.bound = true;
   }
@@ -129,17 +130,21 @@ export class MlxCacheController implements PromptCacheController {
     }
   }
 
-  private loadIndexSync(): void {
+  private async loadIndex(): Promise<void> {
     try {
-      if (existsSync(this.indexPath)) {
-        const raw = readFileSync(this.indexPath, 'utf-8');
+      if (!existsSync(this.indexPath)) return;
+      const release = await lockFile(this.indexPath, { realpath: false });
+      try {
+        const raw = await readFile(this.indexPath, 'utf-8');
         const parsed = JSON.parse(raw);
         if (parsed && parsed.version === 1 && Array.isArray(parsed.entries)) {
           this.cacheIndex = parsed;
         }
+      } finally {
+        await release();
       }
     } catch {
-      // corrupt index — start fresh
+      // corrupt index or lock failure — start fresh
     }
   }
 
@@ -147,7 +152,12 @@ export class MlxCacheController implements PromptCacheController {
     if (this.managedDir) return;
     try {
       await this.ensureCacheDir();
-      await writeFile(this.indexPath, JSON.stringify(this.cacheIndex, null, 2));
+      const release = await lockFile(this.indexPath, { realpath: false });
+      try {
+        await writeFile(this.indexPath, JSON.stringify(this.cacheIndex, null, 2));
+      } finally {
+        await release();
+      }
     } catch {
       // best-effort
     }

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -205,7 +205,7 @@ export class MlxDriver implements AIDriver {
             this.queryLogger.log.info('VLM models do not support prompt caching — cacheController disabled');
             this.cacheController = undefined;
           } else {
-            this.cacheController.bind(
+            await this.cacheController.bind(
               this.process,
               this.formatterOptions,
               (msgs) => this.modelProcessor.applyChatSpecificProcessing(msgs),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,7 @@ importers:
         specifier: 5.23.2
         version: 5.23.2(ws@8.18.3)(zod@3.25.76)
       proper-lockfile:
-        specifier: ^4.1.2
+        specifier: 4.1.2
         version: 4.1.2
     devDependencies:
       '@eslint/js':
@@ -97,7 +97,7 @@ importers:
         specifier: 20.19.27
         version: 20.19.27
       '@types/proper-lockfile':
-        specifier: ^4.1.4
+        specifier: 4.1.4
         version: 4.1.4
       '@typescript-eslint/eslint-plugin':
         specifier: 8.50.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       openai:
         specifier: 5.23.2
         version: 5.23.2(ws@8.18.3)(zod@3.25.76)
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
     devDependencies:
       '@eslint/js':
         specifier: 9.39.2
@@ -93,6 +96,9 @@ importers:
       '@types/node':
         specifier: 20.19.27
         version: 20.19.27
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       '@typescript-eslint/eslint-plugin':
         specifier: 8.50.0
         version: 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -782,6 +788,9 @@ packages:
 
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
+
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -1575,6 +1584,9 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   protobufjs@7.5.7:
     resolution: {integrity: sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==}
     engines: {node: '>=12.0.0'}
@@ -1600,6 +1612,10 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -1642,6 +1658,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2366,6 +2385,10 @@ snapshots:
   '@types/node@20.19.27':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.0
 
   '@types/retry@0.12.0': {}
 
@@ -3202,6 +3225,12 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   protobufjs@7.5.7:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -3233,6 +3262,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  retry@0.12.0: {}
 
   retry@0.13.1: {}
 
@@ -3287,6 +3318,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 


### PR DESCRIPTION
## Summary

- `cache-index.json`の読み書きに`proper-lockfile`によるアドバイザリロックを追加し、外部プロセスとの安全な共有を実現
- `invalidate()`を`release()`ヒント機構に置き換え。利用側は「もう要らない」という意図を伝えるだけで、実際の削除タイミングはコントローラーの責務に
- incremental prefill時にsupersedesされたキャッシュを自動的にreleaseする仕組みを追加
- `CACHE_DESIGN.md`を新規作成し、キャッシュシステムの設計思想を文書化

## Changes

### インターフェース変更 (`cache-controller.ts`)
- `invalidate(handle: CacheHandle): Promise<void>` → `release(ref: string): void`

### MlxCacheController
- `loadIndex()` / `saveIndex()` にファイルロック追加
- `bind()` を非同期化（`async`）
- `release(ref)`: hint='release'を設定し、メモリキャッシュから除外
- `findBestBase()`: release済みエントリを候補から除外
- `createCache()`: supersedes時に自動release
- `close()`: release済みエントリのファイルを削除

### GoogleGenAICacheController
- `invalidate()` → `release()` に名前変更（APIキャッシュは即座に削除）

### ドキュメント
- `docs/CACHE_DESIGN.md` 新規作成
- `docs/README.md`、`AGENTS.md` にリンク追加

closes #274

## Test plan

- [x] MlxCacheControllerのテスト（47件）パス
- [x] GoogleGenAICacheControllerのテスト（22件）パス
- [x] 型チェック通過
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)