### PR TITLE
fix: outputSchemaの挿入位置をOutputセクションに移動

### DIFF
--- a/.changeset/output-schema-section.md
+++ b/.changeset/output-schema-section.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/driver": patch
+---
+
+fix: outputSchemaの挿入位置をInstructionsセクションからOutputセクションに移動。Outputセクションの表示条件をoutput要素またはoutputSchemaの有無で判定するように変更。これによりMlxDriverのoutputSchema使用時のキャッシュ迂回ガードが不要になり、routingリクエスト等でもキャッシュが利用可能に。

--- a/.changeset/output-schema-section.md
+++ b/.changeset/output-schema-section.md
@@ -2,4 +2,4 @@
 "@modular-prompt/driver": patch
 ---
 
-fix: outputSchemaの挿入位置をInstructionsセクションからOutputセクションに移動。Outputセクションの表示条件をoutput要素またはoutputSchemaの有無で判定するように変更。これによりMlxDriverのoutputSchema使用時のキャッシュ迂回ガードが不要になり、routingリクエスト等でもキャッシュが利用可能に。
+fix: outputSchemaの挿入位置をInstructionsセクションからOutputセクションに移動。Outputセクションヘッダーはpreambleの"three main sections"宣言と一貫性を保つためデフォルトで常に出力されるように変更。alwaysIncludeOutputHeader: falseで抑制可能。これによりMlxDriverのoutputSchema使用時のキャッシュ迂回ガードが不要になり、routingリクエスト等でもキャッシュが利用可能に。

--- a/packages/driver/src/echo-driver.ts
+++ b/packages/driver/src/echo-driver.ts
@@ -1,7 +1,7 @@
 import type { CompiledPrompt } from '@modular-prompt/core';
 import type { AIDriver, QueryOptions, QueryResult, StreamResult } from './types.js';
 import type { FormatterOptions } from './formatter/types.js';
-import { formatCompletionPrompt, formatPromptAsMessages, ECHO_SPECIAL_TOKENS, defaultFormatterTexts } from './formatter/converter.js';
+import { formatCompletionPrompt, formatPromptAsMessages, ECHO_SPECIAL_TOKENS } from './formatter/converter.js';
 import { extractJSON } from '@modular-prompt/utils';
 
 /**
@@ -122,59 +122,25 @@ export class EchoDriver implements AIDriver {
 
       case 'both': {
         // Both text and messages in a single object
-        // outputSchemaの二重出力を防ぐため、一時的に削除してフォーマット
-        const outputSchema = prompt.metadata?.outputSchema;
-        const promptWithoutSchema = outputSchema ? {
-          ...prompt,
-          metadata: { ...prompt.metadata, outputSchema: undefined }
-        } : prompt;
-
-        const text = formatCompletionPrompt(promptWithoutSchema, this.formatterOptions);
-        const messages = formatPromptAsMessages(promptWithoutSchema, this.formatterOptions);
-
-        // outputSchemaがある場合は一度だけ追加
-        let finalText = text;
-        let finalMessages = messages;
-        if (outputSchema) {
-          const schemaContent = JSON.stringify(outputSchema, null, 2);
-          const schemaMessage = `### Output Schema\n\n${defaultFormatterTexts.schemaInstruction}\n\nJSONSchema:\n\`\`\`json\n${schemaContent}\n\`\`\``;
-          finalText = `${text}\n\n${schemaMessage}`;
-          finalMessages = [...messages, { role: 'system', content: schemaMessage }];
-        }
+        const text = formatCompletionPrompt(prompt, this.formatterOptions);
+        const messages = formatPromptAsMessages(prompt, this.formatterOptions);
 
         content = JSON.stringify({
-          text: finalText,
-          messages: finalMessages
+          text,
+          messages
         }, null, 2);
         break;
       }
 
       case 'debug': {
-        // outputSchemaの二重出力を防ぐため、一時的に削除してフォーマット
-        const outputSchema = prompt.metadata?.outputSchema;
-        const promptWithoutSchema = outputSchema ? {
-          ...prompt,
-          metadata: { ...prompt.metadata, outputSchema: undefined }
-        } : prompt;
-
-        const text = formatCompletionPrompt(promptWithoutSchema, this.formatterOptions);
-        const messages = formatPromptAsMessages(promptWithoutSchema, this.formatterOptions);
-
-        // outputSchemaがある場合は一度だけ追加
-        let finalText = text;
-        let finalMessages = messages;
-        if (outputSchema) {
-          const schemaContent = JSON.stringify(outputSchema, null, 2);
-          const schemaMessage = `### Output Schema\n\n${defaultFormatterTexts.schemaInstruction}\n\nJSONSchema:\n\`\`\`json\n${schemaContent}\n\`\`\``;
-          finalText = `${text}\n\n${schemaMessage}`;
-          finalMessages = [...messages, { role: 'system', content: schemaMessage }];
-        }
+        const text = formatCompletionPrompt(prompt, this.formatterOptions);
+        const messages = formatPromptAsMessages(prompt, this.formatterOptions);
 
         const debug = {
           raw: prompt,
           formatted: {
-            text: finalText,
-            messages: finalMessages
+            text,
+            messages
           },
           metadata: {
             instructionsCount: prompt.instructions?.length || 0,

--- a/packages/driver/src/formatter/completion-formatter.test.ts
+++ b/packages/driver/src/formatter/completion-formatter.test.ts
@@ -86,8 +86,8 @@ describe('formatCompletionPrompt', () => {
     // ECHO_SPECIAL_TOKENS markers are applied to chunk elements
     expect(result).toContain('<chunk>');
     expect(result).toContain('</chunk>');
-    // Output section is not shown when there are no output elements or schema
-    expect(result).not.toContain('# Output');
+    // Output section is always included by default (matches preamble structure)
+    expect(result).toContain('# Output');
   });
 
   it('should format chunk elements', () => {
@@ -192,7 +192,24 @@ describe('formatCompletionPrompt', () => {
 
     const result = formatCompletionPrompt(prompt);
 
-    // Output section is not shown when there are no output elements or schema
+    // Output section is always included by default
+    expect(result).toContain('# Output');
+  });
+
+  it('should suppress Output section when alwaysIncludeOutputHeader is false', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [
+        { type: 'text', content: 'Task' }
+      ],
+      data: [],
+      output: []
+    };
+
+    const result = formatCompletionPrompt(prompt, {
+      alwaysIncludeOutputHeader: false
+    });
+
+    expect(result).toContain('# Instructions');
     expect(result).not.toContain('# Output');
   });
 

--- a/packages/driver/src/formatter/completion-formatter.test.ts
+++ b/packages/driver/src/formatter/completion-formatter.test.ts
@@ -87,7 +87,8 @@ describe('formatCompletionPrompt', () => {
     // ECHO_SPECIAL_TOKENS markers are applied to chunk elements
     expect(result).toContain('<chunk>');
     expect(result).toContain('</chunk>');
-    expect(result).toContain('# Output');
+    // Output section is not shown when there are no output elements or schema
+    expect(result).not.toContain('# Output');
   });
 
   it('should format chunk elements', () => {
@@ -192,9 +193,8 @@ describe('formatCompletionPrompt', () => {
 
     const result = formatCompletionPrompt(prompt);
 
-    // Even with empty prompt, Output section header is always included
-    expect(result).toContain('# Output');
-    expect(result).toContain('This section is where you write your response.');
+    // Output section is not shown when there are no output elements or schema
+    expect(result).not.toContain('# Output');
   });
 
   it('should include preamble when provided', () => {

--- a/packages/driver/src/formatter/completion-formatter.test.ts
+++ b/packages/driver/src/formatter/completion-formatter.test.ts
@@ -82,7 +82,6 @@ describe('formatCompletionPrompt', () => {
 
     const result = formatCompletionPrompt(prompt, ECHO_SPECIAL_TOKENS);
 
-    // formatCompletionPrompt always adds section headers
     expect(result).toContain('# Data');
     // ECHO_SPECIAL_TOKENS markers are applied to chunk elements
     expect(result).toContain('<chunk>');
@@ -195,6 +194,38 @@ describe('formatCompletionPrompt', () => {
 
     // Output section is not shown when there are no output elements or schema
     expect(result).not.toContain('# Output');
+  });
+
+  it('should show Output section with schema when output elements are empty', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [
+        { type: 'text', content: 'Do something' }
+      ],
+      data: [],
+      output: [],
+      metadata: {
+        outputSchema: {
+          type: 'object',
+          properties: {
+            isNewTopic: { type: 'boolean' },
+            title: { type: 'string' }
+          }
+        }
+      }
+    };
+
+    const result = formatCompletionPrompt(prompt);
+
+    expect(result).toContain('# Output');
+    expect(result).toContain('### Output Schema');
+    expect(result).toContain('isNewTopic');
+    expect(result).toContain('```json');
+    // Schema should appear after Instructions, not inside it
+    const instructionsIndex = result.indexOf('# Instructions');
+    const outputIndex = result.indexOf('# Output');
+    const schemaIndex = result.indexOf('### Output Schema');
+    expect(outputIndex).toBeGreaterThan(instructionsIndex);
+    expect(schemaIndex).toBeGreaterThan(outputIndex);
   });
 
   it('should include preamble when provided', () => {

--- a/packages/driver/src/formatter/completion-formatter.ts
+++ b/packages/driver/src/formatter/completion-formatter.ts
@@ -54,20 +54,6 @@ export function formatCompletionPrompt(
     }
     sections.push('');
     sections.push(formatter.formatAll(prompt.instructions));
-
-    // Add output schema to Instructions section if metadata.outputSchema exists
-    if (prompt.metadata?.outputSchema) {
-      sections.push('');
-      const schemaContent = JSON.stringify(prompt.metadata.outputSchema, null, 2);
-      sections.push('### Output Schema');
-      sections.push('');
-      sections.push(defaultFormatterTexts.schemaInstruction);
-      sections.push('');
-      sections.push('JSONSchema:');
-      sections.push('```json');
-      sections.push(schemaContent);
-      sections.push('```');
-    }
   }
 
   // Format data section with header
@@ -82,16 +68,33 @@ export function formatCompletionPrompt(
     sections.push(formatter.formatAll(prompt.data));
   }
 
-  // Format output section with header - always show the section
-  if (sections.length > 0) sections.push('');
-  sections.push('# Output');
-  if (sectionDescriptions?.output) {
-    sections.push('');
-    sections.push(sectionDescriptions.output);
-  }
-  if (prompt.output && prompt.output.length > 0) {
-    sections.push('');
-    sections.push(formatter.formatAll(prompt.output));
+  // Format output section with header
+  const hasOutputElements = prompt.output && prompt.output.length > 0;
+  const hasOutputSchema = !!prompt.metadata?.outputSchema;
+
+  if (hasOutputElements || hasOutputSchema) {
+    if (sections.length > 0) sections.push('');
+    sections.push('# Output');
+    if (sectionDescriptions?.output) {
+      sections.push('');
+      sections.push(sectionDescriptions.output);
+    }
+    if (hasOutputSchema) {
+      sections.push('');
+      const schemaContent = JSON.stringify(prompt.metadata!.outputSchema, null, 2);
+      sections.push('### Output Schema');
+      sections.push('');
+      sections.push(defaultFormatterTexts.schemaInstruction);
+      sections.push('');
+      sections.push('JSONSchema:');
+      sections.push('```json');
+      sections.push(schemaContent);
+      sections.push('```');
+    }
+    if (hasOutputElements) {
+      sections.push('');
+      sections.push(formatter.formatAll(prompt.output!));
+    }
   }
 
   return sections.join(lineBreak);

--- a/packages/driver/src/formatter/completion-formatter.ts
+++ b/packages/driver/src/formatter/completion-formatter.ts
@@ -68,11 +68,14 @@ export function formatCompletionPrompt(
     sections.push(formatter.formatAll(prompt.data));
   }
 
-  // Format output section with header
+  // Output section: always included by default to match the preamble's
+  // "three main sections" declaration. Set alwaysIncludeOutputHeader: false
+  // to suppress when there is no output content.
+  const alwaysOutput = options.alwaysIncludeOutputHeader !== false;
   const hasOutputElements = (prompt.output?.length ?? 0) > 0;
   const hasOutputSchema = !!prompt.metadata?.outputSchema;
 
-  if (hasOutputElements || hasOutputSchema) {
+  if (alwaysOutput || hasOutputElements || hasOutputSchema) {
     if (sections.length > 0) sections.push('');
     sections.push('# Output');
     if (sectionDescriptions?.output) {

--- a/packages/driver/src/formatter/completion-formatter.ts
+++ b/packages/driver/src/formatter/completion-formatter.ts
@@ -69,7 +69,7 @@ export function formatCompletionPrompt(
   }
 
   // Format output section with header
-  const hasOutputElements = prompt.output && prompt.output.length > 0;
+  const hasOutputElements = (prompt.output?.length ?? 0) > 0;
   const hasOutputSchema = !!prompt.metadata?.outputSchema;
 
   if (hasOutputElements || hasOutputSchema) {

--- a/packages/driver/src/formatter/converter.test.ts
+++ b/packages/driver/src/formatter/converter.test.ts
@@ -137,8 +137,8 @@ describe('formatCompletionPrompt', () => {
     // Data section is included
     expect(result).toContain('# Data');
     expect(result).toContain('Some data');
-    // Output section is always included
-    expect(result).toContain('# Output');
+    // Output section is not shown when there are no output elements or schema
+    expect(result).not.toContain('# Output');
   });
   
   it('should use custom line breaks', () => {

--- a/packages/driver/src/formatter/converter.test.ts
+++ b/packages/driver/src/formatter/converter.test.ts
@@ -620,7 +620,7 @@ describe('formatPromptAsMessages', () => {
       ],
       output: []
     };
-    
+
     const messages = formatPromptAsMessages(prompt, {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
@@ -629,6 +629,38 @@ describe('formatPromptAsMessages', () => {
     expect(messages).toHaveLength(2);
     expect(messages[0].content).toBe('# Data');
     expect(messages[1].content).toBe('Some data');
+  });
+
+  it('should show Output section with schema when output elements are empty', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [
+        { type: 'text', content: 'Process input' }
+      ],
+      data: [],
+      output: [],
+      metadata: {
+        outputSchema: {
+          type: 'object',
+          properties: {
+            isNewTopic: { type: 'boolean' },
+            title: { type: 'string' }
+          }
+        }
+      }
+    };
+
+    const messages = formatPromptAsMessages(prompt, {
+      sectionDescriptions: {}
+    });
+
+    // Instructions header + content + Output header + schema = 4 messages
+    expect(messages).toHaveLength(4);
+    expect(messages[0].content).toBe('# Instructions');
+    expect(messages[1].content).toBe('Process input');
+    expect(messages[2].content).toBe('# Output');
+    expect((messages[3].content as string)).toContain('### Output Schema');
+    expect((messages[3].content as string)).toContain('isNewTopic');
+    expect((messages[3].content as string)).toContain('```json');
   });
   
   it('should use default formatter texts', () => {

--- a/packages/driver/src/formatter/converter.test.ts
+++ b/packages/driver/src/formatter/converter.test.ts
@@ -137,10 +137,10 @@ describe('formatCompletionPrompt', () => {
     // Data section is included
     expect(result).toContain('# Data');
     expect(result).toContain('Some data');
-    // Output section is not shown when there are no output elements or schema
-    expect(result).not.toContain('# Output');
+    // Output section is always included by default
+    expect(result).toContain('# Output');
   });
-  
+
   it('should use custom line breaks', () => {
     const prompt: CompiledPrompt = {
       instructions: [
@@ -360,8 +360,8 @@ describe('formatPromptAsMessages', () => {
         instructions: 'Follow these carefully'
       }
     });
-    
-    expect(messages).toHaveLength(3);
+
+    expect(messages).toHaveLength(4);
     
     // Preamble
     expect(messages[0]).toEqual({
@@ -391,12 +391,12 @@ describe('formatPromptAsMessages', () => {
       ],
       output: []
     };
-    
+
     const messages = formatPromptAsMessages(prompt, {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    expect(messages).toHaveLength(3);
+    expect(messages).toHaveLength(4);
 
     expect(messages[0]).toEqual({
       role: 'system',
@@ -424,12 +424,12 @@ describe('formatPromptAsMessages', () => {
       data: [],
       output: []
     };
-    
+
     const messages = formatPromptAsMessages(prompt, {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    expect(messages).toHaveLength(2);
+    expect(messages).toHaveLength(3);
     expect(messages[0]).toEqual({
       role: 'system',
       content: '# Instructions'
@@ -454,12 +454,12 @@ describe('formatPromptAsMessages', () => {
       ],
       output: []
     };
-    
+
     const messages = formatPromptAsMessages(prompt, {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    expect(messages).toHaveLength(2);
+    expect(messages).toHaveLength(3);
     expect(messages[0]).toEqual({
       role: 'system',
       content: '# Data'
@@ -489,12 +489,12 @@ describe('formatPromptAsMessages', () => {
       ],
       output: []
     };
-    
+
     const messages = formatPromptAsMessages(prompt, {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    expect(messages).toHaveLength(3);
+    expect(messages).toHaveLength(4);
     expect(messages[0]).toEqual({
       role: 'system',
       content: '# Data'
@@ -523,12 +523,12 @@ describe('formatPromptAsMessages', () => {
       ],
       output: []
     };
-    
+
     const messages = formatPromptAsMessages(prompt, {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    expect(messages).toHaveLength(2);
+    expect(messages).toHaveLength(3);
     expect(messages[0]).toEqual({
       role: 'system',
       content: '# Data'
@@ -551,12 +551,12 @@ describe('formatPromptAsMessages', () => {
       ],
       output: []
     };
-    
+
     const messages = formatPromptAsMessages(prompt, {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    expect(messages).toHaveLength(2);
+    expect(messages).toHaveLength(3);
     expect(messages[0]).toEqual({
       role: 'system',
       content: '# Data'
@@ -625,7 +625,27 @@ describe('formatPromptAsMessages', () => {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    // Should only have data section
+    // Data + Output (always included by default)
+    expect(messages).toHaveLength(3);
+    expect(messages[0].content).toBe('# Data');
+    expect(messages[1].content).toBe('Some data');
+    expect(messages[2].content).toBe('# Output');
+  });
+
+  it('should suppress Output section when alwaysIncludeOutputHeader is false', () => {
+    const prompt: CompiledPrompt = {
+      instructions: [],
+      data: [
+        { type: 'text', content: 'Some data' }
+      ],
+      output: []
+    };
+
+    const messages = formatPromptAsMessages(prompt, {
+      sectionDescriptions: {},
+      alwaysIncludeOutputHeader: false
+    });
+
     expect(messages).toHaveLength(2);
     expect(messages[0].content).toBe('# Data');
     expect(messages[1].content).toBe('Some data');
@@ -731,7 +751,7 @@ describe('formatPromptAsMessages', () => {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    expect(messages).toHaveLength(2);
+    expect(messages).toHaveLength(3);
     expect(messages[0]).toEqual({
       role: 'system',
       content: '# Data'
@@ -762,7 +782,7 @@ describe('formatPromptAsMessages', () => {
       sectionDescriptions: {} // Disable section descriptions for basic test
     });
 
-    expect(messages).toHaveLength(2);
+    expect(messages).toHaveLength(3);
     expect(messages[0]).toEqual({
       role: 'system',
       content: '# Data'

--- a/packages/driver/src/formatter/converter.ts
+++ b/packages/driver/src/formatter/converter.ts
@@ -77,11 +77,14 @@ export function formatPromptAsMessages(
     }
   }
   
-  // Process output section
+  // Output section: always included by default to match the preamble's
+  // "three main sections" declaration. Set alwaysIncludeOutputHeader: false
+  // to suppress when there is no output content.
+  const alwaysOutput = options.alwaysIncludeOutputHeader !== false;
   const hasOutputElements = (prompt.output?.length ?? 0) > 0;
   const hasOutputSchema = !!prompt.metadata?.outputSchema;
 
-  if (hasOutputElements || hasOutputSchema) {
+  if (alwaysOutput || hasOutputElements || hasOutputSchema) {
     const outputHeader = sectionDescriptions?.output
       ? `# Output\n\n${sectionDescriptions.output}`
       : '# Output';

--- a/packages/driver/src/formatter/converter.ts
+++ b/packages/driver/src/formatter/converter.ts
@@ -78,7 +78,7 @@ export function formatPromptAsMessages(
   }
   
   // Process output section
-  const hasOutputElements = prompt.output && prompt.output.length > 0;
+  const hasOutputElements = (prompt.output?.length ?? 0) > 0;
   const hasOutputSchema = !!prompt.metadata?.outputSchema;
 
   if (hasOutputElements || hasOutputSchema) {

--- a/packages/driver/src/formatter/converter.ts
+++ b/packages/driver/src/formatter/converter.ts
@@ -58,16 +58,8 @@ export function formatPromptAsMessages(
       messages.push(...elementToMessages(element, formatter));
     }
 
-    // Add output schema to Instructions section if metadata.outputSchema exists
-    if (prompt.metadata?.outputSchema) {
-      const schemaContent = JSON.stringify(prompt.metadata.outputSchema, null, 2);
-      messages.push({
-        role: 'system',
-        content: `### Output Schema\n\n${defaultFormatterTexts.schemaInstruction}\n\nJSONSchema:\n\`\`\`json\n${schemaContent}\n\`\`\``
-      });
-    }
   }
-  
+
   // Process data section
   if (prompt.data && prompt.data.length > 0) {
     // Add section header with description
@@ -86,7 +78,10 @@ export function formatPromptAsMessages(
   }
   
   // Process output section
-  if (prompt.output && prompt.output.length > 0) {
+  const hasOutputElements = prompt.output && prompt.output.length > 0;
+  const hasOutputSchema = !!prompt.metadata?.outputSchema;
+
+  if (hasOutputElements || hasOutputSchema) {
     const outputHeader = sectionDescriptions?.output
       ? `# Output\n\n${sectionDescriptions.output}`
       : '# Output';
@@ -95,9 +90,18 @@ export function formatPromptAsMessages(
       content: outputHeader
     });
 
-    // Convert each element to a message
-    for (const element of prompt.output) {
-      messages.push(...elementToMessages(element, formatter));
+    if (hasOutputSchema) {
+      const schemaContent = JSON.stringify(prompt.metadata!.outputSchema, null, 2);
+      messages.push({
+        role: 'system',
+        content: `### Output Schema\n\n${defaultFormatterTexts.schemaInstruction}\n\nJSONSchema:\n\`\`\`json\n${schemaContent}\n\`\`\``
+      });
+    }
+
+    if (hasOutputElements) {
+      for (const element of prompt.output!) {
+        messages.push(...elementToMessages(element, formatter));
+      }
     }
   }
 

--- a/packages/driver/src/formatter/formatter.ts
+++ b/packages/driver/src/formatter/formatter.ts
@@ -14,7 +14,7 @@ import type { ElementFormatter, FormatterOptions, SpecialToken, SpecialTokenPair
  * Default formatter implementation for converting elements to text
  */
 export class DefaultFormatter implements ElementFormatter {
-  private options: Required<Omit<FormatterOptions, 'preamble' | 'sectionDescriptions' | 'formatter' | 'specialTokens'>> & 
+  private options: Required<Omit<FormatterOptions, 'preamble' | 'sectionDescriptions' | 'formatter' | 'specialTokens' | 'alwaysIncludeOutputHeader'>> &
     Pick<FormatterOptions, 'preamble' | 'sectionDescriptions' | 'specialTokens'>;
   private specialTokens?: Record<string, SpecialToken | SpecialTokenPair>;
   

--- a/packages/driver/src/formatter/section-headers.test.ts
+++ b/packages/driver/src/formatter/section-headers.test.ts
@@ -266,8 +266,8 @@ describe('Section Headers in Prompts', () => {
 
       const messages = formatPromptAsMessages(prompt, defaultFormatterTexts);
 
-      // When preamble is provided via defaultFormatterTexts, should have preamble message only
-      expect(messages).toHaveLength(1);
+      // When preamble is provided via defaultFormatterTexts, should have preamble message + Output header
+      expect(messages).toHaveLength(2);
       expect(messages[0].content).toContain('This prompt is organized into three main sections');
     });
 

--- a/packages/driver/src/formatter/types.ts
+++ b/packages/driver/src/formatter/types.ts
@@ -73,6 +73,14 @@ export interface FormatterOptions {
    * Line break settings
    */
   lineBreak?: '\n' | '\r\n';
+
+  /**
+   * Whether to always include the Output section header.
+   * Default: true — the default preamble declares three sections (Instructions, Data, Output),
+   * so omitting the Output header would contradict that structure.
+   * Set to false for chat-style formatting where trailing messages are preferred over section framing.
+   */
+  alwaysIncludeOutputHeader?: boolean;
   
   /**
    * Model-specific special tokens

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -297,13 +297,12 @@ export class MlxDriver implements AIDriver {
         ? messages.flatMap(m => 'content' in m && !isToolResult(m) ? extractImagePaths(m.content) : [])
         : [];
 
-      // Cache: chat APIのみ、以下の条件を全て満たす場合にキャッシュを使用
-      // - outputSchema未指定（formatPromptAsMessagesがschemaを挿入し、prefixがずれる）
+      // Cache: chat APIのみ、trustRemoteCode未指定の場合にキャッシュを使用
       // - trustRemoteCode未指定（明示的なtrue/falseどちらもapply_chat_template kwargsに影響）
       let cachePath: string | undefined;
       let cacheTrimTokens: number | undefined;
       const trustRemoteCode = mlxOptions.trustRemoteCode;
-      if (this.cacheController && !augmentedPrompt.metadata?.outputSchema && trustRemoteCode === undefined) {
+      if (this.cacheController && trustRemoteCode === undefined) {
         const prefix = extractCacheablePrefix(augmentedPrompt);
         const hasCacheableContent =
           prefix.instructions.length > 0 ||


### PR DESCRIPTION
## Summary

Closes #278

- outputSchemaの挿入位置をInstructionsセクション末尾からOutputセクション内に移動
- Outputセクションヘッダーはpreambleの"three main sections"宣言と一貫性を保つためデフォルトで常に出力するように変更
- `alwaysIncludeOutputHeader: false`オプションでOutputヘッダーを抑制可能（chat系フォーマット向け）
- echo-driver.tsの二重出力防止ロジックを削除（フォーマッタ側で正しい位置に1回だけ出力されるため不要に）
- mlx-driver.tsのoutputSchema使用時キャッシュ迂回ガードを削除（Outputセクションはキャッシュプレフィックスに影響しない）

## Test plan

- [x] フォーマッタテスト（converter, completion-formatter, section-headers）全通過
- [x] echo-driverテスト全通過
- [x] 型チェック通過
- [x] outputSchemaのみ存在時のテスト追加
- [x] alwaysIncludeOutputHeader: false のテスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)