### PR TITLE
fix(ci): release ワークフローの npm EBADENGINE を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,12 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:
-    # release/*ブランチからのマージ時のみ実行
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    # release/*ブランチからのマージ時、または手動再実行時
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -29,8 +30,8 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Upgrade npm for Trusted Publisher
-      run: npm install -g npm@latest
-      # Trusted Publisher requires npm CLI v11.5.1+
+      run: npm install -g npm@^11.5.1
+      # Trusted Publisher requires npm CLI v11.5.1+ (npm@12 requires Node 22+)
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
*🤖 by Cursor*

## 問題

`release.yml` の `npm install -g npm@latest` が npm 12.0.1 を入れようとし、Node 20 で EBADENGINE:

```
Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
Actual:   {"node":"v20.20.2"}
```

Release v0.17.0 の npm 公開が失敗。

## 修正

- `npm@^11.5.1` に固定（Trusted Publisher 要件 v11.5.1+ を満たし Node 20 対応）
- `workflow_dispatch` 追加（マージ後に手動で Release 再実行可能）

## Test plan

- [ ] main マージ後 `gh workflow run Release` で成功
- [ ] `@modular-prompt/driver@0.14.0` が npm に公開される

Made with [Cursor](https://cursor.com)