### PR TITLE
fix(driver): MLX QueryOptions 処理の一本化（#298）

### DIFF
--- a/.changeset/mlx-query-options-unify.md
+++ b/.changeset/mlx-query-options-unify.md
@@ -1,0 +1,8 @@
+---
+"@modular-prompt/driver": patch
+---
+
+fix: MLX ドライバーの QueryOptions 処理を一本化し mode の Python 漏れを修正
+
+`defaultOptions` を `Partial<MlxQueryOptions>` に統一。マージ後に `toMlxSamplingOptions` で
+サンプリングパラメータのみ Python 層へ渡す。Closes #298

--- a/packages/driver/src/driver-registry/factory-helper.ts
+++ b/packages/driver/src/driver-registry/factory-helper.ts
@@ -76,7 +76,7 @@ export function registerStandardDriverFactories(
         defaultOptions: validateAndClampMaxTokens(
           spec,
           spec.defaultOptions
-        ) as Partial<import('../mlx-ml/types.js').MlxMlModelOptions>,
+        ),
         textOnly: spec.metadata?.textOnly as boolean | undefined,
         drafterModel: spec.metadata?.drafterModel as string | undefined,
         draftBlockSize: spec.metadata?.draftBlockSize as number | undefined

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -107,6 +107,8 @@ export type {
   MlxContentPart
 } from './mlx-ml/types.js';
 
+export type { MlxQueryOptions } from './mlx-ml/mlx-options.js';
+
 // VertexAI driver
 export {
   VertexAIDriver,

--- a/packages/driver/src/mlx-ml/mlx-driver-default-options.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver-default-options.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Readable } from 'stream';
+import { MlxDriver } from './mlx-driver.js';
+import type { CompiledPrompt } from '@modular-prompt/core';
+
+const mockCapabilities = {
+  methods: ['chat', 'completion', 'format_test', 'capabilities'],
+  special_tokens: {},
+  features: {
+    apply_chat_template: true,
+    vocab_size: 32000,
+    model_max_length: 4096,
+    chat_template: {
+      supported_roles: ['system', 'user', 'assistant'],
+      preview: null,
+      constraints: {},
+    },
+  },
+};
+
+const mockProcess = {
+  ensureInitialized: vi.fn().mockResolvedValue(undefined),
+  getCapabilities: vi.fn().mockResolvedValue(mockCapabilities),
+  chat: vi.fn(),
+  completion: vi.fn(),
+  cancelActiveRequest: vi.fn(),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('./process/index.js', () => ({
+  MlxProcess: vi.fn().mockImplementation(() => mockProcess),
+}));
+
+function createMockStream(chunks: string[]): Readable {
+  return Readable.from(chunks);
+}
+
+const prompt: CompiledPrompt = {
+  instructions: [{ type: 'text', content: 'test' }],
+  data: [],
+  output: [],
+};
+
+describe('MlxDriver defaultOptions.mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcess.chat.mockResolvedValue(createMockStream(['ok']));
+    mockProcess.completion.mockResolvedValue(createMockStream(['ok']));
+  });
+
+  it('does not pass mode to Python when set via defaultOptions', async () => {
+    const driver = new MlxDriver({
+      model: 'test-model',
+      defaultOptions: { mode: 'instruct', maxTokens: 16 },
+    });
+
+    await driver.query(prompt);
+
+    const completionOptions = mockProcess.completion.mock.calls[0]?.[1];
+    expect(completionOptions).toEqual({ maxTokens: 16 });
+    expect(completionOptions).not.toHaveProperty('mode');
+  });
+
+  it('uses defaultOptions.mode for API selection', async () => {
+    const driver = new MlxDriver({
+      model: 'test-model',
+      defaultOptions: { mode: 'instruct' },
+    });
+
+    await driver.query(prompt);
+
+    expect(mockProcess.completion).toHaveBeenCalled();
+    expect(mockProcess.chat).not.toHaveBeenCalled();
+  });
+});

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -6,6 +6,7 @@ import { formatPromptAsMessages } from '../formatter/converter.js';
 import { formatCompletionPrompt } from '../formatter/completion-formatter.js';
 import { MlxProcess } from './process/index.js';
 import type { MlxMlModelOptions, MlxModelCapabilities } from './types.js';
+import { mergeMlxQueryOptions, toMlxSamplingOptions, type MlxQueryOptions } from './mlx-options.js';
 import type { MlxRuntimeInfo } from './process/types.js';
 import { createModelSpecificProcessor, selectApi } from './process/model-specific.js';
 import { selectResponseProcessor } from './process/model-handlers.js';
@@ -54,7 +55,7 @@ export function hasMessageElement(prompt: CompiledPrompt): boolean {
  */
 export interface MlxDriverConfig {
   model: string;
-  defaultOptions?: Partial<MlxMlModelOptions>;
+  defaultOptions?: Partial<MlxQueryOptions>;
   formatterOptions?: FormatterOptions;
   /** VLM画像の最大辺ピクセル数（デフォルト: 768） */
   maxImageSize?: number;
@@ -161,7 +162,7 @@ function createStreamIterable(
 export class MlxDriver implements AIDriver {
   private process: MlxProcess;
   private model: string;
-  private _defaultOptions: Partial<MlxMlModelOptions>;
+  private _defaultOptions: Partial<MlxQueryOptions>;
   private runtimeInfo: MlxRuntimeInfo | null = null;
   private modelProcessor;
   private formatterOptions: FormatterOptions;
@@ -170,17 +171,17 @@ export class MlxDriver implements AIDriver {
   private cacheController?: PromptCacheController;
   private cacheControllerBound = false;
 
-  get defaultOptions(): Partial<MlxMlModelOptions> {
+  get defaultOptions(): Partial<MlxQueryOptions> {
     return this._defaultOptions;
   }
 
-  set defaultOptions(value: Partial<MlxMlModelOptions>) {
-    this._defaultOptions = value;
+  set defaultOptions(value: Partial<MlxQueryOptions>) {
+    this._defaultOptions = value ?? {};
   }
 
   constructor(config: MlxDriverConfig) {
     this.model = config.model;
-    this._defaultOptions = config.defaultOptions || {};
+    this._defaultOptions = config.defaultOptions ?? {};
     this.formatterOptions = config.formatterOptions || {};
     this.maxImageSize = config.maxImageSize ?? 768;
     this.process = new MlxProcess(config.model, {
@@ -276,7 +277,7 @@ export class MlxDriver implements AIDriver {
   private async executeQuery(
     prompt: CompiledPrompt,
     mlxOptions: MlxMlModelOptions,
-    options?: QueryOptions
+    options?: MlxQueryOptions
   ): Promise<{ stream: Readable; cacheTokensUsed: number; cacheWriteTokens: number }> {
     // APIを選択
     const api = this.determineApi(options);
@@ -413,18 +414,12 @@ export class MlxDriver implements AIDriver {
     });
     const checkAborted = () => abortRequested || isAborted(signal);
 
-    // Merge options (only override if explicitly provided)
-    const mlxOptions: MlxMlModelOptions = {
-      ...this.defaultOptions,
-      ...(options?.maxTokens !== undefined && { maxTokens: options.maxTokens }),
-      ...(options?.temperature !== undefined && { temperature: options.temperature }),
-      ...(options?.topP !== undefined && { topP: options.topP }),
-      ...(options?.topK !== undefined && { topK: options.topK }),
-    };
-    this.queryLogger.mark(mlxOptions as Record<string, unknown>);
+    const merged = mergeMlxQueryOptions(this._defaultOptions, options);
+    const mlxOptions = toMlxSamplingOptions(merged);
+    this.queryLogger.mark(merged as Record<string, unknown>);
 
     const queryStart = performance.now();
-    const { stream, cacheTokensUsed, cacheWriteTokens } = await this.executeQuery(prompt, mlxOptions, options);
+    const { stream, cacheTokensUsed, cacheWriteTokens } = await this.executeQuery(prompt, mlxOptions, merged);
 
     if (checkAborted()) {
       this.process.cancelActiveRequest();

--- a/packages/driver/src/mlx-ml/mlx-options.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-options.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { mergeMlxQueryOptions, toMlxSamplingOptions } from './mlx-options.js';
+import { mapOptionsToPython } from './process/parameter-mapper.js';
+
+describe('mergeMlxQueryOptions', () => {
+  it('merges defaults with per-query overrides', () => {
+    const merged = mergeMlxQueryOptions(
+      { mode: 'instruct', temperature: 0.1, maxTokens: 50 },
+      { temperature: 0.8, topP: 0.9 },
+    );
+
+    expect(merged).toEqual({
+      mode: 'instruct',
+      temperature: 0.8,
+      maxTokens: 50,
+      topP: 0.9,
+    });
+  });
+});
+
+describe('toMlxSamplingOptions', () => {
+  it('extracts only Python-facing sampling parameters', () => {
+    const merged = mergeMlxQueryOptions(
+      {
+        mode: 'instruct',
+        maxTokens: 128,
+        temperature: 0.2,
+        repetitionPenalty: 1.1,
+        tools: [{ name: 'fn' }],
+        signal: undefined,
+        cache: true,
+        apiStrategy: 'force-chat',
+      },
+      {},
+    );
+
+    expect(toMlxSamplingOptions(merged)).toEqual({
+      maxTokens: 128,
+      temperature: 0.2,
+      repetitionPenalty: 1.1,
+    });
+    expect(toMlxSamplingOptions(merged)).not.toHaveProperty('mode');
+  });
+});
+
+describe('mode is not forwarded to Python', () => {
+  it('mapOptionsToPython rejects mode in strict mode', () => {
+    expect(() => mapOptionsToPython({ mode: 'instruct' } as never, true)).toThrow('Unknown parameter');
+  });
+});

--- a/packages/driver/src/mlx-ml/mlx-options.ts
+++ b/packages/driver/src/mlx-ml/mlx-options.ts
@@ -1,0 +1,49 @@
+import type { QueryOptions } from '../types.js';
+import type { MlxMlModelOptions } from './types.js';
+
+/** MLX 固有のサンプリングパラメータ（QueryOptions に無いもの） */
+export type MlxSamplingExtras = Pick<
+  MlxMlModelOptions,
+  'repetitionPenalty' | 'repetitionContextSize' | 'trustRemoteCode'
+>;
+
+/**
+ * MLX ドライバーのクエリオプション。
+ * 共通 QueryOptions + MLX 固有サンプリング。Python 層には toMlxSamplingOptions で変換して渡す。
+ */
+export type MlxQueryOptions = QueryOptions & Partial<MlxSamplingExtras>;
+
+const MLX_SAMPLING_KEYS = [
+  'maxTokens',
+  'temperature',
+  'topP',
+  'topK',
+  'repetitionPenalty',
+  'repetitionContextSize',
+  'trustRemoteCode',
+] as const satisfies readonly (keyof MlxMlModelOptions)[];
+
+/**
+ * defaultOptions と per-query オプションをマージする（他ドライバーと同じパターン）。
+ */
+export function mergeMlxQueryOptions(
+  defaults?: Partial<MlxQueryOptions>,
+  overrides?: QueryOptions,
+): MlxQueryOptions {
+  return { ...defaults, ...overrides };
+}
+
+/**
+ * マージ済み QueryOptions から Python 向けサンプリングパラメータのみ抽出する。
+ * mode / apiStrategy / tools / signal / cache 等は含めない。
+ */
+export function toMlxSamplingOptions(merged: Partial<MlxQueryOptions>): MlxMlModelOptions {
+  const result: MlxMlModelOptions = {};
+  for (const key of MLX_SAMPLING_KEYS) {
+    const value = merged[key];
+    if (value !== undefined) {
+      (result as Record<string, unknown>)[key] = value;
+    }
+  }
+  return result;
+}

--- a/packages/driver/src/mlx-ml/types.ts
+++ b/packages/driver/src/mlx-ml/types.ts
@@ -58,7 +58,6 @@ export type MlxMessage = MlxStandardMessage | MlxAssistantToolCallMessage | MlxT
  * Python側へはmapOptionsToPythonで変換される
  */
 export interface MlxMlModelOptions {
-  mode?: import('../types.js').QueryMode;
   maxTokens?: number;
   temperature?: number;
   topP?: number;


### PR DESCRIPTION
*🤖 by Cursor*

Closes #298

## Summary

`ModelSpec.defaultOptions.mode` が `mlxOptions` に spread され Python 層で `Unknown parameter 'mode'` になるバグを修正し、他ドライバーと同じ **QueryOptions マージ → 境界 map** パターンに一本化しました。

## 変更内容

- `MlxDriverConfig.defaultOptions` を `Partial<MlxQueryOptions>` に統一（`QueryOptions` + MLX 固有サンプリング）
- `mergeMlxQueryOptions` で default / per-query を一度マージ
- `toMlxSamplingOptions` で Python 向けフィールドのみ抽出（`mode` / `apiStrategy` / `tools` 等は除外）
- `MlxMlModelOptions` から `mode` を削除（Python ワイヤ型として維持）
- `MlxQueryOptions` を `@modular-prompt/driver` から export

## 設計

```
defaultOptions + options
  → mergeMlxQueryOptions (1回)
  → toMlxSamplingOptions → Python
  → determineApi(merged.mode) → TS 層 API 選択
```

## Test plan

- [x] `mlx-options.test.ts` — merge / sampling 抽出 / mode 拒否
- [x] `mlx-driver-default-options.test.ts` — defaultOptions.mode が API 選択に効き Python に渡らない
- [x] `pnpm typecheck` (driver)
- [ ] CI green

Made with [Cursor](https://cursor.com)