### PR TITLE
feat(driver): AbortSignal と cache usage を共通 API に追加

### DIFF
--- a/.changeset/driver-signal-cache-usage.md
+++ b/.changeset/driver-signal-cache-usage.md
@@ -1,0 +1,5 @@
+---
+"@modular-prompt/driver": minor
+---
+
+feat: QueryOptions.signal と usage の cache 系フィールドを共通ドライバ API に追加（MLX で実装）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,8 +143,13 @@ npm run lint
 
 ### 共通インターフェース (AIDriver)
 - `query`: 通常クエリ実行
-- `streamQuery`: ストリーミングクエリ
+- `streamQuery`: ストリーミングクエリ（`stream` + `result` の二経路。usage は `result` のみ）
 - `close`: リソースクリーンアップ
+
+### QueryOptions / QueryResult 拡張
+- `QueryOptions.signal`: 推論キャンセル（MLX 実装済み、他ドライバーは未対応）
+- `QueryResult.usage.cacheReadTokens` / `cacheWriteTokens`: キャッシュ利用量（MLX 実装済み）
+- 共通ヘルパー: `packages/driver/src/query-utils.ts`（`buildQueryUsage`, `watchAbortSignal` 等）
 
 ### DriverInput / DriverSet
 ワークフロー関数は `DriverInput` 型（`AIDriver | DriverSet`）を第1引数に受け入れます:

--- a/docs/CACHE_DESIGN.md
+++ b/docs/CACHE_DESIGN.md
@@ -14,6 +14,7 @@
   - [GoogleGenAICacheController](#googlegenaicachecontroller)
 - [ファイルロック機構](#ファイルロック機構)
 - [Incremental Prefillとsupersedes](#incremental-prefillとsupersedes)
+- [QueryResult.usage との関係](#queryresultusage-との関係)
 - [関連ドキュメント](#関連ドキュメント)
 
 ## 概要
@@ -329,6 +330,42 @@ interface PrefixMeta {
   - 共通部分のprefillを省略し、差分のみ処理
 - **自動クリーンアップ**
   - 古いキャッシュが自動的にreleaseされる
+
+## QueryResult.usage との関係
+
+プロンプトキャッシュの利用状況は、ドライバーが `QueryResult.usage` の任意フィールドとして報告します。
+
+```typescript
+usage?: {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cacheReadTokens?: number;   // 今回リクエストでキャッシュから読んだトークン数
+  cacheWriteTokens?: number;  // 今回リクエストでキャッシュに新規書き込みしたトークン数
+};
+```
+
+### MlxCacheController + MlxDriver
+
+| フィールド | ソース |
+|---|---|
+| `promptTokens` | Python ストリーム終端 meta の `prompt_tokens` |
+| `completionTokens` | Python ストリーム終端 meta の `generation_tokens` |
+| `cacheReadTokens` | クエリで使用した KV キャッシュのトークン数（`cacheTrimTokens` または `.meta.json` の `token_count`） |
+| `cacheWriteTokens` | 同一 `streamQuery` 内の `prepare()` で新規作成した prefill トークン数（`getStats().cacheGrowthTokens` の差分） |
+
+`promptTokens` はキャッシュ分を差し引いた値ではありません。キャッシュヒット分は `cacheReadTokens` で別途報告します。
+
+### AbortSignal とキャッシュ
+
+MLX ドライバーで `QueryOptions.signal` により推論をキャンセルする場合:
+
+1. TS が `ProcessCommunication.cancelActiveStream()` で Node `Readable` を destroy
+2. stdin に `{"method":"cancel"}\n` を送信
+3. Python の `_stream_to_stdout` が `poll_cancel()` でループを抜け、`\0` でレスポンス終端
+4. TS が stdout をドレインし、キューを解放（次リクエストを受け付け可能に）
+
+キャンセル後も `MlxCacheController` が作成済みのキャッシュファイルは保持されます。`release()` / `close()` のライフサイクルは通常どおりです。
 
 ## 関連ドキュメント
 

--- a/docs/DRIVER_API.md
+++ b/docs/DRIVER_API.md
@@ -7,6 +7,9 @@
 - [インターフェース](#インターフェース)
 - [利用可能なドライバー](#利用可能なドライバー)
 - [型定義](#型定義)
+- [推論キャンセル（AbortSignal）](#推論キャンセルabortsignal)
+- [トークン使用量（usage）](#トークン使用量usage)
+- [共通ユーティリティ（query-utils）](#共通ユーティリティquery-utils)
 - [エラーハンドリング](#エラーハンドリング)
 - [関連ドキュメント](#関連ドキュメント)
 
@@ -36,7 +39,7 @@ query(prompt: CompiledPrompt, options?: QueryOptions): Promise<QueryResult>
 
 **streamQuery()**
 
-ストリーミングレスポンスを生成。
+ストリーミングレスポンスを生成。`stream`（テキスト断片）と `result`（最終集計）は別経路です。usage は `result.usage` にのみ載せ、各チャンクには含めません。
 
 ```typescript
 streamQuery(prompt: CompiledPrompt, options?: QueryOptions): Promise<StreamResult>
@@ -221,6 +224,96 @@ type DriverProvider =
   | string;  // カスタムプロバイダー
 ```
 
+## 推論キャンセル（AbortSignal）
+
+`QueryOptions.signal` で進行中の推論をキャンセルします。未対応ドライバーはこのオプションを無視します。
+
+### 契約
+
+| 条件 | 振る舞い |
+|---|---|
+| 呼び出し時点で `signal.aborted` | 推論を開始しない。`result` は reject せず `finishReason: 'error'` で resolve |
+| ストリーム消費中に `abort()` | バックエンドの推論を止め、`stream` を終了させる |
+| キャンセル判定 | `finishReason === 'error'` かつ `signal.aborted`（呼び出し側がキャンセルとエラーを区別） |
+| 部分応答 | キャンセル前に yield されたテキストは `result.content` に保持 |
+
+### ドライバー対応状況
+
+| ドライバー | `signal` 対応 |
+|---|---|
+| MlxDriver | ✅（Python 子プロセス連携） |
+| その他 | 未実装（無視） |
+
+### 使用例
+
+```typescript
+const controller = new AbortController();
+
+const { stream, result } = await driver.streamQuery(prompt, {
+  signal: controller.signal,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+  if (shouldCancel) controller.abort();
+}
+
+const final = await result;
+if (controller.signal.aborted) {
+  // キャンセル（Pi 連携では stopReason: "aborted" に変換）
+} else if (final.finishReason === 'error') {
+  // 推論エラー
+}
+```
+
+### MLX ドライバーの実装概要
+
+TS 側が `{"method":"cancel"}\n` を Python 子プロセスの stdin に送り、Python は `stream_generate` の各チャンク前に `poll_cancel()` で非ブロッキング検知してループを抜けます。同時に Node 側の `Readable` を `destroy()` し、stdout をドレインして次リクエストがキュー詰まりしないようにします。詳細は [プロンプトキャッシュ設計](./CACHE_DESIGN.md#queryresultusage-との関係) および `packages/driver/src/mlx-ml/python/handlers/cancel.py` を参照。
+
+## トークン使用量（usage）
+
+`QueryResult.usage` はプロバイダ報告のトークン数を正規化したオブジェクトです。
+
+| フィールド | 意味 |
+|---|---|
+| `promptTokens` | プロンプト側トークン総数（キャッシュ分を差し引く前の生値） |
+| `completionTokens` | 今回の生成トークン数 |
+| `totalTokens` | 少なくとも `promptTokens + completionTokens` と整合 |
+| `cacheReadTokens` | 今回リクエストでキャッシュから読んだトークン数（任意） |
+| `cacheWriteTokens` | 今回リクエストでキャッシュに新規書き込みしたトークン数（任意） |
+
+driver は `promptTokens` を「非キャッシュ入力」に分解しません（`promptTokens - cacheRead - cacheWrite` のような計算は行いません）。
+
+### ドライバー対応状況
+
+| ドライバー | `usage` 基本3フィールド | `cacheReadTokens` / `cacheWriteTokens` |
+|---|---|---|
+| OpenAI / Anthropic / VertexAI / GoogleGenAI | ✅ | 未対応（省略） |
+| MlxDriver | ✅ | ✅（KV キャッシュ利用時） |
+| その他 | 状況により異なる | 未対応 |
+
+MLX では Python 側の `prompt_tokens` / `generation_tokens` をマッピングし、`cacheReadTokens` は KV ヒット分、`cacheWriteTokens` は同一クエリ内の `prepare()` による新規 prefill 分を報告します。
+
+## 共通ユーティリティ（query-utils）
+
+`@modular-prompt/driver` が提供するヘルパー。カスタムドライバーやアダプタ実装で利用できます。
+
+```typescript
+import {
+  buildQueryUsage,
+  createAbortedStreamResult,
+  isAborted,
+  watchAbortSignal,
+} from '@modular-prompt/driver';
+```
+
+| 関数 | 用途 |
+|---|---|
+| `buildQueryUsage(counts)` | 生トークン数から `QueryResult.usage` を組み立て（全ゼロなら `undefined`） |
+| `createAbortedStreamResult(extras?)` | 即時 abort 用の空 `StreamResult`（`result` は resolve） |
+| `isAborted(signal?)` | `signal?.aborted ?? false` |
+| `watchAbortSignal(signal, onAbort)` | abort リスナー登録。既に aborted なら即 `onAbort` を呼ぶ |
+
 ## エラーハンドリング
 
 すべてのドライバーは統一されたエラーハンドリングを提供：
@@ -229,8 +322,10 @@ type DriverProvider =
 const result = await driver.query(prompt);
 
 if (result.finishReason === 'error') {
-  // エラー発生 — errors フィールドで詳細を確認
-  if (result.errors) {
+  // エラーまたはキャンセル — signal.aborted で区別
+  if (options?.signal?.aborted) {
+    console.log('Query was cancelled');
+  } else if (result.errors) {
     for (const entry of result.errors) {
       console.error(`[${entry.prefix}] ${entry.message}`);
     }

--- a/docs/DRIVER_API.md
+++ b/docs/DRIVER_API.md
@@ -111,8 +111,15 @@ interface QueryOptions {
   topP?: number;                // トップPサンプリング
   stream?: boolean;             // ストリーミング有効化
   reasoningEffort?: 'low' | 'medium' | 'high';  // 推論深度（thinking系モデル用）
+  signal?: AbortSignal;         // 推論キャンセル（未対応ドライバーは無視）
+  cache?: boolean | 'read-only'; // プロンプトキャッシュ（ドライバー依存）
 }
 ```
+
+**signal**: 進行中の推論をキャンセルするための `AbortSignal` です。
+- 呼び出し時点で `aborted` の場合、推論を開始せず `finishReason: 'error'` で `result` を resolve します
+- ストリーム消費中の abort では `result` を reject しません（キャンセル判定は `signal.aborted`）
+- 現時点で対応しているのは MLX ドライバーのみです
 
 **reasoningEffort**: 推論特化モデル（OpenAI o-series、llm-jp-4-thinking等）の思考深度を制御します。
 - 対応ドライバー: OpenAI（APIパラメータとして送信）、MLX（`apply_chat_template`に渡す）
@@ -129,9 +136,11 @@ interface QueryResult {
   structuredOutput?: unknown;          // 構造化出力（スキーマ指定時）
   finishReason?: 'stop' | 'length' | 'error' | 'tool_calls';
   usage?: {
-    promptTokens: number;
-    completionTokens: number;
-    totalTokens: number;
+    promptTokens: number;       // プロンプト側トークン総数（プロバイダ報告値）
+    completionTokens: number;   // 生成トークン数
+    totalTokens: number;        // promptTokens + completionTokens と整合
+    cacheReadTokens?: number;   // 今回リクエストでキャッシュから読んだトークン数
+    cacheWriteTokens?: number;  // 今回リクエストでキャッシュに新規書き込みしたトークン数
   };
   logEntries?: LogEntry[];             // クエリ実行中のログエントリ
   errors?: LogEntry[];                 // エラーレベルのログエントリ
@@ -141,6 +150,11 @@ interface QueryResult {
 **thinkingContent**: モデルの思考・推論過程の内容を格納します。
 - Harmonyフォーマット（llm-jp-4等）の `analysis` チャネル
 - 将来的にAnthropicのthinkingブロック等にも対応予定
+
+**usage**: トークン使用量は `stream` チャンクではなく `result.usage` にのみ載せます。
+- `promptTokens` はキャッシュ分を差し引く前のプロバイダ報告値です
+- `cacheReadTokens` / `cacheWriteTokens` はプロンプトキャッシュ対応ドライバーが任意で付与します（未取得時は省略または 0）
+- MLX ドライバーは `prompt_tokens` / `generation_tokens` をマッピングし、KV キャッシュ利用時は `cacheReadTokens` を付与します
 
 ### StreamResult
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Moduler Promptのドキュメント集へようこそ。このディレクトリ
 
 ### AIモデルとの接続
 
-- **[Driver APIリファレンス](./DRIVER_API.md)** - `@modular-prompt/driver`パッケージのAPIリファレンス
+- **[Driver APIリファレンス](./DRIVER_API.md)** - `@modular-prompt/driver`パッケージのAPIリファレンス（`signal` / `usage` / `query-utils` 含む）
 - **[ローカルモデルセットアップガイド](./LOCAL_MODEL_SETUP.md)** - MLXとOllamaのセットアップとモデルダウンロード
 - **[AIService 完全ガイド](./AI_SERVICE_GUIDE.md)** - 動的なAIドライバー選択と管理
 - **[Structured Outputs仕様](./STRUCTURED_OUTPUTS.md)** - 構造化出力の仕様と実装ガイド

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -243,7 +243,7 @@ describe('Parameter Mapping Integration', () => {
 // test/setup/mlx-test-setup.ts
 export class MlxTestEnvironment {
   private static instance: MlxTestEnvironment;
-  private testModel = 'mlx-community/gemma-3-270m-it-qat-4bit';
+  private testModel = DEFAULT_MLX_TEST_MODEL;
 
   static async setup() {
     if (!this.instance) {
@@ -287,11 +287,13 @@ export async function waitForModelLoad(
 
 | テストファイル | モデル指定元 | モデル名（例） | 備考 |
 |---|---|---|---|
-| `test/integration/*.integration.test.ts` | `test-drivers.yaml` の `mlx.nativeModel` | `mlx-community/Qwen3.5-4B-OptiQ-4bit`（ローカル設定による） | cache / abort / tool-call 統合テスト |
-| `test/integration/test-drivers.yaml.example` | 例示 | `Qwen3.5-2B-OptiQ-4bit` / `gemma-3-270m-it-qat-8bit` | fallback はテキスト注入 tool call 用 |
-| `src/mlx-ml/mlx-driver-params.test.ts` | ハードコード | `mlx-community/gemma-3-27b-it-qat-4bit` | macOS ローカルのみ（CI スキップ） |
-| `src/mlx-ml/mlx-driver-structured-outputs.integration.test.ts` | ハードコード | `mlx-community/gemma-3-270m-it-qat-8bit` | macOS ローカルのみ（CI スキップ） |
-| `test/system/mlx-parameters.system.test.ts` | ハードコード | `mlx-community/gemma-3-270m-it-qat-8bit` | システムテスト専用 config |
+| `test/integration/mlx-abort-cache.integration.test.ts` | `DEFAULT_MLX_TEST_MODEL` | `Josiefied-LFM2.5-1.2B-Instruct-abliterated-4bit` | abort / cache usage |
+| `test/integration/mlx-cache.integration.test.ts` | `DEFAULT_MLX_TEST_MODEL` | 同上 | KV キャッシュ統合 |
+| `test/integration/mlx-tool-call.integration.test.ts` | `test-drivers.yaml` | `nativeModel` / `fallbackModel` | native のみ実行中。fallback は #294 待ちでスキップ |
+| `test/integration/test-drivers.yaml.example` | 例示 | Josiefied-LFM2.5-1.2B / Gemma-3-270m-GroomAttention | native は LFM、fallback は tool なし |
+| `src/mlx-ml/mlx-driver-params.test.ts` | `DEFAULT_MLX_TEST_MODEL` | Josiefied-LFM2.5-1.2B | macOS ローカルのみ（CI スキップ） |
+| `src/mlx-ml/mlx-driver-structured-outputs.integration.test.ts` | `DEFAULT_MLX_TEST_MODEL` | 同上 | macOS ローカルのみ（CI スキップ） |
+| `test/system/mlx-parameters.system.test.ts` | `DEFAULT_MLX_TEST_MODEL` | 同上 | システムテスト専用 config |
 | `src/mlx-ml/mlx-driver*.test.ts`（abort 等） | モック | `test-model`（実ロードなし） | `MlxProcess` を vi.mock |
 
 ユニットテスト（`mlx-driver-abort.test.ts` 等）は **Python 子プロセスを起動せず** `test-model` 名で `MlxProcess` をモックします。実モデルをロードするのは `describe.skipIf(!darwin || !test-drivers.yaml)` 付きの統合テストのみです。

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -279,6 +279,23 @@ export async function waitForModelLoad(
 
 ## モックの使用方針
 
+### MLX ローカルモデルテストの並行実行
+
+`packages/driver` の Vitest 設定では **並行実行を禁止** しています（`fileParallelism: false`, `maxWorkers: 1`）。オンメモリ MLX モデルはメモリを大量に消費するため、同一ワーカーで逐次実行します。
+
+### テストで使用しているローカルモデル一覧
+
+| テストファイル | モデル指定元 | モデル名（例） | 備考 |
+|---|---|---|---|
+| `test/integration/*.integration.test.ts` | `test-drivers.yaml` の `mlx.nativeModel` | `mlx-community/Qwen3.5-4B-OptiQ-4bit`（ローカル設定による） | cache / abort / tool-call 統合テスト |
+| `test/integration/test-drivers.yaml.example` | 例示 | `Qwen3.5-2B-OptiQ-4bit` / `gemma-3-270m-it-qat-8bit` | fallback はテキスト注入 tool call 用 |
+| `src/mlx-ml/mlx-driver-params.test.ts` | ハードコード | `mlx-community/gemma-3-27b-it-qat-4bit` | macOS ローカルのみ（CI スキップ） |
+| `src/mlx-ml/mlx-driver-structured-outputs.integration.test.ts` | ハードコード | `mlx-community/gemma-3-270m-it-qat-8bit` | macOS ローカルのみ（CI スキップ） |
+| `test/system/mlx-parameters.system.test.ts` | ハードコード | `mlx-community/gemma-3-270m-it-qat-8bit` | システムテスト専用 config |
+| `src/mlx-ml/mlx-driver*.test.ts`（abort 等） | モック | `test-model`（実ロードなし） | `MlxProcess` を vi.mock |
+
+ユニットテスト（`mlx-driver-abort.test.ts` 等）は **Python 子プロセスを起動せず** `test-model` 名で `MlxProcess` をモックします。実モデルをロードするのは `describe.skipIf(!darwin || !test-drivers.yaml)` 付きの統合テストのみです。
+
 ### MLXドライバーテストでのモック戦略
 
 | テストレベル | MLXプロセス | モデルロード | 推論実行 |

--- a/docs/TOOLS_SPEC.md
+++ b/docs/TOOLS_SPEC.md
@@ -131,6 +131,10 @@ interface QueryOptions {
   toolChoice?: ToolChoice;
   /** 会話ループ用の追加メッセージ（tool result等） */
   messages?: ChatMessage[];
+  /** 推論キャンセル（未対応ドライバーは無視） */
+  signal?: AbortSignal;
+  /** プロンプトキャッシュ（ドライバー依存） */
+  cache?: boolean | 'read-only';
 }
 ```
 
@@ -142,6 +146,13 @@ interface QueryResult {
   /** モデルが選択したツール呼び出し（0個以上） */
   toolCalls?: ToolCall[];
   finishReason?: 'stop' | 'length' | 'error' | 'tool_calls';
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
 }
 ```
 

--- a/docs/UTILITIES.md
+++ b/docs/UTILITIES.md
@@ -785,6 +785,26 @@ const noUsage = aggregateUsage([undefined, undefined]);
 // undefined
 ```
 
+`aggregateUsage` は `promptTokens` / `completionTokens` / `totalTokens` のみ合算します。`cacheReadTokens` / `cacheWriteTokens` は現時点では合算しません。
+
+### buildQueryUsage()（@modular-prompt/driver）
+
+単一クエリの usage オブジェクトを組み立てるヘルパー。カスタムドライバー実装で利用します。
+
+```typescript
+import { buildQueryUsage } from '@modular-prompt/driver';
+
+const usage = buildQueryUsage({
+  promptTokens: 100,
+  completionTokens: 20,
+  cacheReadTokens: 80,
+  cacheWriteTokens: 0,
+});
+// { promptTokens: 100, completionTokens: 20, totalTokens: 120, cacheReadTokens: 80 }
+```
+
+詳細は [Driver APIリファレンス](./DRIVER_API.md#共通ユーティリティquery-utils) を参照。
+
 ### aggregateLogEntries()
 
 複数の LogEntry 配列をフラット化します。全タスク・全クエリのログを1つの配列にまとめる際に使用します。

--- a/packages/driver/README.md
+++ b/packages/driver/README.md
@@ -73,9 +73,69 @@ if (result.logEntries) {
 ## 主な機能
 
 - **統一インターフェース**: `query()` / `streamQuery()` / `close()` の3メソッド
+- **推論キャンセル**: `QueryOptions.signal`（`AbortSignal`）— 現時点は MLX ドライバーで実装
+- **トークン使用量**: `QueryResult.usage`（`cacheReadTokens` / `cacheWriteTokens` 含む）
 - **ツール呼び出し**: Function Calling対応（OpenAI、Anthropic、VertexAI、GoogleGenAI）
 - **構造化出力**: JSONスキーマによる出力制御
 - **AIService**: 能力ベースのモデル自動選択
+
+## 推論キャンセル（AbortSignal）
+
+```typescript
+import { MlxDriver } from '@modular-prompt/driver';
+
+const driver = new MlxDriver({ model: 'mlx-community/...' });
+const controller = new AbortController();
+
+const { stream, result } = await driver.streamQuery(prompt, {
+  signal: controller.signal,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+}
+
+// 途中でキャンセルする場合
+controller.abort();
+
+const final = await result;
+// final.finishReason === 'error' かつ controller.signal.aborted → キャンセル
+```
+
+- `result` はキャンセル時も **reject しません**（`finishReason: 'error'` で resolve）
+- キャンセル前の部分応答は `result.content` に残ります
+- 他ドライバーは `signal` を無視します（未実装）
+
+詳細は [Driver APIリファレンス](../../docs/DRIVER_API.md#推論キャンセルabortsignal) を参照。
+
+## トークン使用量（usage）
+
+```typescript
+const { stream, result } = await driver.streamQuery(prompt, { cache: true });
+for await (const _ of stream) { /* consume */ }
+
+const final = await result;
+if (final.usage) {
+  console.log(final.usage.promptTokens, final.usage.completionTokens);
+  console.log(final.usage.cacheReadTokens);   // MLX + KV キャッシュ時
+  console.log(final.usage.cacheWriteTokens);  // 同一クエリ内の新規 prefill 時
+}
+```
+
+usage は `stream` の各チャンクではなく **`result.usage` のみ** に載ります。
+
+## 共通ユーティリティ（query-utils）
+
+カスタムドライバーやアダプタ向けヘルパー:
+
+```typescript
+import {
+  buildQueryUsage,
+  createAbortedStreamResult,
+  isAborted,
+  watchAbortSignal,
+} from '@modular-prompt/driver';
+```
 
 ## カスタムドライバーの作成
 

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -1,3 +1,12 @@
+// Query utilities (shared driver interface helpers)
+export {
+  buildQueryUsage,
+  createAbortedStreamResult,
+  isAborted,
+  watchAbortSignal,
+  type UsageCounts,
+} from './query-utils.js';
+
 // Types
 export type {
   AIDriver,

--- a/packages/driver/src/mlx-ml/mlx-driver-abort.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver-abort.test.ts
@@ -86,6 +86,26 @@ describe('MlxDriver abort signal', () => {
     expect(mockProcess.cancelActiveRequest).toHaveBeenCalled();
   });
 
+  it('rejects result on non-abort stream errors', async () => {
+    const driver = new MlxDriver({ model: 'test-model' });
+
+    const failingStream = new Readable({
+      read() {
+        this.destroy(new Error('stream failed'));
+      },
+    });
+    mockProcess.chat.mockResolvedValue(failingStream);
+
+    const { stream, result } = await driver.streamQuery(prompt);
+    await expect(async () => {
+      for await (const chunk of stream) {
+        void chunk;
+      }
+    }).rejects.toThrow('stream failed');
+
+    await expect(result).rejects.toThrow('stream failed');
+  });
+
   it('includes usage with token counts from stream meta', async () => {
     const driver = new MlxDriver({ model: 'test-model' });
     const { stream, result } = await driver.streamQuery(prompt);

--- a/packages/driver/src/mlx-ml/mlx-driver-abort.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver-abort.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Readable } from 'stream';
+import { MlxDriver } from './mlx-driver.js';
+import type { CompiledPrompt } from '@modular-prompt/core';
+
+const META_MARKER = '\x1e__META__:';
+
+function createMockStream(chunks: string[]): Readable {
+  return Readable.from(chunks);
+}
+
+const mockCapabilities = {
+  methods: ['chat', 'completion', 'format_test', 'capabilities'],
+  special_tokens: {},
+  features: {
+    apply_chat_template: true,
+    vocab_size: 32000,
+    model_max_length: 4096,
+    chat_template: {
+      supported_roles: ['system', 'user', 'assistant'],
+      preview: null,
+      constraints: {},
+    },
+  },
+};
+
+const mockProcess = {
+  ensureInitialized: vi.fn().mockResolvedValue(undefined),
+  getCapabilities: vi.fn().mockResolvedValue(mockCapabilities),
+  chat: vi.fn(),
+  completion: vi.fn(),
+  cancelActiveRequest: vi.fn(),
+  exit: vi.fn(),
+};
+
+vi.mock('./process/index.js', () => ({
+  MlxProcess: vi.fn().mockImplementation(() => mockProcess),
+}));
+
+const prompt: CompiledPrompt = {
+  instructions: [{ type: 'text', content: 'Hello' }],
+  data: [],
+  output: [],
+};
+
+describe('MlxDriver abort signal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcess.getCapabilities.mockResolvedValue(mockCapabilities);
+    mockProcess.chat.mockResolvedValue(
+      createMockStream(['partial ', `answer${META_MARKER}{"prompt_tokens":10,"generation_tokens":3}`]),
+    );
+  });
+
+  it('returns immediately when signal is already aborted', async () => {
+    const driver = new MlxDriver({ model: 'test-model' });
+    const controller = new AbortController();
+    controller.abort();
+
+    const { stream, result } = await driver.streamQuery(prompt, { signal: controller.signal });
+
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([]);
+    await expect(result).resolves.toMatchObject({
+      content: '',
+      finishReason: 'error',
+    });
+    expect(mockProcess.chat).not.toHaveBeenCalled();
+  });
+
+  it('invokes cancelActiveRequest when aborted during stream', async () => {
+    const driver = new MlxDriver({ model: 'test-model' });
+    const controller = new AbortController();
+
+    mockProcess.chat.mockResolvedValue(createMockStream(['partial ']));
+
+    const { stream } = await driver.streamQuery(prompt, { signal: controller.signal });
+    const iterator = stream[Symbol.asyncIterator]();
+    await iterator.next();
+    controller.abort();
+
+    expect(mockProcess.cancelActiveRequest).toHaveBeenCalled();
+  });
+
+  it('includes usage with token counts from stream meta', async () => {
+    const driver = new MlxDriver({ model: 'test-model' });
+    const { stream, result } = await driver.streamQuery(prompt);
+
+    for await (const _chunk of stream) {
+      // consume
+    }
+
+    await expect(result).resolves.toMatchObject({
+      usage: {
+        promptTokens: 10,
+        completionTokens: 3,
+        totalTokens: 13,
+      },
+      finishReason: 'stop',
+    });
+  });
+});

--- a/packages/driver/src/mlx-ml/mlx-driver-abort.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver-abort.test.ts
@@ -90,8 +90,8 @@ describe('MlxDriver abort signal', () => {
     const driver = new MlxDriver({ model: 'test-model' });
     const { stream, result } = await driver.streamQuery(prompt);
 
-    for await (const _chunk of stream) {
-      // consume
+    for await (const chunk of stream) {
+      void chunk;
     }
 
     await expect(result).resolves.toMatchObject({

--- a/packages/driver/src/mlx-ml/mlx-driver-params.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver-params.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { MlxDriver } from './mlx-driver.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
 import { platform } from 'os';
+import { DEFAULT_MLX_TEST_MODEL } from '../../test/integration/test-config.js';
 
 // MLXはApple Silicon専用なので、CI環境や非対応環境ではスキップ
 const shouldSkipMLX =
@@ -22,7 +23,7 @@ describe.skipIf(shouldSkipMLX)('MLX Driver Parameters Integration', () => {
   beforeAll(async () => {
     // ダウンロード済みのモデルを使用
     driver = new MlxDriver({
-      model: 'mlx-community/gemma-3-27b-it-qat-4bit'
+      model: DEFAULT_MLX_TEST_MODEL,
     });
   });
 

--- a/packages/driver/src/mlx-ml/mlx-driver-structured-outputs.integration.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver-structured-outputs.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { MlxDriver } from './mlx-driver.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
 import { platform } from 'os';
+import { DEFAULT_MLX_TEST_MODEL } from '../../test/integration/test-config.js';
 
 // Test data types
 interface PersonData {
@@ -27,7 +28,7 @@ describe.skipIf(shouldSkipMLX)('MLXDriver Structured Outputs', () => {
 
   beforeAll(() => {
     driver = new MlxDriver({
-      model: 'mlx-community/gemma-3-270m-it-qat-8bit',
+      model: DEFAULT_MLX_TEST_MODEL,
       defaultOptions: {
         maxTokens: 100,
         temperature: 0.1,  // Low temperature for more deterministic output

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -17,6 +17,12 @@ import { QueryLogger } from '../query-logger.js';
 import type { PromptCacheController } from '../cache-controller.js';
 import { extractCacheablePrefix } from '../cache-utils.js';
 import { MlxCacheController } from './mlx-cache-controller.js';
+import {
+  buildQueryUsage,
+  createAbortedStreamResult,
+  isAborted,
+  watchAbortSignal,
+} from '../query-utils.js';
 
 // ========================================================================
 // Utility Functions (exported for testing)
@@ -83,7 +89,10 @@ function extractStreamMeta(content: string): { content: string; meta: StreamMeta
   }
 }
 
-function createStreamIterable(stream: Readable): {
+function createStreamIterable(
+  stream: Readable,
+  isAborted?: () => boolean,
+): {
   iterable: AsyncIterable<string>;
   completion: Promise<{ content: string; meta: StreamMeta; error: Error | null }>;
 } {
@@ -100,6 +109,9 @@ function createStreamIterable(stream: Readable): {
         let buffer = '';
         let markerFound = false;
         for await (const chunk of stream) {
+          if (isAborted?.()) {
+            break;
+          }
           const str = chunk.toString();
           chunks.push(str);
           if (markerFound) continue;
@@ -120,12 +132,19 @@ function createStreamIterable(stream: Readable): {
         if (!markerFound && buffer) yield buffer;
         const raw = chunks.join('');
         const { content, meta } = extractStreamMeta(raw);
+        const aborted = isAborted?.() ?? false;
         resolveCompletion({ content, meta, error: null });
+        if (aborted) {
+          return;
+        }
       } catch (error) {
         const raw = chunks.join('');
         const { content, meta } = extractStreamMeta(raw);
-        resolveCompletion({ content, meta, error: error as Error });
-        throw error;
+        const aborted = isAborted?.() ?? false;
+        resolveCompletion({ content, meta, error: aborted ? null : error as Error });
+        if (!aborted) {
+          throw error;
+        }
       }
     }
   };
@@ -255,7 +274,7 @@ export class MlxDriver implements AIDriver {
     prompt: CompiledPrompt,
     mlxOptions: MlxMlModelOptions,
     options?: QueryOptions
-  ): Promise<{ stream: Readable; cacheTokensUsed: number }> {
+  ): Promise<{ stream: Readable; cacheTokensUsed: number; cacheWriteTokens: number }> {
     // APIを選択
     const api = this.determineApi(options);
 
@@ -302,6 +321,10 @@ export class MlxDriver implements AIDriver {
       // - trustRemoteCode未指定（明示的なtrue/falseどちらもapply_chat_template kwargsに影響）
       let cachePath: string | undefined;
       let cacheTrimTokens: number | undefined;
+      let cacheWriteTokens = 0;
+      const cacheGrowthBefore = this.cacheController instanceof MlxCacheController
+        ? this.cacheController.getStats().cacheGrowthTokens
+        : 0;
       const trustRemoteCode = mlxOptions.trustRemoteCode;
       if (this.cacheController && options?.cache !== false && trustRemoteCode === undefined) {
         const prefix = extractCacheablePrefix(augmentedPrompt);
@@ -331,16 +354,23 @@ export class MlxDriver implements AIDriver {
         }
       }
 
+      if (this.cacheController instanceof MlxCacheController) {
+        cacheWriteTokens = Math.max(
+          0,
+          this.cacheController.getStats().cacheGrowthTokens - cacheGrowthBefore,
+        );
+      }
+
       stream = await this.process.chat(mlxMessages, undefined, mlxOptions, nativeTools, images.length > 0 ? images : undefined, images.length > 0 ? this.maxImageSize : undefined, options?.reasoningEffort, cachePath, cacheTrimTokens);
 
       const cacheTokensUsed = cachePath
         ? (cacheTrimTokens ?? (this.cacheController instanceof MlxCacheController
           ? this.cacheController.readCacheTokenCount(cachePath) : 0))
         : 0;
-      return { stream, cacheTokensUsed };
+      return { stream, cacheTokensUsed, cacheWriteTokens };
     }
 
-    return { stream, cacheTokensUsed: 0 };
+    return { stream, cacheTokensUsed: 0, cacheWriteTokens: 0 };
   }
 
   /**
@@ -368,6 +398,18 @@ export class MlxDriver implements AIDriver {
   ): Promise<StreamResult> {
     await this.ensureInitialized();
 
+    const signal = options?.signal;
+    if (isAborted(signal)) {
+      return createAbortedStreamResult(this.queryLogger.collect());
+    }
+
+    let abortRequested = false;
+    const cleanupAbort = watchAbortSignal(signal, () => {
+      abortRequested = true;
+      this.process.cancelActiveRequest();
+    });
+    const checkAborted = () => abortRequested || isAborted(signal);
+
     // Merge options (only override if explicitly provided)
     const mlxOptions: MlxMlModelOptions = {
       ...this.defaultOptions,
@@ -378,19 +420,18 @@ export class MlxDriver implements AIDriver {
     };
     this.queryLogger.mark(mlxOptions as Record<string, unknown>);
 
-    // Use executeQuery for the actual stream generation
     const queryStart = performance.now();
-    const { stream, cacheTokensUsed } = await this.executeQuery(prompt, mlxOptions, options);
+    const { stream, cacheTokensUsed, cacheWriteTokens } = await this.executeQuery(prompt, mlxOptions, options);
+
+    if (checkAborted()) {
+      this.process.cancelActiveRequest();
+    }
+
     const streamStart = performance.now();
     this.queryLogger.log.debug(`setup ${(streamStart - queryStart).toFixed(0)}ms`);
 
-    // Convert stream to async iterable with collection
-    const { iterable, completion } = createStreamIterable(stream);
+    const { iterable, completion } = createStreamIterable(stream, checkAborted);
 
-    // Wrap iterable with phase-separated timing:
-    //   TTFT: streamStart → first chunk (inference latency, shows cache benefit)
-    //   generation: first chunk → last chunk (output speed, tok/s)
-    //   query total: queryStart → last chunk (end-to-end)
     const queryLogger = this.queryLogger;
     let firstChunkTime = 0;
     const wrappedIterable: AsyncIterable<string> = {
@@ -399,6 +440,10 @@ export class MlxDriver implements AIDriver {
         let firstChunk = true;
         return {
           async next() {
+            if (checkAborted()) {
+              void inner.return?.();
+              return { done: true as const, value: undefined };
+            }
             const result = await inner.next();
             if (!result.done) {
               if (firstChunk) {
@@ -419,72 +464,85 @@ export class MlxDriver implements AIDriver {
             return result;
           },
           async return(value?: string) {
+            cleanupAbort();
             return inner.return?.(value) ?? { done: true as const, value: undefined };
           },
           async throw(e?: unknown) {
+            cleanupAbort();
             return inner.throw?.(e) ?? { done: true as const, value: undefined };
           },
         };
       },
     };
 
-    // Create result promise that waits for stream completion
     const cacheController = this.cacheController;
-    const resultPromise = completion.then(({ content, meta, error }) => {
-      // If there was an error, log and throw it
-      if (error) {
-        this.queryLogger.log.error('Stream error:', error.message);
-        throw error;
-      }
-
-      if (cacheController instanceof MlxCacheController && meta.prompt_tokens != null) {
-        cacheController.recordPromptTokens(meta.prompt_tokens, cacheTokensUsed);
-      }
-
-      // Log accurate generation stats if available
-      if (meta.generation_tokens != null && firstChunkTime > 0) {
-        const genMs = performance.now() - firstChunkTime;
-        const actualTps = (meta.generation_tokens / genMs * 1000).toFixed(1);
-        this.queryLogger.log.debug(
-          `${meta.generation_tokens} tokens, ${actualTps} tok/s`
-        );
-      }
-
-      // Response post-processing: thinking抽出 + tool call解析
-      const hasTools = options?.tools && options.tools.length > 0;
-      const responseProcessor = selectResponseProcessor(this.model, this.runtimeInfo, { enableToolParsing: !!hasTools });
-      const parsed = responseProcessor(content);
-      let finalContent = parsed.content;
-      const thinkingContent = parsed.thinkingContent;
-      const toolCalls = parsed.toolCalls;
-
-      if (thinkingContent) {
-        this.queryLogger.log.verbose('Thinking content:', thinkingContent);
-      }
-
-      // Handle structured output if schema is provided
-      let structuredOutput: unknown | undefined;
-      if (prompt.metadata?.outputSchema && finalContent) {
-        const extracted = extractJSON(finalContent, { multiple: false });
-        if (extracted.source !== 'none' && extracted.data !== null) {
-          structuredOutput = extracted.data;
+    const resultPromise = completion
+      .then(({ content, meta, error }) => {
+        const aborted = checkAborted();
+        if (error && !aborted) {
+          this.queryLogger.log.error('Stream error:', error.message);
+          throw error;
         }
-      }
 
-      const finishReason: FinishReason = toolCalls ? 'tool_calls' : 'stop';
-      return {
-        content: finalContent,
-        thinkingContent,
-        structuredOutput,
-        toolCalls,
-        finishReason,
-        ...this.queryLogger.collect()
-      };
-    });
+        if (cacheController instanceof MlxCacheController && meta.prompt_tokens != null) {
+          cacheController.recordPromptTokens(meta.prompt_tokens, cacheTokensUsed);
+        }
+
+        if (meta.generation_tokens != null && firstChunkTime > 0) {
+          const genMs = performance.now() - firstChunkTime;
+          const actualTps = (meta.generation_tokens / genMs * 1000).toFixed(1);
+          this.queryLogger.log.debug(
+            `${meta.generation_tokens} tokens, ${actualTps} tok/s`
+          );
+        }
+
+        const hasTools = options?.tools && options.tools.length > 0;
+        const responseProcessor = selectResponseProcessor(this.model, this.runtimeInfo, { enableToolParsing: !!hasTools });
+        const parsed = responseProcessor(content);
+        const finalContent = parsed.content;
+        const thinkingContent = parsed.thinkingContent;
+        const toolCalls = parsed.toolCalls;
+
+        if (thinkingContent) {
+          this.queryLogger.log.verbose('Thinking content:', thinkingContent);
+        }
+
+        let structuredOutput: unknown | undefined;
+        if (prompt.metadata?.outputSchema && finalContent) {
+          const extracted = extractJSON(finalContent, { multiple: false });
+          if (extracted.source !== 'none' && extracted.data !== null) {
+            structuredOutput = extracted.data;
+          }
+        }
+
+        const finishReason: FinishReason = aborted
+          ? 'error'
+          : toolCalls
+            ? 'tool_calls'
+            : 'stop';
+
+        return {
+          content: finalContent,
+          thinkingContent,
+          structuredOutput,
+          toolCalls,
+          finishReason,
+          usage: buildQueryUsage({
+            promptTokens: meta.prompt_tokens,
+            completionTokens: meta.generation_tokens,
+            cacheReadTokens: cacheTokensUsed,
+            cacheWriteTokens,
+          }),
+          ...this.queryLogger.collect(),
+        };
+      })
+      .finally(() => {
+        cleanupAbort();
+      });
 
     return {
       stream: wrappedIterable,
-      result: resultPromise
+      result: resultPromise,
     };
   }
   

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -98,6 +98,16 @@ function createStreamIterable(
 } {
   const chunks: string[] = [];
   let resolveCompletion: (value: { content: string; meta: StreamMeta; error: Error | null }) => void;
+  let settled = false;
+
+  const settle = (error: Error | null) => {
+    if (settled) return;
+    settled = true;
+    const raw = chunks.join('');
+    const { content, meta } = extractStreamMeta(raw);
+    const aborted = isAborted?.() ?? false;
+    resolveCompletion({ content, meta, error: aborted ? null : error });
+  };
 
   const completion = new Promise<{ content: string; meta: StreamMeta; error: Error | null }>((resolve) => {
     resolveCompletion = resolve;
@@ -130,21 +140,14 @@ function createStreamIterable(
           }
         }
         if (!markerFound && buffer) yield buffer;
-        const raw = chunks.join('');
-        const { content, meta } = extractStreamMeta(raw);
-        const aborted = isAborted?.() ?? false;
-        resolveCompletion({ content, meta, error: null });
-        if (aborted) {
-          return;
-        }
       } catch (error) {
-        const raw = chunks.join('');
-        const { content, meta } = extractStreamMeta(raw);
+        settle(error as Error);
         const aborted = isAborted?.() ?? false;
-        resolveCompletion({ content, meta, error: aborted ? null : error as Error });
         if (!aborted) {
           throw error;
         }
+      } finally {
+        settle(null);
       }
     }
   };

--- a/packages/driver/src/mlx-ml/process/index.ts
+++ b/packages/driver/src/mlx-ml/process/index.ts
@@ -64,7 +64,8 @@ export class MlxProcess {
 
     const queueCallbacks: QueueManagerCallbacks = {
       sendToProcess: (data: string) => this.processComm.sendToProcess(data),
-      createNewStream: () => this.processComm.createNewStream()
+      createNewStream: () => this.processComm.createNewStream(),
+      cancelActiveStream: () => this.processComm.cancelActiveStream(),
     };
 
     // 各コンポーネント初期化
@@ -112,6 +113,10 @@ export class MlxProcess {
 
   async exit(): Promise<void> {
     await this.processComm.exit();
+  }
+
+  cancelActiveRequest(): void {
+    this.queueManager.cancelActiveRequest();
   }
 
   // デバッグ・ステータス情報

--- a/packages/driver/src/mlx-ml/process/process-communication.ts
+++ b/packages/driver/src/mlx-ml/process/process-communication.ts
@@ -42,6 +42,7 @@ export class ProcessCommunication {
   private decoder: StringDecoder;
   private currentStream: Readable | null = null;
   private jsonBuffer: string = '';
+  private draining = false;
   private callbacks: ProcessCommunicationCallbacks;
 
   constructor(modelName: string, callbacks: ProcessCommunicationCallbacks, options?: ProcessCommunicationOptions) {
@@ -118,6 +119,8 @@ export class ProcessCommunication {
           this.currentStream.push(chunk);
           this.currentStream.push(null); // ストリーム終了
           this.currentStream = null;
+        } else if (this.draining) {
+          // キャンセル後のドレイン: データを破棄
         } else {
           // JSONレスポンスの場合
           this.jsonBuffer += chunk;
@@ -126,6 +129,10 @@ export class ProcessCommunication {
         }
 
         this.callbacks.onRequestCompleted();
+
+        if (this.draining) {
+          this.draining = false;
+        }
 
         // null文字以降の残りデータを続けて処理
         remaining = remaining.slice(nullIndex + 1);
@@ -136,6 +143,8 @@ export class ProcessCommunication {
         if (this.currentStream) {
           // ストリーミング中
           this.currentStream.push(chunk);
+        } else if (this.draining) {
+          // キャンセル後のドレイン: データを破棄
         } else {
           // JSONレスポンス蓄積中
           this.jsonBuffer += chunk;
@@ -150,6 +159,29 @@ export class ProcessCommunication {
       read() {} // 空のreadメソッド
     });
     return this.currentStream;
+  }
+
+  /**
+   * Cancel the active streaming request.
+   * Destroys the current stream, drains stdout until the response terminator,
+   * and sends a cancel command to the Python process.
+   */
+  cancelActiveStream(): void {
+    if (!this.currentStream && !this.draining) {
+      return;
+    }
+
+    if (this.currentStream) {
+      this.currentStream.destroy();
+      this.currentStream = null;
+    }
+
+    this.draining = true;
+    this.sendToProcess(JSON.stringify({ method: 'cancel' }) + '\n');
+  }
+
+  isDraining(): boolean {
+    return this.draining;
   }
 
   sendToProcess(data: string): void {

--- a/packages/driver/src/mlx-ml/process/queue.cancel.test.ts
+++ b/packages/driver/src/mlx-ml/process/queue.cancel.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Readable } from 'stream';
+import { QueueManager } from './queue.js';
+
+function createQueueManager(overrides?: Partial<{
+  cancelActiveStream: () => void;
+}>) {
+  const cancelActiveStream = overrides?.cancelActiveStream ?? vi.fn();
+  const sendToProcess = vi.fn();
+  const queue = new QueueManager({
+    sendToProcess,
+    createNewStream: () => new Readable({ read() {} }),
+    cancelActiveStream,
+  });
+  return { queue, cancelActiveStream, sendToProcess };
+}
+
+describe('QueueManager.cancelActiveRequest', () => {
+  it('calls cancelActiveStream while a streaming request is in flight', async () => {
+    const { queue, cancelActiveStream } = createQueueManager();
+
+    const streamPromise = queue.addChatRequest([{ role: 'user', content: 'hi' }]);
+    await streamPromise;
+
+    queue.cancelActiveRequest();
+    expect(cancelActiveStream).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing when the queue is idle', () => {
+    const { queue, cancelActiveStream } = createQueueManager();
+
+    queue.cancelActiveRequest();
+    expect(cancelActiveStream).not.toHaveBeenCalled();
+  });
+
+  it('unblocks the queue after request completion following cancel', async () => {
+    const { queue, sendToProcess } = createQueueManager();
+
+    await queue.addChatRequest([{ role: 'user', content: 'first' }]);
+    queue.onRequestCompleted();
+
+    await queue.addChatRequest([{ role: 'user', content: 'second' }]);
+    expect(sendToProcess).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/driver/src/mlx-ml/process/queue.ts
+++ b/packages/driver/src/mlx-ml/process/queue.ts
@@ -31,6 +31,7 @@ import type {
 export interface QueueManagerCallbacks {
   sendToProcess: (data: string) => void;
   createNewStream: () => Readable;
+  cancelActiveStream: () => void;
 }
 
 export class QueueManager {
@@ -250,6 +251,13 @@ export class QueueManager {
   onRequestCompleted(): void {
     this.isProcessing = false;
     this.processNext(); // 次のリクエストを処理
+  }
+
+  cancelActiveRequest(): void {
+    if (!this.isProcessing) {
+      return;
+    }
+    this.callbacks.cancelActiveStream();
   }
 
   get length(): number {

--- a/packages/driver/src/mlx-ml/python/handlers/cancel.py
+++ b/packages/driver/src/mlx-ml/python/handlers/cancel.py
@@ -1,0 +1,53 @@
+"""Cancel request handling for in-flight streaming generation."""
+
+from __future__ import annotations
+
+import json
+import select
+import sys
+
+_cancel_requested = False
+
+
+def request_cancel() -> None:
+    global _cancel_requested
+    _cancel_requested = True
+
+
+def reset_cancel() -> None:
+    global _cancel_requested
+    _cancel_requested = False
+
+
+def is_cancel_requested() -> bool:
+    return _cancel_requested
+
+
+def poll_cancel() -> bool:
+    """Non-blocking check for a cancel command on stdin during streaming."""
+    global _cancel_requested
+    if _cancel_requested:
+        return True
+
+    try:
+        ready, _, _ = select.select([sys.stdin], [], [], 0)
+    except (ValueError, OSError):
+        return False
+
+    if not ready:
+        return False
+
+    line = sys.stdin.readline()
+    if not line:
+        return False
+
+    try:
+        req = json.loads(line)
+    except json.JSONDecodeError:
+        return False
+
+    if req.get("method") == "cancel":
+        _cancel_requested = True
+        return True
+
+    return False

--- a/packages/driver/src/mlx-ml/python/handlers/chat.py
+++ b/packages/driver/src/mlx-ml/python/handlers/chat.py
@@ -7,6 +7,7 @@ import sys
 from backends.base import ModelBackend
 from mlx_lm.models.cache import trim_prompt_cache
 from utils.prompt_builder import generate_merged_prompt, supports_chat_template
+from handlers.cancel import poll_cancel
 
 
 def _read_cache_token_count(cache_path: str) -> int | None:
@@ -34,6 +35,8 @@ def _stream_to_stdout(
 
     last_response = None
     for response in backend.stream_generate(prompt, options, images, prompt_cache=prompt_cache):
+        if poll_cancel():
+            break
         print(response.text.replace("\0", "").replace("\x1e", ""), end="", flush=True)
         last_response = response
 

--- a/packages/driver/src/mlx-ml/python/handlers/completion.py
+++ b/packages/driver/src/mlx-ml/python/handlers/completion.py
@@ -5,6 +5,7 @@ import re
 import sys
 
 from backends.base import ModelBackend
+from handlers.cancel import poll_cancel
 
 
 def handle_completion(
@@ -31,6 +32,8 @@ def handle_completion(
             sys.stderr.write(f"--- prompt\n{prompt}\n")
 
     for response in backend.stream_generate(prompt, final_options, images):
+        if poll_cancel():
+            break
         print(response.text.replace("\0", ""), end="", flush=True)
 
     print("\n", end="\0", flush=True)

--- a/packages/driver/src/mlx-ml/python/server.py
+++ b/packages/driver/src/mlx-ml/python/server.py
@@ -4,6 +4,7 @@ import sys
 
 from backends.base import ModelBackend
 from handlers import handle_cache_prefill, handle_capabilities, handle_chat, handle_completion, handle_format_test, handle_tokenize
+from handlers.cancel import request_cancel, reset_cancel
 
 
 MAX_READ_LINES = 10000
@@ -47,6 +48,12 @@ class Server:
         if not method:
             self._error_response("'method' field is required")
             return
+
+        if method == 'cancel':
+            request_cancel()
+            return
+
+        reset_cancel()
 
         try:
             if method == 'capabilities':

--- a/packages/driver/src/mlx-ml/tool-call-parser/tool-formatter.ts
+++ b/packages/driver/src/mlx-ml/tool-call-parser/tool-formatter.ts
@@ -77,8 +77,8 @@ export function formatToolDefinitionsAsText(
   }
 
   const concreteExample = exampleToolName
-    ? `{"name": "${exampleToolName}", "arguments": ${exampleArgs}}`
-    : '{"name": "tool_name", "arguments": {"key": "value"}}';
+    ? `{ "name": "${exampleToolName}", "arguments": ${exampleArgs} }`
+    : '{ "name": "tool_name", "arguments": {"key": "value"} }';
 
   if (toolCallFormat?.call_start && toolCallFormat?.call_end) {
     lines.push('To call a tool, respond ONLY with:');

--- a/packages/driver/src/query-utils.test.ts
+++ b/packages/driver/src/query-utils.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildQueryUsage,
+  createAbortedStreamResult,
+  isAborted,
+  watchAbortSignal,
+} from './query-utils.js';
+
+describe('buildQueryUsage', () => {
+  it('returns undefined when all counts are zero', () => {
+    expect(buildQueryUsage({})).toBeUndefined();
+    expect(buildQueryUsage({ promptTokens: 0, completionTokens: 0 })).toBeUndefined();
+  });
+
+  it('maps prompt and completion tokens', () => {
+    expect(buildQueryUsage({ promptTokens: 10, completionTokens: 5 })).toEqual({
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
+  it('includes cache fields when positive', () => {
+    expect(
+      buildQueryUsage({
+        promptTokens: 100,
+        completionTokens: 20,
+        cacheReadTokens: 80,
+        cacheWriteTokens: 30,
+      }),
+    ).toEqual({
+      promptTokens: 100,
+      completionTokens: 20,
+      totalTokens: 120,
+      cacheReadTokens: 80,
+      cacheWriteTokens: 30,
+    });
+  });
+
+  it('omits zero cache fields', () => {
+    expect(
+      buildQueryUsage({ promptTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 }),
+    ).toEqual({
+      promptTokens: 1,
+      completionTokens: 0,
+      totalTokens: 1,
+    });
+  });
+});
+
+describe('isAborted', () => {
+  it('returns false when signal is undefined', () => {
+    expect(isAborted()).toBe(false);
+  });
+
+  it('reflects signal.aborted', () => {
+    const controller = new AbortController();
+    expect(isAborted(controller.signal)).toBe(false);
+    controller.abort();
+    expect(isAborted(controller.signal)).toBe(true);
+  });
+});
+
+describe('watchAbortSignal', () => {
+  it('invokes onAbort immediately when already aborted', () => {
+    const controller = new AbortController();
+    controller.abort();
+    const onAbort = vi.fn();
+    const cleanup = watchAbortSignal(controller.signal, onAbort);
+    expect(onAbort).toHaveBeenCalledOnce();
+    cleanup();
+  });
+
+  it('invokes onAbort when signal aborts later', () => {
+    const controller = new AbortController();
+    const onAbort = vi.fn();
+    const cleanup = watchAbortSignal(controller.signal, onAbort);
+    expect(onAbort).not.toHaveBeenCalled();
+    controller.abort();
+    expect(onAbort).toHaveBeenCalledOnce();
+    cleanup();
+  });
+});
+
+describe('createAbortedStreamResult', () => {
+  it('resolves with error finish reason and empty stream', async () => {
+    const { stream, result } = createAbortedStreamResult();
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([]);
+    await expect(result).resolves.toEqual({
+      content: '',
+      finishReason: 'error',
+    });
+  });
+});

--- a/packages/driver/src/query-utils.ts
+++ b/packages/driver/src/query-utils.ts
@@ -1,0 +1,85 @@
+import type { QueryResult, StreamResult } from './types.js';
+
+/**
+ * Token usage fields for {@link QueryResult.usage}.
+ * Drivers map provider-specific stats into this shape.
+ */
+export interface UsageCounts {
+  promptTokens?: number;
+  completionTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+/**
+ * Build {@link QueryResult.usage} from raw token counts.
+ * Omits the field when all counts are zero/undefined.
+ */
+export function buildQueryUsage(counts: UsageCounts): QueryResult['usage'] | undefined {
+  const promptTokens = counts.promptTokens ?? 0;
+  const completionTokens = counts.completionTokens ?? 0;
+  const cacheReadTokens = counts.cacheReadTokens ?? 0;
+  const cacheWriteTokens = counts.cacheWriteTokens ?? 0;
+
+  if (
+    promptTokens === 0 &&
+    completionTokens === 0 &&
+    cacheReadTokens === 0 &&
+    cacheWriteTokens === 0
+  ) {
+    return undefined;
+  }
+
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+    ...(cacheReadTokens > 0 ? { cacheReadTokens } : {}),
+    ...(cacheWriteTokens > 0 ? { cacheWriteTokens } : {}),
+  };
+}
+
+/** Whether an {@link AbortSignal} is already aborted. */
+export function isAborted(signal?: AbortSignal): boolean {
+  return signal?.aborted ?? false;
+}
+
+/**
+ * Register an abort listener. Invokes `onAbort` immediately when already aborted.
+ * Returns a cleanup function.
+ */
+export function watchAbortSignal(
+  signal: AbortSignal | undefined,
+  onAbort: () => void,
+): () => void {
+  if (!signal) {
+    return () => {};
+  }
+  if (signal.aborted) {
+    onAbort();
+    return () => {};
+  }
+  const handler = () => onAbort();
+  signal.addEventListener('abort', handler);
+  return () => signal.removeEventListener('abort', handler);
+}
+
+/**
+ * StreamResult for a request that was aborted before inference started.
+ * `result` resolves (does not reject) with `finishReason: 'error'`.
+ */
+export function createAbortedStreamResult(
+  extras: Partial<QueryResult> = {},
+): StreamResult {
+  const emptyStream: AsyncIterable<string> = {
+    async *[Symbol.asyncIterator]() {},
+  };
+  return {
+    stream: emptyStream,
+    result: Promise.resolve({
+      content: '',
+      finishReason: 'error',
+      ...extras,
+    }),
+  };
+}

--- a/packages/driver/src/types.ts
+++ b/packages/driver/src/types.ts
@@ -110,6 +110,10 @@ export interface QueryResult {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
+    /** Tokens read from prompt/KV cache in this request */
+    cacheReadTokens?: number;
+    /** Tokens newly written to prompt/KV cache in this request */
+    cacheWriteTokens?: number;
   };
 
   /** Tool calls selected by the model */
@@ -170,6 +174,11 @@ export interface QueryOptions {
    * - undefined: driver default behavior
    */
   cache?: boolean | 'read-only';
+  /**
+   * Abort signal for cancelling in-flight inference.
+   * Unsupported drivers ignore this option.
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/packages/driver/test/integration/mlx-abort-cache.integration.test.ts
+++ b/packages/driver/test/integration/mlx-abort-cache.integration.test.ts
@@ -2,10 +2,8 @@
  * MLX Driver: AbortSignal と cache usage の統合テスト
  *
  * 実 MLX モデルを 1 プロセスで逐次実行する（並行実行禁止）。
- * モデルは test-drivers.yaml の mlx.nativeModel を使用。
- *
- * ローカル設定例（packages/driver/test/integration/test-drivers.yaml）:
- *   nativeModel: mlx-community/Qwen3.5-4B-OptiQ-4bit
+ * モデルは DEFAULT_MLX_TEST_MODEL（軽量・逐次実行向け）。
+ * tool-call 統合テストの nativeModel / fallbackModel とは別設定。
  *
  * macOS + test-drivers.yaml の mlx セクションが必要。
  */
@@ -16,13 +14,24 @@ import type { PromptModule } from '@modular-prompt/core';
 import { compile, createContext } from '@modular-prompt/core';
 import { MlxDriver } from '../../src/mlx-ml/mlx-driver.js';
 import { MlxCacheController } from '../../src/mlx-ml/mlx-cache-controller.js';
-import { hasDriverConfig, getDriverConfig } from './test-config.js';
+import { hasDriverConfig, DEFAULT_MLX_TEST_MODEL } from './test-config.js';
 
 const isMacOS = platform() === 'darwin';
 
 interface ChatContext {
   userMessage: string;
 }
+
+/** abort 検証用: 長文生成を促す（chatModule の短文指示と混ぜない） */
+const longOutputModule: PromptModule<ChatContext> = {
+  createContext: () => ({ userMessage: '' }),
+  instructions: [
+    'You are a creative writing assistant. Write long, detailed multi-paragraph responses. Never summarize or stop early.',
+  ],
+  messages: [
+    (ctx) => ({ type: 'message' as const, role: 'user' as const, content: ctx.userMessage }),
+  ],
+};
 
 const chatModule: PromptModule<ChatContext> = {
   createContext: () => ({ userMessage: '' }),
@@ -48,8 +57,7 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Abort & Cache Usage In
     let model: string;
 
     beforeAll(async () => {
-      const config = getDriverConfig('mlx')!;
-      model = config.nativeModel!;
+      model = DEFAULT_MLX_TEST_MODEL;
 
       cacheController = new MlxCacheController();
       driver = new MlxDriver({ model, cacheController });
@@ -66,19 +74,22 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Abort & Cache Usage In
 
     it('aborts mid-stream, keeps partial content, and resolves result', async () => {
       const controller = new AbortController();
-      const ctx = createContext(chatModule);
-      ctx.userMessage = 'Count from 1 to 100 slowly, one number per line.';
+      const ctx = createContext(longOutputModule);
+      ctx.userMessage =
+        'Write a detailed essay of at least 800 words about the history of computing, ' +
+        'from mechanical calculators through mainframes, personal computers, the internet, and modern AI. ' +
+        'Use many paragraphs and elaborate on each era. Do not stop early.';
 
-      const { stream, result } = await driver.streamQuery(compile(chatModule, ctx), {
+      const { stream, result } = await driver.streamQuery(compile(longOutputModule, ctx), {
         signal: controller.signal,
-        maxTokens: 200,
-        temperature: 0,
+        maxTokens: 1024,
+        temperature: 0.7,
       });
 
       let received = '';
       for await (const chunk of stream) {
         received += chunk;
-        if (received.length >= 15) {
+        if (received.length >= 50) {
           controller.abort();
           break;
         }
@@ -89,7 +100,8 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Abort & Cache Usage In
       const final = await result;
       expect(final.finishReason).toBe('error');
       expect(final.content.length).toBeGreaterThan(0);
-      console.log('[abort-mid-stream] partial:', final.content.slice(0, 60));
+      expect(final.content.length).toBeLessThan(800);
+      console.log('[abort-mid-stream] partial:', final.content.slice(0, 80));
     }, 90_000);
 
     it('accepts the next query after abort without hanging', async () => {

--- a/packages/driver/test/integration/mlx-abort-cache.integration.test.ts
+++ b/packages/driver/test/integration/mlx-abort-cache.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * MLX Driver: AbortSignal と cache usage の統合テスト
+ *
+ * 実 MLX モデルを 1 プロセスで逐次実行する（並行実行禁止）。
+ * モデルは test-drivers.yaml の mlx.nativeModel を使用。
+ *
+ * ローカル設定例（packages/driver/test/integration/test-drivers.yaml）:
+ *   nativeModel: mlx-community/Qwen3.5-4B-OptiQ-4bit
+ *
+ * macOS + test-drivers.yaml の mlx セクションが必要。
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { platform } from 'os';
+import type { PromptModule } from '@modular-prompt/core';
+import { compile, createContext } from '@modular-prompt/core';
+import { MlxDriver } from '../../src/mlx-ml/mlx-driver.js';
+import { MlxCacheController } from '../../src/mlx-ml/mlx-cache-controller.js';
+import { hasDriverConfig, getDriverConfig } from './test-config.js';
+
+const isMacOS = platform() === 'darwin';
+
+interface ChatContext {
+  userMessage: string;
+}
+
+const chatModule: PromptModule<ChatContext> = {
+  createContext: () => ({ userMessage: '' }),
+  instructions: ['You are a helpful assistant. Reply in one short sentence.'],
+  messages: [
+    { type: 'message', role: 'user', content: 'What is 2+2?' },
+    { type: 'message', role: 'assistant', content: '2+2 equals 4.' },
+    (ctx) => ({ type: 'message' as const, role: 'user' as const, content: ctx.userMessage }),
+  ],
+};
+
+async function consumeStream(stream: AsyncIterable<string>): Promise<string> {
+  const chunks: string[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks.join('');
+}
+
+describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Abort & Cache Usage Integration', () => {
+    let driver: MlxDriver;
+    let cacheController: MlxCacheController;
+    let model: string;
+
+    beforeAll(async () => {
+      const config = getDriverConfig('mlx')!;
+      model = config.nativeModel!;
+
+      cacheController = new MlxCacheController();
+      driver = new MlxDriver({ model, cacheController });
+
+      const warmup: PromptModule = {
+        messages: [{ type: 'message', role: 'user', content: 'ping' }],
+      };
+      await driver.query(compile(warmup), { maxTokens: 1 });
+    }, 300_000);
+
+    afterAll(async () => {
+      await driver.close();
+    });
+
+    it('aborts mid-stream, keeps partial content, and resolves result', async () => {
+      const controller = new AbortController();
+      const ctx = createContext(chatModule);
+      ctx.userMessage = 'Count from 1 to 100 slowly, one number per line.';
+
+      const { stream, result } = await driver.streamQuery(compile(chatModule, ctx), {
+        signal: controller.signal,
+        maxTokens: 200,
+        temperature: 0,
+      });
+
+      let received = '';
+      for await (const chunk of stream) {
+        received += chunk;
+        if (received.length >= 15) {
+          controller.abort();
+          break;
+        }
+      }
+
+      expect(controller.signal.aborted).toBe(true);
+
+      const final = await result;
+      expect(final.finishReason).toBe('error');
+      expect(final.content.length).toBeGreaterThan(0);
+      console.log('[abort-mid-stream] partial:', final.content.slice(0, 60));
+    }, 90_000);
+
+    it('accepts the next query after abort without hanging', async () => {
+      const ctx = createContext(chatModule);
+      ctx.userMessage = 'Say OK only.';
+
+      const { stream, result } = await driver.streamQuery(compile(chatModule, ctx), {
+        maxTokens: 20,
+        temperature: 0,
+      });
+      await consumeStream(stream);
+
+      const final = await result;
+      expect(final.finishReason).not.toBe('error');
+      expect(final.content).toBeTruthy();
+      console.log('[after-abort] next query:', final.content.slice(0, 40));
+    }, 60_000);
+
+    it('reports cacheReadTokens when cache is reused', async () => {
+      const ctx1 = createContext(chatModule);
+      ctx1.userMessage = 'What is TypeScript in one sentence?';
+      const ctx2 = createContext(chatModule);
+      ctx2.userMessage = 'What is JavaScript in one sentence?';
+
+      const first = await driver.streamQuery(compile(chatModule, ctx1), {
+        cache: true,
+        maxTokens: 40,
+        temperature: 0,
+      });
+      await consumeStream(first.stream);
+      await first.result;
+
+      const second = await driver.streamQuery(compile(chatModule, ctx2), {
+        cache: true,
+        maxTokens: 40,
+        temperature: 0,
+      });
+      await consumeStream(second.stream);
+      const final = await second.result;
+
+      expect(final.usage).toBeDefined();
+      expect(final.usage!.promptTokens).toBeGreaterThan(0);
+      expect(final.usage!.completionTokens).toBeGreaterThan(0);
+      expect(final.usage!.totalTokens).toBe(
+        final.usage!.promptTokens + final.usage!.completionTokens,
+      );
+      expect(final.usage!.cacheReadTokens).toBeGreaterThan(0);
+
+      console.log('[cache-usage]', final.usage);
+    }, 120_000);
+
+    it('returns immediately when signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const ctx = createContext(chatModule);
+      ctx.userMessage = 'This should not run.';
+
+      const { stream, result } = await driver.streamQuery(compile(chatModule, ctx), {
+        signal: controller.signal,
+        maxTokens: 20,
+      });
+
+      const text = await consumeStream(stream);
+      const final = await result;
+
+      expect(text).toBe('');
+      expect(final.finishReason).toBe('error');
+      expect(final.content).toBe('');
+    }, 30_000);
+});

--- a/packages/driver/test/integration/mlx-cache.integration.test.ts
+++ b/packages/driver/test/integration/mlx-cache.integration.test.ts
@@ -105,6 +105,8 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Cache Integration', ()
       const result2 = await driver.query(compile(chatModule, ctx2), { maxTokens: 100, temperature: 0 });
       expect(result2.content).toBeTruthy();
       expect(result2.finishReason).toBeDefined();
+      expect(result2.usage?.promptTokens).toBeGreaterThan(0);
+      expect(result2.usage?.cacheReadTokens).toBeGreaterThan(0);
 
       console.log('[cache-messages] result1:', result1.content?.slice(0, 80));
       console.log('[cache-messages] result2:', result2.content?.slice(0, 80));
@@ -154,6 +156,8 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Cache Integration', ()
       const queryResult = await result;
       expect(chunks.length).toBeGreaterThan(0);
       expect(queryResult.content).toBeTruthy();
+      expect(queryResult.usage?.promptTokens).toBeGreaterThan(0);
+      expect(queryResult.usage?.completionTokens).toBeGreaterThan(0);
       console.log('[cache-messages-stream]:', queryResult.content?.slice(0, 80));
     }, 60_000);
   });

--- a/packages/driver/test/integration/mlx-cache.integration.test.ts
+++ b/packages/driver/test/integration/mlx-cache.integration.test.ts
@@ -7,15 +7,16 @@
  * - テストケース群1: 会話履歴（messages）のキャッシュ
  *   静的な会話履歴はcacheable prefix、動的な最新メッセージはvolatile
  * - テストケース群2: state/materials構成でのキャッシュ
- *   state (Current State section) がdata内のcacheable prefixを遮断する挙動
+ *   materials 等の安定セクションは prefix に含め、Current State と contextual 要素は除外
  *
- * test-drivers.yaml に mlx.nativeModel の設定が必要。
+ * モデルは DEFAULT_MLX_TEST_MODEL（軽量・逐次実行向け）。
+ * tool-call 統合テストの nativeModel / fallbackModel とは別設定。
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { MlxDriver } from '../../src/mlx-ml/mlx-driver.js';
 import { MlxCacheController } from '../../src/mlx-ml/mlx-cache-controller.js';
-import { hasDriverConfig, getDriverConfig } from './test-config.js';
+import { hasDriverConfig, DEFAULT_MLX_TEST_MODEL } from './test-config.js';
 import type { PromptModule } from '@modular-prompt/core';
 import { compile, createContext } from '@modular-prompt/core';
 import { extractCacheablePrefix } from '../../src/cache-utils.js';
@@ -38,8 +39,7 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Cache Integration', ()
   let model: string;
 
   beforeAll(async () => {
-    const config = getDriverConfig('mlx')!;
-    model = config.nativeModel!;
+    model = DEFAULT_MLX_TEST_MODEL;
 
     cacheController = new MlxCacheController();
     driver = new MlxDriver({ model, cacheController });
@@ -165,11 +165,10 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Cache Integration', ()
   // ================================================================
   // テストケース群2: State-aware caching
   //
-  // STANDARD_SECTIONSの配置順: state → inputs → materials → chunks → messages
-  // state (title: 'Current State') は extractCacheablePrefix で非キャッシュと判定
-  // されるため、data 内の cacheable prefix は state で遮断される。
-  //
-  // stateなしの場合は materials が cacheable prefix に含まれる。
+  // STANDARD_SECTIONS の data 配置順: inputs → materials → messages → chunks → state
+  // materials など安定セクションは cacheable prefix に含まれる。
+  // DynamicContent 由来の最新 user message (contextual) と Current State section は
+  // prefix 外（state は messages より後なので、contextual message で先に途切れる）。
   // ================================================================
   describe('State-aware caching', () => {
     const docModule: PromptModule<DocContext> = {
@@ -189,25 +188,24 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Cache Integration', ()
       ],
     };
 
-    it('should block data prefix at state section while queries still work', async () => {
+    it('should cache stable materials but exclude state and contextual messages from prefix', async () => {
       const ctx1 = createContext(docModule);
       ctx1.stateInfo = 'User is reading the API reference';
       ctx1.userMessage = 'What parameters does createUser accept?';
       const compiled1 = compile(docModule, ctx1);
 
-      // state が data 先頭に来るため、data の cacheable prefix は空
+      // materials + Messages section までが prefix。contextual user message と state は含まれない
       const prefix = extractCacheablePrefix(compiled1);
       expect(prefix.instructions.length).toBeGreaterThan(0);
-      expect(prefix.data.length).toBe(0);
+      expect(prefix.data.length).toBe(4);
 
-      // stateがprefixを遮断するため、キャッシュはinstructionsのみ
       const handle = await cacheController.prepare({
         model,
         instructions: prefix.instructions,
         data: prefix.data,
       });
       expect(handle.includes.instructions).toBe(true);
-      expect(handle.includes.dataElementCount).toBe(0);
+      expect(handle.includes.dataElementCount).toBe(4);
 
       const result1 = await driver.query(compiled1, { maxTokens: 100, temperature: 0 });
       expect(result1.content).toBeTruthy();

--- a/packages/driver/test/integration/mlx-tool-call.integration.test.ts
+++ b/packages/driver/test/integration/mlx-tool-call.integration.test.ts
@@ -4,6 +4,7 @@
  * 実際のMLXモデルを使用して、tool call機能が正しく動作することを検証する。
  * - nativeModel: chat_templateでtool call形式をサポートするモデル
  * - fallbackModel: テキスト注入方式でtool callを実現するモデル
+ *   （一時スキップ: unsupported かつ注入に従えるモデルがなく #294 待ち）
  *
  * test-drivers.yaml に mlx セクションの設定がない場合はスキップされる。
  */
@@ -156,7 +157,8 @@ describe.skipIf(!isMacOS || !hasDriverConfig('mlx'))('MLX Tool Call Integration'
     defineToolCallTests(() => driver, 'native');
   });
 
-  describe.skipIf(!mlxConfig?.fallbackModel)('Text-based Tool Support Model', () => {
+  // #294: QueryOptions.toolCallMode 実装後に再有効化
+  describe.skip('Text-based Tool Support Model', () => {
     let driver: MlxDriver;
 
     beforeAll(async () => {

--- a/packages/driver/test/integration/test-config.ts
+++ b/packages/driver/test/integration/test-config.ts
@@ -12,6 +12,16 @@ import yaml from 'js-yaml';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONFIG_PATH = join(__dirname, 'test-drivers.yaml');
 
+/** ローカル MLX 統合テストのデフォルトモデル（軽量・逐次実行向け） */
+export const DEFAULT_MLX_TEST_MODEL =
+  'prism-ml/Ternary-Bonsai-1.7B-mlx-2bit';
+
+/**
+ * test-drivers.yaml の mlx セクションは tool-call 統合テスト専用:
+ * - nativeModel: chat_template による native tool call 対応モデル
+ * - fallbackModel: テキスト注入方式（native 未サポート）のモデル
+ */
+
 export interface TestDriversConfig {
   anthropic?: {
     apiKey?: string;

--- a/packages/driver/test/integration/test-drivers.yaml.example
+++ b/packages/driver/test/integration/test-drivers.yaml.example
@@ -28,5 +28,5 @@ anthropic:
 #   model: gemini-2.0-flash
 
 # mlx:
-#   nativeModel: mlx-community/Qwen3.5-2B-OptiQ-4bit  # tool call native対応モデル
-#   fallbackModel: mlx-community/gemma-3-270m-it-qat-8bit  # テキスト注入方式で検証
+#   nativeModel: mlx-community/Josiefied-LFM2.5-1.2B-Instruct-abliterated-4bit
+#   fallbackModel: Naturemort/Gemma-3-270m-it-GroomAttention  # tool なし（テキスト注入）

--- a/packages/driver/test/integration/vertexai-driver.integration.test.ts
+++ b/packages/driver/test/integration/vertexai-driver.integration.test.ts
@@ -3,10 +3,12 @@
  *
  * 実際のVertexAI (Gemini) APIに接続して基本機能を確認する。
  * test-drivers.yaml に vertexai の設定がない場合はスキップされる。
+ *
+ * 一時スキップ: SDK更新・genai統合方針の検討待ち（#295）
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { VertexAIDriver } from '../../src/vertexai/vertexai-driver.js';
-import { hasDriverConfig, getDriverConfig } from './test-config.js';
+import { getDriverConfig } from './test-config.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
 
 function chatPrompt(content: string): CompiledPrompt {
@@ -17,7 +19,8 @@ function chatPrompt(content: string): CompiledPrompt {
   };
 }
 
-describe.skipIf(!hasDriverConfig('vertexai'))('VertexAIDriver Integration', () => {
+// #295: VertexAIDriver メンテナンス方針確定後に再有効化
+describe.skip('VertexAIDriver Integration', () => {
   let driver: VertexAIDriver;
 
   beforeAll(() => {

--- a/packages/driver/test/system/mlx-parameters.system.test.ts
+++ b/packages/driver/test/system/mlx-parameters.system.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { MlxDriver } from '../../src/mlx-ml/mlx-driver.js';
+import { DEFAULT_MLX_TEST_MODEL } from '../integration/test-config.js';
 import type { CompiledPrompt } from '@modular-prompt/core';
 import { platform } from 'os';
 
@@ -29,7 +30,7 @@ function chatPrompt(content: string): CompiledPrompt {
 
 describe.skipIf(!isMacOS)('MLX Parameters System Test', () => {
   let driver: MlxDriver;
-  const testModel = 'mlx-community/gemma-3-270m-it-qat-8bit';
+  const testModel = DEFAULT_MLX_TEST_MODEL;
 
   beforeAll(async () => {
     console.log(`\n🔧 Setting up MLX system test with model: ${testModel}`);

--- a/packages/driver/vitest.config.system.ts
+++ b/packages/driver/vitest.config.system.ts
@@ -6,6 +6,12 @@ export default defineConfig({
     include: [
       '**/test/system/**/*.test.ts'
     ],
+    // オンメモリ MLX モデルは逐次実行
+    fileParallelism: false,
+    maxWorkers: 1,
+    sequence: {
+      concurrent: false,
+    },
     // システムテストは時間がかかるため長めのタイムアウト
     testTimeout: 60000,     // 60秒
     hookTimeout: 60000,

--- a/packages/driver/vitest.config.ts
+++ b/packages/driver/vitest.config.ts
@@ -9,8 +9,14 @@ export default defineConfig({
       '**/test/system/**/*.test.ts',  // システムテストを除外
       '**/test/e2e/**/*.test.ts'      // E2Eテストを除外
     ],
+    // MLX 等のオンメモリモデルテストは逐次実行（並行禁止）
+    fileParallelism: false,
+    maxWorkers: 1,
+    sequence: {
+      concurrent: false,
+    },
     // タイムアウト設定
     testTimeout: 10000,     // ユニットテスト: 10秒
-    hookTimeout: 10000,
+    hookTimeout: 300_000,   // MLX 統合テストの beforeAll（モデルロード）向け
   }
 });

--- a/skills/driver-usage/SKILL.md
+++ b/skills/driver-usage/SKILL.md
@@ -54,6 +54,8 @@ interface QueryOptions {
   stream?: boolean;
   tools?: ToolDefinition[];
   toolChoice?: ToolChoice;
+  cache?: boolean | 'read-only';  // プロンプトキャッシュ（ドライバー依存）
+  signal?: AbortSignal;           // 推論キャンセル（未対応ドライバーは無視）
 }
 ```
 
@@ -67,6 +69,8 @@ interface QueryResult {
     promptTokens: number;
     completionTokens: number;
     totalTokens: number;
+    cacheReadTokens?: number;    // キャッシュヒット分（MLX 等）
+    cacheWriteTokens?: number;   // 新規キャッシュ書き込み分（MLX 等）
   };
   toolCalls?: ToolCall[];        // ツール呼び出し
   finishReason?: FinishReason;   // 'stop' | 'length' | 'error' | 'tool_calls'
@@ -78,9 +82,46 @@ interface QueryResult {
 ```typescript
 interface StreamResult {
   stream: AsyncIterable<string>;  // テキストチャンクのストリーム
-  result: Promise<QueryResult>;   // 最終結果（ストリーム完了後に解決）
+  result: Promise<QueryResult>;   // 最終結果（ストリーム完了または abort 後に解決）
 }
 ```
+
+- usage は `stream` チャンクではなく **`result.usage` のみ**
+- `signal` でキャンセルした場合も `result` は reject しない（`finishReason: 'error'` + `signal.aborted` で判定）
+
+## 推論キャンセル（AbortSignal）
+
+```typescript
+const controller = new AbortController();
+const { stream, result } = await driver.streamQuery(compiled, {
+  signal: controller.signal,
+});
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+  if (userPressedEsc) controller.abort();
+}
+
+const final = await result;
+```
+
+| ドライバー | 対応 |
+|---|---|
+| MlxDriver | ✅ stdin cancel + Python `poll_cancel()` |
+| その他 | 未実装（`signal` 無視） |
+
+ヘルパー: `watchAbortSignal`, `createAbortedStreamResult`, `isAborted`（`@modular-prompt/driver`）
+
+## トークン使用量とキャッシュ
+
+```typescript
+const final = await result;
+final.usage?.promptTokens;      // プロバイダ報告の prompt 側総数
+final.usage?.cacheReadTokens;   // MLX: KV キャッシュヒット分
+final.usage?.cacheWriteTokens;  // MLX: 同一クエリ内の新規 prefill 分
+```
+
+`buildQueryUsage()` でカスタムドライバーから同形式の usage を組み立てられます。
 
 ## 各ドライバーのConfig
 
@@ -218,6 +259,20 @@ await driver.close();
 ```
 
 Apple Silicon専用。Python 3.11以上が必要。
+
+#### AbortSignal（推論キャンセル）
+
+`QueryOptions.signal` を渡すと、ストリーム中の推論をキャンセルできます。
+
+```typescript
+const controller = new AbortController();
+const { stream, result } = await driver.streamQuery(compiled, {
+  signal: controller.signal,
+});
+// controller.abort() → Python 子プロセスに cancel 送信、部分 content 保持
+```
+
+実装: TS が stdin に `{"method":"cancel"}` を送り、Python の `stream_generate` ループが `poll_cancel()` で協調的に終了します。
 
 #### textOnlyオプション
 


### PR DESCRIPTION
## Summary

- `QueryOptions.signal` と `QueryResult.usage` の `cacheReadTokens` / `cacheWriteTokens` を共通ドライバ API として追加（#291）
- 共通ヘルパー `query-utils.ts`（`watchAbortSignal`, `buildQueryUsage`, `createAbortedStreamResult`）を `@modular-prompt/driver` からエクスポート
- MLX ドライバーで signal による推論キャンセル（Python 子プロセス連携含む）と usage / cache usage のマッピングを実装
- `DRIVER_API.md` に signal と cache usage フィールドの説明を追記

## スコープ外

- 他ドライバー（OpenAI / Anthropic 等）の signal 対応 — 未実装（無視で可）
- Pi 拡張側の `streamFromMessages` / 増分パーサ — modular-prompt-pi-provider 側

## Test plan

- [x] `pnpm --filter @modular-prompt/driver exec vitest run src/query-utils.test.ts src/mlx-ml/mlx-driver-abort.test.ts src/mlx-ml/mlx-driver.test.ts`
- [x] `pnpm --filter @modular-prompt/driver run typecheck`
- [x] MLX 実機でのストリーム途中 abort → 次リクエスト正常動作の確認
- [ ] Pi 連携アダプタとの結合（`abort.test.ts` 相当）

Closes #291


Made with [Cursor](https://cursor.com)