### PR TITLE
feat(driver): LIP 通信層を InferenceProcessClient に抽出（Phase 2）

### DIFF
--- a/.changeset/lip-phase2-process-client.md
+++ b/.changeset/lip-phase2-process-client.md
@@ -1,0 +1,7 @@
+---
+"@modular-prompt/driver": minor
+---
+
+feat: LIP 通信層を InferenceProcessClient に抽出（Phase 2）
+
+Closes #309

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -123,6 +123,11 @@ export type {
   InferenceCachePrefillResult,
 } from './local-inference/index.js';
 
+export {
+  InferenceProcessClient,
+  type InferenceProcessClientConfig,
+} from './local-inference/index.js';
+
 // Python runtime (MLX venv under ~/.modular-prompt)
 export {
   MODULAR_PROMPT_DIR,

--- a/packages/driver/src/local-inference/index.ts
+++ b/packages/driver/src/local-inference/index.ts
@@ -1,3 +1,10 @@
+/**
+ * Local Inference Protocol — モジュール集約
+ *
+ * `@modular-prompt/driver` の公開 API は主に `InferenceProcessClient`。
+ * 以下の通信層・キュー型はパッケージ内部向け（テスト・将来の PyTorch バックエンド用）。
+ */
+
 export type {
   InferenceMethod,
   InferenceContentPart,
@@ -24,6 +31,7 @@ export type {
   InferenceTokenizeResult,
 } from './protocol.js';
 
+/** @internal キュー実装の内部型 */
 export type {
   LegacyStreamingRequest,
   BaseQueueItem,
@@ -35,18 +43,21 @@ export type {
   QueueItem,
 } from './queue-types.js';
 
+/** @internal stdio 通信（InferenceProcessClient から利用） */
 export {
   ProcessCommunication,
   type ProcessCommunicationCallbacks,
   type ProcessCommunicationConfig,
 } from './process-communication.js';
 
+/** @internal JSON-RPC リクエストキュー */
 export {
   InferenceRequestQueue,
   type RequestQueueCallbacks,
   type SamplingOptionsMapper,
 } from './request-queue.js';
 
+/** バックエンド非依存の LIP プロセスクライアント（公開 API） */
 export {
   InferenceProcessClient,
   type InferenceProcessClientConfig,

--- a/packages/driver/src/local-inference/index.ts
+++ b/packages/driver/src/local-inference/index.ts
@@ -23,3 +23,31 @@ export type {
   InferenceFormatTestResult,
   InferenceTokenizeResult,
 } from './protocol.js';
+
+export type {
+  LegacyStreamingRequest,
+  BaseQueueItem,
+  CapabilitiesQueueItem,
+  FormatTestQueueItem,
+  TokenizeQueueItem,
+  CachePrefillQueueItem,
+  StreamingQueueItem,
+  QueueItem,
+} from './queue-types.js';
+
+export {
+  ProcessCommunication,
+  type ProcessCommunicationCallbacks,
+  type ProcessCommunicationConfig,
+} from './process-communication.js';
+
+export {
+  InferenceRequestQueue,
+  type RequestQueueCallbacks,
+  type SamplingOptionsMapper,
+} from './request-queue.js';
+
+export {
+  InferenceProcessClient,
+  type InferenceProcessClientConfig,
+} from './process-client.js';

--- a/packages/driver/src/local-inference/process-client.test.ts
+++ b/packages/driver/src/local-inference/process-client.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import type { InferenceProcessClientConfig } from './process-client.js';
+
+describe('InferenceProcessClientConfig', () => {
+  it('accepts configurable python project and venv paths', () => {
+    const config: InferenceProcessClientConfig = {
+      modelName: 'test-model',
+      pythonProjectDir: '/custom/python',
+      venvPath: '/custom/.venv',
+      extraSpawnArgs: ['--text-only'],
+      loggerPrefix: 'TEST',
+    };
+    expect(config.pythonProjectDir).toBe('/custom/python');
+    expect(config.venvPath).toBe('/custom/.venv');
+  });
+});

--- a/packages/driver/src/local-inference/process-client.test.ts
+++ b/packages/driver/src/local-inference/process-client.test.ts
@@ -1,16 +1,52 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { ProcessCommunication } from './process-communication.js';
 import type { InferenceProcessClientConfig } from './process-client.js';
 
-describe('InferenceProcessClientConfig', () => {
-  it('accepts configurable python project and venv paths', () => {
-    const config: InferenceProcessClientConfig = {
+vi.mock('./process-communication.js', () => ({
+  ProcessCommunication: vi.fn().mockImplementation(() => ({
+    sendToProcess: vi.fn(),
+    createNewStream: vi.fn(),
+    cancelActiveStream: vi.fn(),
+    isStreamingActive: vi.fn(() => false),
+    isJsonBuffering: vi.fn(() => false),
+    exit: vi.fn(),
+  })),
+}));
+
+vi.mock('../runtime/index.js', () => ({
+  assertRuntimeReady: vi.fn(),
+}));
+
+import { InferenceProcessClient } from './process-client.js';
+
+describe('InferenceProcessClient', () => {
+  it('passes python project dir, venv path, and spawn args to ProcessCommunication', () => {
+    new InferenceProcessClient({
       modelName: 'test-model',
       pythonProjectDir: '/custom/python',
       venvPath: '/custom/.venv',
       extraSpawnArgs: ['--text-only'],
       loggerPrefix: 'TEST',
+    });
+
+    expect(ProcessCommunication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pythonProjectDir: '/custom/python',
+        venvPath: '/custom/.venv',
+        modelName: 'test-model',
+        extraArgs: ['--text-only'],
+        loggerPrefix: 'TEST',
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('accepts configurable paths in InferenceProcessClientConfig', () => {
+    const config: InferenceProcessClientConfig = {
+      modelName: 'test-model',
+      pythonProjectDir: '/custom/python',
+      venvPath: '/custom/.venv',
     };
     expect(config.pythonProjectDir).toBe('/custom/python');
-    expect(config.venvPath).toBe('/custom/.venv');
   });
 });

--- a/packages/driver/src/local-inference/process-client.ts
+++ b/packages/driver/src/local-inference/process-client.ts
@@ -1,0 +1,190 @@
+/**
+ * Local Inference Protocol プロセスクライアント
+ *
+ * stdio JSON-RPC 通信とリクエストキューを統合する。
+ */
+
+import { Readable } from 'stream';
+import { Logger } from '@modular-prompt/utils';
+import type { RuntimeProfile } from '../runtime/index.js';
+import { assertRuntimeReady } from '../runtime/index.js';
+import type {
+  InferenceCapabilities,
+  InferenceFormatTestResult,
+  InferenceTokenizeResult,
+  InferenceCachePrefillResult,
+  InferenceMessage,
+  InferenceToolDefinition,
+} from './protocol.js';
+import {
+  ProcessCommunication,
+  type ProcessCommunicationCallbacks,
+} from './process-communication.js';
+import {
+  InferenceRequestQueue,
+  type RequestQueueCallbacks,
+  type SamplingOptionsMapper,
+} from './request-queue.js';
+
+export interface InferenceProcessClientConfig {
+  modelName: string;
+  /** uv --project に渡す Python プロジェクトディレクトリ */
+  pythonProjectDir: string;
+  /** UV_PROJECT_ENVIRONMENT に設定する venv パス */
+  venvPath: string;
+  /** 指定時は起動前に runtime venv の存在を確認する */
+  runtimeProfile?: RuntimeProfile;
+  extraSpawnArgs?: string[];
+  loggerPrefix?: string;
+  mapSamplingOptions?: SamplingOptionsMapper;
+  processExitErrorMessage?: (code: number | null, signal: string | null) => string;
+}
+
+export class InferenceProcessClient {
+  readonly modelName: string;
+
+  private requestQueue: InferenceRequestQueue;
+  private processComm: ProcessCommunication;
+
+  constructor(config: InferenceProcessClientConfig) {
+    this.modelName = config.modelName;
+
+    if (config.runtimeProfile) {
+      assertRuntimeReady(config.runtimeProfile);
+    }
+
+    const logger = new Logger({
+      prefix: config.loggerPrefix ?? 'LIP',
+      context: 'process',
+    });
+
+    const processCallbacks: ProcessCommunicationCallbacks = {
+      onJsonResponse: (jsonData) => this.requestQueue.handleJsonResponse(jsonData),
+      onRequestCompleted: () => this.requestQueue.onRequestCompleted(),
+      onProcessExit: (code, signal) => {
+        if (code !== 0) {
+          const message =
+            config.processExitErrorMessage?.(code, signal) ??
+            `Inference process exited unexpectedly (code=${code}, signal=${signal})`;
+          logger.error(message);
+          this.requestQueue.rejectAll(new Error(message));
+        }
+      },
+    };
+
+    const queueCallbacks: RequestQueueCallbacks = {
+      sendToProcess: (data) => this.processComm.sendToProcess(data),
+      createNewStream: () => this.processComm.createNewStream(),
+      cancelActiveStream: () => this.processComm.cancelActiveStream(),
+    };
+
+    this.processComm = new ProcessCommunication(
+      {
+        pythonProjectDir: config.pythonProjectDir,
+        venvPath: config.venvPath,
+        modelName: config.modelName,
+        extraArgs: config.extraSpawnArgs,
+        loggerPrefix: config.loggerPrefix,
+        processExitErrorMessage: config.processExitErrorMessage,
+      },
+      processCallbacks,
+    );
+
+    this.requestQueue = new InferenceRequestQueue(queueCallbacks, config.mapSamplingOptions);
+  }
+
+  async ensureInitialized(): Promise<void> {
+    // 互換性のため維持
+  }
+
+  async getCapabilities(): Promise<InferenceCapabilities> {
+    return this.requestQueue.addCapabilitiesRequest();
+  }
+
+  async formatTest(
+    messages: InferenceMessage[],
+    options?: { primer?: string },
+  ): Promise<InferenceFormatTestResult> {
+    return this.requestQueue.addFormatTestRequest(messages, options);
+  }
+
+  async tokenize(
+    messages: InferenceMessage[],
+    tools?: InferenceToolDefinition[],
+    reasoningEffort?: 'low' | 'medium' | 'high',
+  ): Promise<InferenceTokenizeResult> {
+    return this.requestQueue.addTokenizeRequest(messages, tools, reasoningEffort);
+  }
+
+  async cachePrefill(
+    cachePath: string,
+    messages: InferenceMessage[],
+    baseCachePath?: string,
+    trimToTokens?: number,
+    prefixOffsets?: number[],
+    prefixHashes?: string[],
+    tools?: InferenceToolDefinition[],
+    reasoningEffort?: 'low' | 'medium' | 'high',
+  ): Promise<InferenceCachePrefillResult> {
+    return this.requestQueue.addCachePrefillRequest(
+      cachePath,
+      messages,
+      baseCachePath,
+      trimToTokens,
+      prefixOffsets,
+      prefixHashes,
+      tools,
+      reasoningEffort,
+    );
+  }
+
+  async chat(
+    messages: InferenceMessage[],
+    primer?: string,
+    options?: unknown,
+    tools?: InferenceToolDefinition[],
+    images?: string[],
+    maxImageSize?: number,
+    reasoningEffort?: 'low' | 'medium' | 'high',
+    cachePath?: string,
+    cacheTrimTokens?: number,
+  ): Promise<Readable> {
+    return this.requestQueue.addChatRequest(
+      messages,
+      primer,
+      options,
+      tools,
+      images,
+      maxImageSize,
+      reasoningEffort,
+      cachePath,
+      cacheTrimTokens,
+    );
+  }
+
+  async completion(
+    prompt: string,
+    options?: unknown,
+    images?: string[],
+    maxImageSize?: number,
+  ): Promise<Readable> {
+    return this.requestQueue.addCompletionRequest(prompt, options, images, maxImageSize);
+  }
+
+  async exit(): Promise<void> {
+    await this.processComm.exit();
+  }
+
+  cancelActiveRequest(): void {
+    this.requestQueue.cancelActiveRequest();
+  }
+
+  getStatus() {
+    return {
+      modelName: this.modelName,
+      queueLength: this.requestQueue.length,
+      isStreamingActive: this.processComm.isStreamingActive(),
+      isJsonBuffering: this.processComm.isJsonBuffering(),
+    };
+  }
+}

--- a/packages/driver/src/local-inference/process-client.ts
+++ b/packages/driver/src/local-inference/process-client.ts
@@ -58,6 +58,8 @@ export class InferenceProcessClient {
       context: 'process',
     });
 
+    // processCallbacks は this.requestQueue 代入前に定義するが、
+    // コールバックは子プロセスの stdout/exit など非同期イベント時のみ呼ばれるため安全。
     const processCallbacks: ProcessCommunicationCallbacks = {
       onJsonResponse: (jsonData) => this.requestQueue.handleJsonResponse(jsonData),
       onRequestCompleted: () => this.requestQueue.onRequestCompleted(),

--- a/packages/driver/src/local-inference/process-communication.ts
+++ b/packages/driver/src/local-inference/process-communication.ts
@@ -1,25 +1,11 @@
 /**
- * MLX Driver プロセス通信管理
- * 
- * Pythonプロセスとの通信、データの送受信、ストリーミング処理を管理
+ * Thin Python 推論プロセスとの stdio 通信
  */
 
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { Readable } from 'stream';
 import { StringDecoder } from 'string_decoder';
 import { Logger } from '@modular-prompt/utils';
-import {
-  assertRuntimeReady,
-  getMlxPythonDir,
-  getVenvPath,
-  resolvePackageRootFromProcessModule,
-} from '../../runtime/index.js';
-
-const logger = new Logger({ prefix: 'MLX', context: 'process' });
-
-const packageRoot = resolvePackageRootFromProcessModule(import.meta.url);
-const mlxDriverDir = getMlxPythonDir(packageRoot);
-const mlxVenvPath = getVenvPath('mlx');
 
 export interface ProcessCommunicationCallbacks {
   onJsonResponse: (jsonData: string) => void;
@@ -27,10 +13,17 @@ export interface ProcessCommunicationCallbacks {
   onProcessExit: (code: number | null, signal: string | null) => void;
 }
 
-export interface ProcessCommunicationOptions {
-  textOnly?: boolean;
-  drafterModel?: string;
-  draftBlockSize?: number;
+export interface ProcessCommunicationConfig {
+  /** uv --project に渡す Python プロジェクトディレクトリ */
+  pythonProjectDir: string;
+  /** UV_PROJECT_ENVIRONMENT に設定する venv パス */
+  venvPath: string;
+  modelName: string;
+  /** `__main__.py` と modelName の後に付与する追加引数 */
+  extraArgs?: string[];
+  loggerPrefix?: string;
+  loggerContext?: string;
+  processExitErrorMessage?: (code: number | null, signal: string | null) => string;
 }
 
 export class ProcessCommunication {
@@ -40,43 +33,38 @@ export class ProcessCommunication {
   private jsonBuffer: string = '';
   private draining = false;
   private callbacks: ProcessCommunicationCallbacks;
+  private readonly exitErrorMessage: (code: number | null, signal: string | null) => string;
 
-  constructor(modelName: string, callbacks: ProcessCommunicationCallbacks, options?: ProcessCommunicationOptions) {
+  constructor(config: ProcessCommunicationConfig, callbacks: ProcessCommunicationCallbacks) {
     this.callbacks = callbacks;
     this.decoder = new StringDecoder('utf8');
+    this.exitErrorMessage =
+      config.processExitErrorMessage ??
+      ((code, signal) => `Inference process exited unexpectedly (code=${code}, signal=${signal})`);
 
-    assertRuntimeReady('mlx');
+    const logger = new Logger({
+      prefix: config.loggerPrefix ?? 'LIP',
+      context: config.loggerContext ?? 'process',
+    });
 
     const args = [
       '--project',
-      mlxDriverDir,
+      config.pythonProjectDir,
       'run',
       'python',
       '__main__.py',
-      modelName
+      config.modelName,
+      ...(config.extraArgs ?? []),
     ];
-    if (options?.textOnly) {
-      args.push('--text-only');
-    }
-    if (options?.drafterModel) {
-      args.push('--drafter', options.drafterModel);
-    }
-    if (options?.draftBlockSize !== undefined) {
-      args.push('--draft-block-size', options.draftBlockSize.toString());
-    }
 
     this.process = spawn('uv', args, {
-      cwd: mlxDriverDir,
+      cwd: config.pythonProjectDir,
       env: {
         ...process.env,
-        UV_PROJECT_ENVIRONMENT: mlxVenvPath,
+        UV_PROJECT_ENVIRONMENT: config.venvPath,
       },
     });
 
-    this.setupProcessHandlers();
-  }
-
-  private setupProcessHandlers(): void {
     this.process.stderr.on('data', (data) => {
       logger.debug(data.toString());
     });
@@ -91,20 +79,13 @@ export class ProcessCommunication {
 
     this.process.on('exit', (code, signal) => {
       if (this.currentStream) {
-        this.currentStream.destroy(
-          new Error(`MLX process exited unexpectedly (code=${code}, signal=${signal})`)
-        );
+        this.currentStream.destroy(new Error(this.exitErrorMessage(code, signal)));
         this.currentStream = null;
       }
       this.callbacks.onProcessExit(code, signal);
     });
   }
 
-  /**
-   * stdoutから受信したデータを処理する
-   * null文字をレスポンス区切りとして解釈し、
-   * 1つのdataチャンクに複数のレスポンスが含まれる場合も正しく処理する
-   */
   private processData(data: Buffer): void {
     let remaining: Buffer = data;
 
@@ -112,19 +93,14 @@ export class ProcessCommunication {
       const nullIndex = remaining.indexOf('\0');
 
       if (nullIndex !== -1) {
-        // null文字が見つかった場合、レスポンス終了
         const chunk = this.decoder.write(remaining.slice(0, nullIndex));
         this.decoder = new StringDecoder('utf8');
 
         if (this.currentStream) {
-          // ストリーミングレスポンスの場合
           this.currentStream.push(chunk);
-          this.currentStream.push(null); // ストリーム終了
+          this.currentStream.push(null);
           this.currentStream = null;
-        } else if (this.draining) {
-          // キャンセル後のドレイン: データを破棄
-        } else {
-          // JSONレスポンスの場合
+        } else if (!this.draining) {
           this.jsonBuffer += chunk;
           this.callbacks.onJsonResponse(this.jsonBuffer);
           this.jsonBuffer = '';
@@ -136,19 +112,13 @@ export class ProcessCommunication {
           this.draining = false;
         }
 
-        // null文字以降の残りデータを続けて処理
         remaining = remaining.slice(nullIndex + 1);
       } else {
-        // null文字がない場合、データを蓄積
         const chunk = this.decoder.write(remaining);
 
         if (this.currentStream) {
-          // ストリーミング中
           this.currentStream.push(chunk);
-        } else if (this.draining) {
-          // キャンセル後のドレイン: データを破棄
-        } else {
-          // JSONレスポンス蓄積中
+        } else if (!this.draining) {
           this.jsonBuffer += chunk;
         }
         break;
@@ -158,16 +128,11 @@ export class ProcessCommunication {
 
   createNewStream(): Readable {
     this.currentStream = new Readable({
-      read() {} // 空のreadメソッド
+      read() {},
     });
     return this.currentStream;
   }
 
-  /**
-   * Cancel the active streaming request.
-   * Destroys the current stream, drains stdout until the response terminator,
-   * and sends a cancel command to the Python process.
-   */
   cancelActiveStream(): void {
     if (!this.currentStream && !this.draining) {
       return;
@@ -180,10 +145,6 @@ export class ProcessCommunication {
 
     this.draining = true;
     this.sendToProcess(JSON.stringify({ method: 'cancel' }) + '\n');
-  }
-
-  isDraining(): boolean {
-    return this.draining;
   }
 
   sendToProcess(data: string): void {
@@ -201,17 +162,15 @@ export class ProcessCommunication {
   async exit(): Promise<void> {
     return new Promise((resolve) => {
       const timeout = setTimeout(() => {
-        // タイムアウト後は強制終了
         this.process.kill('SIGTERM');
         resolve();
-      }, 5000); // 5秒でタイムアウト
+      }, 5000);
 
       this.process.once('exit', () => {
         clearTimeout(timeout);
         resolve();
       });
 
-      // stdinを閉じてプロセスに終了を通知
       this.process.stdin.end();
     });
   }

--- a/packages/driver/src/local-inference/queue-types.ts
+++ b/packages/driver/src/local-inference/queue-types.ts
@@ -1,0 +1,72 @@
+import { Readable } from 'stream';
+import type {
+  InferenceCapabilities,
+  InferenceCapabilitiesRequest,
+  InferenceFormatTestRequest,
+  InferenceFormatTestResult,
+  InferenceTokenizeRequest,
+  InferenceTokenizeResult,
+  InferenceChatRequest,
+  InferenceCompletionRequest,
+  InferenceCachePrefillRequest,
+  InferenceCachePrefillResult,
+  InferenceMessage,
+  InferenceRequest,
+  InferenceSamplingOptions,
+} from './protocol.js';
+
+/** 旧プロトコル互換のストリーミングリクエスト形状 */
+export interface LegacyStreamingRequest {
+  messages: InferenceMessage[];
+  prompt?: string;
+  primer?: string;
+  options?: InferenceSamplingOptions | Record<string, unknown>;
+}
+
+export interface BaseQueueItem {
+  request: InferenceRequest | LegacyStreamingRequest;
+  expectJsonResponse?: boolean;
+  reject?: (reason: Error) => void;
+}
+
+export interface CapabilitiesQueueItem extends BaseQueueItem {
+  request: InferenceCapabilitiesRequest;
+  resolve: (value: InferenceCapabilities) => void;
+  reject: (reason: Error) => void;
+  expectJsonResponse: true;
+}
+
+export interface FormatTestQueueItem extends BaseQueueItem {
+  request: InferenceFormatTestRequest;
+  resolve: (value: InferenceFormatTestResult) => void;
+  reject: (reason: Error) => void;
+  expectJsonResponse: true;
+}
+
+export interface TokenizeQueueItem extends BaseQueueItem {
+  request: InferenceTokenizeRequest;
+  resolve: (value: InferenceTokenizeResult) => void;
+  reject: (reason: Error) => void;
+  expectJsonResponse: true;
+}
+
+export interface CachePrefillQueueItem extends BaseQueueItem {
+  request: InferenceCachePrefillRequest;
+  resolve: (value: InferenceCachePrefillResult) => void;
+  reject: (reason: Error) => void;
+  expectJsonResponse: true;
+}
+
+export interface StreamingQueueItem extends BaseQueueItem {
+  request: InferenceChatRequest | InferenceCompletionRequest | LegacyStreamingRequest;
+  resolve: (value: Readable) => void;
+  reject: (reason: Error) => void;
+  expectJsonResponse?: false;
+}
+
+export type QueueItem =
+  | CapabilitiesQueueItem
+  | FormatTestQueueItem
+  | TokenizeQueueItem
+  | CachePrefillQueueItem
+  | StreamingQueueItem;

--- a/packages/driver/src/local-inference/queue-types.ts
+++ b/packages/driver/src/local-inference/queue-types.ts
@@ -15,7 +15,9 @@ import type {
   InferenceSamplingOptions,
 } from './protocol.js';
 
-/** 旧プロトコル互換のストリーミングリクエスト形状 */
+/** 旧プロトコル互換のストリーミングリクエスト形状。
+ * options は LIP ワイヤ形式（snake_case）または mapper 通過後の Record を受け付ける。
+ * 旧 LegacyMlxRequest の MlxMlModelOptions 専用型から意図的に拡張（挙動は mapper 経由で同等）。 */
 export interface LegacyStreamingRequest {
   messages: InferenceMessage[];
   prompt?: string;

--- a/packages/driver/src/local-inference/request-queue.cancel.test.ts
+++ b/packages/driver/src/local-inference/request-queue.cancel.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Readable } from 'stream';
-import { QueueManager } from './queue.js';
+import { InferenceRequestQueue } from './request-queue.js';
 
-function createQueueManager(overrides?: Partial<{
+function createRequestQueue(overrides?: Partial<{
   cancelActiveStream: () => void;
 }>) {
   const cancelActiveStream = overrides?.cancelActiveStream ?? vi.fn();
   const sendToProcess = vi.fn();
-  const queue = new QueueManager({
+  const queue = new InferenceRequestQueue({
     sendToProcess,
     createNewStream: () => new Readable({ read() {} }),
     cancelActiveStream,
@@ -15,9 +15,9 @@ function createQueueManager(overrides?: Partial<{
   return { queue, cancelActiveStream, sendToProcess };
 }
 
-describe('QueueManager.cancelActiveRequest', () => {
+describe('InferenceRequestQueue.cancelActiveRequest', () => {
   it('calls cancelActiveStream while a streaming request is in flight', async () => {
-    const { queue, cancelActiveStream } = createQueueManager();
+    const { queue, cancelActiveStream } = createRequestQueue();
 
     const streamPromise = queue.addChatRequest([{ role: 'user', content: 'hi' }]);
     await streamPromise;
@@ -27,14 +27,14 @@ describe('QueueManager.cancelActiveRequest', () => {
   });
 
   it('does nothing when the queue is idle', () => {
-    const { queue, cancelActiveStream } = createQueueManager();
+    const { queue, cancelActiveStream } = createRequestQueue();
 
     queue.cancelActiveRequest();
     expect(cancelActiveStream).not.toHaveBeenCalled();
   });
 
   it('unblocks the queue after request completion following cancel', async () => {
-    const { queue, sendToProcess } = createQueueManager();
+    const { queue, sendToProcess } = createRequestQueue();
 
     await queue.addChatRequest([{ role: 'user', content: 'first' }]);
     queue.onRequestCompleted();

--- a/packages/driver/src/local-inference/request-queue.ts
+++ b/packages/driver/src/local-inference/request-queue.ts
@@ -1,11 +1,23 @@
 /**
- * MLX Driver キュー管理システム
- *
- * リクエストキューの管理とプロセッシングロジックを提供
+ * LIP JSON-RPC リクエストキュー
  */
 
 import { Readable } from 'stream';
-import { mapOptionsToPython } from './parameter-mapper.js';
+import type {
+  InferenceCapabilities,
+  InferenceCapabilitiesRequest,
+  InferenceFormatTestRequest,
+  InferenceFormatTestResult,
+  InferenceTokenizeRequest,
+  InferenceTokenizeResult,
+  InferenceChatRequest,
+  InferenceCompletionRequest,
+  InferenceCachePrefillRequest,
+  InferenceCachePrefillResult,
+  InferenceMessage,
+  InferenceToolDefinition,
+  InferenceSamplingOptions,
+} from './protocol.js';
 import type {
   QueueItem,
   CapabilitiesQueueItem,
@@ -13,69 +25,69 @@ import type {
   TokenizeQueueItem,
   CachePrefillQueueItem,
   StreamingQueueItem,
-  MlxCapabilitiesRequest,
-  MlxFormatTestRequest,
-  MlxTokenizeRequest,
-  MlxChatRequest,
-  MlxCompletionRequest,
-  MlxCachePrefillRequest,
-  MlxMessage,
-  MlxMlModelOptions,
-  MlxRuntimeInfo,
-  MlxFormatTestResult,
-  MlxTokenizeResult,
-  MlxCachePrefillResult,
-  MlxToolDefinition
-} from './types.js';
+} from './queue-types.js';
 
-export interface QueueManagerCallbacks {
+export interface RequestQueueCallbacks {
   sendToProcess: (data: string) => void;
   createNewStream: () => Readable;
   cancelActiveStream: () => void;
 }
 
-export class QueueManager {
+export type SamplingOptionsMapper = (
+  options?: unknown,
+) => InferenceSamplingOptions | Record<string, unknown> | undefined;
+
+export class InferenceRequestQueue {
   private queue: QueueItem[] = [];
   private isProcessing = false;
-  private callbacks: QueueManagerCallbacks;
+  private callbacks: RequestQueueCallbacks;
+  private mapSamplingOptions: SamplingOptionsMapper;
 
-  constructor(callbacks: QueueManagerCallbacks) {
+  constructor(callbacks: RequestQueueCallbacks, mapSamplingOptions?: SamplingOptionsMapper) {
     this.callbacks = callbacks;
+    this.mapSamplingOptions = mapSamplingOptions ?? ((options) => options as InferenceSamplingOptions | undefined);
   }
 
-  addCapabilitiesRequest(): Promise<MlxRuntimeInfo> {
+  addCapabilitiesRequest(): Promise<InferenceCapabilities> {
     return new Promise((resolve, reject) => {
-      const request: MlxCapabilitiesRequest = { method: 'capabilities' };
+      const request: InferenceCapabilitiesRequest = { method: 'capabilities' };
       this.queue.push({
         request,
         resolve,
         reject,
-        expectJsonResponse: true
+        expectJsonResponse: true,
       } as CapabilitiesQueueItem);
       this.processNext();
     });
   }
 
-  addFormatTestRequest(messages: MlxMessage[], options?: { primer?: string }): Promise<MlxFormatTestResult> {
+  addFormatTestRequest(
+    messages: InferenceMessage[],
+    options?: { primer?: string },
+  ): Promise<InferenceFormatTestResult> {
     return new Promise((resolve, reject) => {
-      const request: MlxFormatTestRequest = {
+      const request: InferenceFormatTestRequest = {
         method: 'format_test',
         messages,
-        options
+        options,
       };
       this.queue.push({
         request,
         resolve,
         reject,
-        expectJsonResponse: true
+        expectJsonResponse: true,
       } as FormatTestQueueItem);
       this.processNext();
     });
   }
 
-  addTokenizeRequest(messages: MlxMessage[], tools?: MlxToolDefinition[], reasoningEffort?: 'low' | 'medium' | 'high'): Promise<MlxTokenizeResult> {
+  addTokenizeRequest(
+    messages: InferenceMessage[],
+    tools?: InferenceToolDefinition[],
+    reasoningEffort?: 'low' | 'medium' | 'high',
+  ): Promise<InferenceTokenizeResult> {
     return new Promise((resolve, reject) => {
-      const request: MlxTokenizeRequest = {
+      const request: InferenceTokenizeRequest = {
         method: 'tokenize',
         messages,
         ...(tools && { tools }),
@@ -85,21 +97,31 @@ export class QueueManager {
         request,
         resolve,
         reject,
-        expectJsonResponse: true
+        expectJsonResponse: true,
       } as TokenizeQueueItem);
       this.processNext();
     });
   }
 
-  addChatRequest(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number, reasoningEffort?: 'low' | 'medium' | 'high', cachePath?: string, cacheTrimTokens?: number): Promise<Readable> {
+  addChatRequest(
+    messages: InferenceMessage[],
+    primer?: string,
+    options?: unknown,
+    tools?: InferenceToolDefinition[],
+    images?: string[],
+    maxImageSize?: number,
+    reasoningEffort?: 'low' | 'medium' | 'high',
+    cachePath?: string,
+    cacheTrimTokens?: number,
+  ): Promise<Readable> {
     return new Promise((resolve, reject) => {
       try {
-        const request: MlxChatRequest = {
+        const request: InferenceChatRequest = {
           method: 'chat',
           messages,
           primer,
           tools,
-          options: mapOptionsToPython(options, true),
+          options: this.mapSamplingOptions(options),
           ...(images?.length ? { images, maxImageSize } : {}),
           ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
           ...(cachePath ? { cache_path: cachePath } : {}),
@@ -117,9 +139,18 @@ export class QueueManager {
     });
   }
 
-  addCachePrefillRequest(cachePath: string, messages: MlxMessage[], baseCachePath?: string, trimToTokens?: number, prefixOffsets?: number[], prefixHashes?: string[], tools?: MlxToolDefinition[], reasoningEffort?: 'low' | 'medium' | 'high'): Promise<MlxCachePrefillResult> {
+  addCachePrefillRequest(
+    cachePath: string,
+    messages: InferenceMessage[],
+    baseCachePath?: string,
+    trimToTokens?: number,
+    prefixOffsets?: number[],
+    prefixHashes?: string[],
+    tools?: InferenceToolDefinition[],
+    reasoningEffort?: 'low' | 'medium' | 'high',
+  ): Promise<InferenceCachePrefillResult> {
     return new Promise((resolve, reject) => {
-      const request: MlxCachePrefillRequest = {
+      const request: InferenceCachePrefillRequest = {
         method: 'cache_prefill',
         cache_path: cachePath,
         messages,
@@ -139,13 +170,18 @@ export class QueueManager {
     });
   }
 
-  addCompletionRequest(prompt: string, options?: MlxMlModelOptions, images?: string[], maxImageSize?: number): Promise<Readable> {
+  addCompletionRequest(
+    prompt: string,
+    options?: unknown,
+    images?: string[],
+    maxImageSize?: number,
+  ): Promise<Readable> {
     return new Promise((resolve, reject) => {
       try {
-        const request: MlxCompletionRequest = {
+        const request: InferenceCompletionRequest = {
           method: 'completion',
           prompt,
-          options: mapOptionsToPython(options, true),
+          options: this.mapSamplingOptions(options),
           ...(images?.length ? { images, maxImageSize } : {}),
         };
         this.queue.push({
@@ -160,24 +196,21 @@ export class QueueManager {
     });
   }
 
-
-  processNext() {
+  processNext(): void {
     if (this.isProcessing || this.queue.length === 0) {
       return;
     }
 
     this.isProcessing = true;
-    const queueItem = this.queue[0]; // まだshiftしない
+    const queueItem = this.queue[0];
     const { request, expectJsonResponse } = queueItem;
 
-    // ストリーミングレスポンスの場合のみcurrentStreamを設定
     if (!expectJsonResponse) {
       const stream = this.callbacks.createNewStream();
       queueItem.resolve(stream);
-      this.queue.shift(); // ここでshiftする
+      this.queue.shift();
     }
 
-    // リクエストを送信
     const input = JSON.stringify(request);
     this.callbacks.sendToProcess(input + '\n');
   }
@@ -188,8 +221,6 @@ export class QueueManager {
       if (queueItem?.expectJsonResponse) {
         try {
           const jsonResponse = JSON.parse(jsonData);
-          // format_test has its own error field in MlxFormatTestResult — resolve if well-formed,
-          // but reject bare protocol errors (missing template_applied indicates server-side exception)
           if (queueItem.request.method === 'format_test') {
             if ('template_applied' in jsonResponse) {
               (queueItem as FormatTestQueueItem).resolve(jsonResponse);
@@ -198,7 +229,7 @@ export class QueueManager {
                 formatted_prompt: null,
                 template_applied: false,
                 model_specific_processing: null,
-                error: jsonResponse.error || 'Malformed format_test response'
+                error: jsonResponse.error || 'Malformed format_test response',
               });
             }
           } else if (queueItem.request.method === 'tokenize') {
@@ -208,7 +239,7 @@ export class QueueManager {
               (queueItem as TokenizeQueueItem).resolve({
                 token_ids: null,
                 token_count: 0,
-                error: jsonResponse.error || 'Malformed tokenize response'
+                error: jsonResponse.error || 'Malformed tokenize response',
               });
             }
           } else if (jsonResponse.error) {
@@ -223,24 +254,24 @@ export class QueueManager {
             (queueItem as CapabilitiesQueueItem).resolve({
               methods: [],
               special_tokens: {},
-              features: { apply_chat_template: false }
+              features: { apply_chat_template: false },
             });
           } else if (queueItem.request.method === 'format_test') {
             (queueItem as FormatTestQueueItem).resolve({
               formatted_prompt: null,
               template_applied: false,
               model_specific_processing: null,
-              error: e instanceof Error ? e.message : 'Unknown error'
+              error: e instanceof Error ? e.message : 'Unknown error',
             });
           } else if (queueItem.request.method === 'tokenize') {
             (queueItem as TokenizeQueueItem).resolve({
               token_ids: null,
               token_count: 0,
-              error: e instanceof Error ? e.message : 'Unknown error'
+              error: e instanceof Error ? e.message : 'Unknown error',
             });
           } else if (queueItem.request.method === 'cache_prefill') {
             (queueItem as CachePrefillQueueItem).reject(
-              e instanceof Error ? e : new Error(String(e))
+              e instanceof Error ? e : new Error(String(e)),
             );
           }
         }
@@ -250,7 +281,7 @@ export class QueueManager {
 
   onRequestCompleted(): void {
     this.isProcessing = false;
-    this.processNext(); // 次のリクエストを処理
+    this.processNext();
   }
 
   cancelActiveRequest(): void {
@@ -264,20 +295,11 @@ export class QueueManager {
     return this.queue.length;
   }
 
-  get isEmpty(): boolean {
-    return this.queue.length === 0;
-  }
-
   rejectAll(error: Error): void {
     const pending = this.queue.splice(0);
     for (const item of pending) {
       item.reject?.(error);
     }
-    this.isProcessing = false;
-  }
-
-  clear(): void {
-    this.queue = [];
     this.isProcessing = false;
   }
 }

--- a/packages/driver/src/mlx-ml/process/index.ts
+++ b/packages/driver/src/mlx-ml/process/index.ts
@@ -1,12 +1,17 @@
 /**
  * MLX Driver 外部インターフェース
- * 
- * mlx-ml.tsドライバーからアクセスされるメイン API
- * 機能をモジュール化し、役割を分離
+ *
+ * mlx-ml.ts ドライバーからアクセスされるメイン API。
+ * 通信層は LIP InferenceProcessClient に委譲する。
  */
 
 import { Readable } from 'stream';
-import { Logger } from '@modular-prompt/utils';
+import {
+  getMlxPythonDir,
+  getVenvPath,
+  resolvePackageRootFromProcessModule,
+} from '../../runtime/index.js';
+import { InferenceProcessClient } from '../../local-inference/process-client.js';
 import type {
   MlxMlModelOptions,
   MlxMessage,
@@ -14,14 +19,14 @@ import type {
   MlxFormatTestResult,
   MlxTokenizeResult,
   MlxCachePrefillResult,
-  MlxToolDefinition
+  MlxToolDefinition,
 } from './types.js';
-import { QueueManager, QueueManagerCallbacks } from './queue.js';
-import { ProcessCommunication, ProcessCommunicationCallbacks } from './process-communication.js';
+import { mapOptionsToPython } from './parameter-mapper.js';
 
-const logger = new Logger({ prefix: 'MLX', context: 'process' });
+const packageRoot = resolvePackageRootFromProcessModule(import.meta.url);
+const mlxPythonDir = getMlxPythonDir(packageRoot);
+const mlxVenvPath = getVenvPath('mlx');
 
-// API v2.0 型をエクスポート
 export type {
   MlxMlModelOptions,
   MlxMessage,
@@ -29,7 +34,7 @@ export type {
   MlxFormatTestResult,
   MlxTokenizeResult,
   MlxCachePrefillResult,
-  MlxToolDefinition
+  MlxToolDefinition,
 };
 
 export interface MlxProcessOptions {
@@ -38,94 +43,124 @@ export interface MlxProcessOptions {
   draftBlockSize?: number;
 }
 
+function buildMlxSpawnArgs(options?: MlxProcessOptions): string[] {
+  const args: string[] = [];
+  if (options?.textOnly) {
+    args.push('--text-only');
+  }
+  if (options?.drafterModel) {
+    args.push('--drafter', options.drafterModel);
+  }
+  if (options?.draftBlockSize !== undefined) {
+    args.push('--draft-block-size', options.draftBlockSize.toString());
+  }
+  return args;
+}
+
 export class MlxProcess {
   modelName: string;
-
-  private queueManager: QueueManager;
-  private processComm: ProcessCommunication;
+  private client: InferenceProcessClient;
 
   constructor(modelName: string, options?: MlxProcessOptions) {
     this.modelName = modelName;
 
-    // コールバック設定
-    const processCallbacks: ProcessCommunicationCallbacks = {
-      onJsonResponse: (jsonData: string) => this.queueManager.handleJsonResponse(jsonData),
-      onRequestCompleted: () => this.queueManager.onRequestCompleted(),
-      onProcessExit: (code: number | null, signal: string | null) => {
-        if (code !== 0) {
-          const error = new Error(
-            `MLX process exited unexpectedly (code=${code}, signal=${signal})`
-          );
-          logger.error(error.message);
-          this.queueManager.rejectAll(error);
-        }
-      },
-    };
-
-    const queueCallbacks: QueueManagerCallbacks = {
-      sendToProcess: (data: string) => this.processComm.sendToProcess(data),
-      createNewStream: () => this.processComm.createNewStream(),
-      cancelActiveStream: () => this.processComm.cancelActiveStream(),
-    };
-
-    // 各コンポーネント初期化
-    this.processComm = new ProcessCommunication(modelName, processCallbacks, options);
-    this.queueManager = new QueueManager(queueCallbacks);
+    this.client = new InferenceProcessClient({
+      modelName,
+      pythonProjectDir: mlxPythonDir,
+      venvPath: mlxVenvPath,
+      runtimeProfile: 'mlx',
+      extraSpawnArgs: buildMlxSpawnArgs(options),
+      loggerPrefix: 'MLX',
+      mapSamplingOptions: (opts) => mapOptionsToPython(opts as MlxMlModelOptions | undefined, true),
+      processExitErrorMessage: (code, signal) =>
+        `MLX process exited unexpectedly (code=${code}, signal=${signal})`,
+    });
   }
 
-  /**
-   * 初期化（何もしない - 互換性のために残す）
-   */
   async ensureInitialized(): Promise<void> {
-    // No-op for compatibility
+    return this.client.ensureInitialized();
   }
 
-  // API v2.0 Capabilities
   async getCapabilities(): Promise<MlxRuntimeInfo> {
-    return this.queueManager.addCapabilitiesRequest();
+    return this.client.getCapabilities();
   }
 
-  // API v2.0 Format Test
   async formatTest(messages: MlxMessage[], options?: { primer?: string }): Promise<MlxFormatTestResult> {
-    return this.queueManager.addFormatTestRequest(messages, options);
+    return this.client.formatTest(messages, options);
   }
 
-  // API v2.0 Tokenize
-  async tokenize(messages: MlxMessage[], tools?: MlxToolDefinition[], reasoningEffort?: 'low' | 'medium' | 'high'): Promise<MlxTokenizeResult> {
-    return this.queueManager.addTokenizeRequest(messages, tools, reasoningEffort);
+  async tokenize(
+    messages: MlxMessage[],
+    tools?: MlxToolDefinition[],
+    reasoningEffort?: 'low' | 'medium' | 'high',
+  ): Promise<MlxTokenizeResult> {
+    return this.client.tokenize(messages, tools, reasoningEffort);
   }
 
-  // Cache operations
-  async cachePrefill(cachePath: string, messages: MlxMessage[], baseCachePath?: string, trimToTokens?: number, prefixOffsets?: number[], prefixHashes?: string[], tools?: MlxToolDefinition[], reasoningEffort?: 'low' | 'medium' | 'high'): Promise<MlxCachePrefillResult> {
-    return this.queueManager.addCachePrefillRequest(cachePath, messages, baseCachePath, trimToTokens, prefixOffsets, prefixHashes, tools, reasoningEffort);
+  async cachePrefill(
+    cachePath: string,
+    messages: MlxMessage[],
+    baseCachePath?: string,
+    trimToTokens?: number,
+    prefixOffsets?: number[],
+    prefixHashes?: string[],
+    tools?: MlxToolDefinition[],
+    reasoningEffort?: 'low' | 'medium' | 'high',
+  ): Promise<MlxCachePrefillResult> {
+    return this.client.cachePrefill(
+      cachePath,
+      messages,
+      baseCachePath,
+      trimToTokens,
+      prefixOffsets,
+      prefixHashes,
+      tools,
+      reasoningEffort,
+    );
   }
 
-  // API v2.0 Chat
-  async chat(messages: MlxMessage[], primer?: string, options?: MlxMlModelOptions, tools?: MlxToolDefinition[], images?: string[], maxImageSize?: number, reasoningEffort?: 'low' | 'medium' | 'high', cachePath?: string, cacheTrimTokens?: number): Promise<Readable> {
-    return this.queueManager.addChatRequest(messages, primer, options, tools, images, maxImageSize, reasoningEffort, cachePath, cacheTrimTokens);
+  async chat(
+    messages: MlxMessage[],
+    primer?: string,
+    options?: MlxMlModelOptions,
+    tools?: MlxToolDefinition[],
+    images?: string[],
+    maxImageSize?: number,
+    reasoningEffort?: 'low' | 'medium' | 'high',
+    cachePath?: string,
+    cacheTrimTokens?: number,
+  ): Promise<Readable> {
+    return this.client.chat(
+      messages,
+      primer,
+      options,
+      tools,
+      images,
+      maxImageSize,
+      reasoningEffort,
+      cachePath,
+      cacheTrimTokens,
+    );
   }
 
-  // API v2.0 Completion
-  async completion(prompt: string, options?: MlxMlModelOptions, images?: string[], maxImageSize?: number): Promise<Readable> {
-    return this.queueManager.addCompletionRequest(prompt, options, images, maxImageSize);
+  async completion(
+    prompt: string,
+    options?: MlxMlModelOptions,
+    images?: string[],
+    maxImageSize?: number,
+  ): Promise<Readable> {
+    return this.client.completion(prompt, options, images, maxImageSize);
   }
-
 
   async exit(): Promise<void> {
-    await this.processComm.exit();
+    return this.client.exit();
   }
 
   cancelActiveRequest(): void {
-    this.queueManager.cancelActiveRequest();
+    this.client.cancelActiveRequest();
   }
 
-  // デバッグ・ステータス情報
   getStatus() {
-    return {
-      modelName: this.modelName,
-      queueLength: this.queueManager.length,
-      isStreamingActive: this.processComm.isStreamingActive(),
-      isJsonBuffering: this.processComm.isJsonBuffering()
-    };
+    return this.client.getStatus();
   }
 }

--- a/packages/driver/src/mlx-ml/process/mlx-process.test.ts
+++ b/packages/driver/src/mlx-ml/process/mlx-process.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mapOptionsToPython } from './parameter-mapper.js';
+
+const clientStub = {
+  ensureInitialized: vi.fn(),
+  getCapabilities: vi.fn(),
+  formatTest: vi.fn(),
+  tokenize: vi.fn(),
+  cachePrefill: vi.fn(),
+  chat: vi.fn(),
+  completion: vi.fn(),
+  exit: vi.fn(),
+  cancelActiveRequest: vi.fn(),
+  getStatus: vi.fn(),
+};
+
+vi.mock('../../local-inference/process-client.js', () => ({
+  InferenceProcessClient: vi.fn(function InferenceProcessClient() {
+    return clientStub;
+  }),
+}));
+
+vi.mock('../../runtime/index.js', () => ({
+  getMlxPythonDir: vi.fn(() => '/test/mlx/python'),
+  getVenvPath: vi.fn(() => '/test/mlx/venv'),
+  resolvePackageRootFromProcessModule: vi.fn(() => '/test/pkg'),
+}));
+
+import { InferenceProcessClient } from '../../local-inference/process-client.js';
+import { MlxProcess } from './index.js';
+
+describe('MlxProcess', () => {
+  beforeEach(() => {
+    vi.mocked(InferenceProcessClient).mockClear();
+  });
+
+  it('constructs InferenceProcessClient with MLX paths and spawn args', () => {
+    const process = new MlxProcess('my-model', {
+      textOnly: true,
+      drafterModel: 'draft-model',
+      draftBlockSize: 8,
+    });
+
+    expect(process.modelName).toBe('my-model');
+    expect(InferenceProcessClient).toHaveBeenCalledOnce();
+    expect(InferenceProcessClient).toHaveBeenCalledWith({
+      modelName: 'my-model',
+      pythonProjectDir: '/test/mlx/python',
+      venvPath: '/test/mlx/venv',
+      runtimeProfile: 'mlx',
+      extraSpawnArgs: ['--text-only', '--drafter', 'draft-model', '--draft-block-size', '8'],
+      loggerPrefix: 'MLX',
+      mapSamplingOptions: expect.any(Function),
+      processExitErrorMessage: expect.any(Function),
+    });
+  });
+
+  it('wires mapSamplingOptions to mapOptionsToPython', () => {
+    new MlxProcess('model');
+
+    const config = vi.mocked(InferenceProcessClient).mock.calls[0][0];
+    const mapped = config.mapSamplingOptions?.({ maxTokens: 32, temperature: 0.5 });
+
+    expect(mapped).toEqual(mapOptionsToPython({ maxTokens: 32, temperature: 0.5 }, true));
+  });
+
+  it('uses MLX-specific process exit error message', () => {
+    new MlxProcess('model');
+
+    const config = vi.mocked(InferenceProcessClient).mock.calls[0][0];
+    expect(config.processExitErrorMessage?.(1, null)).toBe(
+      'MLX process exited unexpectedly (code=1, signal=null)',
+    );
+  });
+});

--- a/packages/driver/src/mlx-ml/process/types.ts
+++ b/packages/driver/src/mlx-ml/process/types.ts
@@ -1,24 +1,18 @@
 /**
  * MLX Driver API v2.0 型定義
  *
- * LIP 共通型は local-inference/protocol から re-export し、
+ * LIP 共通型は local-inference から re-export し、
  * Mlx* 名前で後方互換を維持する。
  */
-import { Readable } from 'stream';
 import type { MlxMlModelOptions } from '../types.js';
 import type {
   InferenceBaseRequest,
-  InferenceCapabilities,
   InferenceCapabilitiesRequest,
   InferenceFormatTestRequest,
   InferenceTokenizeRequest,
   InferenceChatRequest,
   InferenceCompletionRequest,
   InferenceCachePrefillRequest,
-  InferenceCachePrefillResult,
-  InferenceFormatTestResult,
-  InferenceTokenizeResult,
-  InferenceMessage,
 } from '../../local-inference/protocol.js';
 
 export type { MlxMlModelOptions };
@@ -43,6 +37,17 @@ export type {
   InferenceTokenizeResult as MlxTokenizeResult,
 } from '../../local-inference/protocol.js';
 
+export type {
+  LegacyStreamingRequest as LegacyMlxRequest,
+  BaseQueueItem,
+  CapabilitiesQueueItem,
+  FormatTestQueueItem,
+  TokenizeQueueItem,
+  CachePrefillQueueItem,
+  StreamingQueueItem,
+  QueueItem,
+} from '../../local-inference/queue-types.js';
+
 export type MlxBaseRequest = InferenceBaseRequest;
 
 /** MLX ドライバー向け chat リクエスト（options は camelCase の MlxMlModelOptions） */
@@ -64,60 +69,3 @@ export type MlxRequest =
   | MlxChatRequest
   | MlxCompletionRequest
   | InferenceCachePrefillRequest;
-
-// レガシー互換性のための型
-export interface LegacyMlxRequest {
-  messages: InferenceMessage[];
-  prompt?: string;
-  primer?: string;
-  options?: MlxMlModelOptions;
-}
-
-// 内部用型定義
-export interface BaseQueueItem {
-  request: MlxRequest | LegacyMlxRequest;
-  expectJsonResponse?: boolean;
-  reject?: (reason: Error) => void;
-}
-
-export interface CapabilitiesQueueItem extends BaseQueueItem {
-  request: InferenceCapabilitiesRequest;
-  resolve: (value: InferenceCapabilities) => void;
-  reject: (reason: Error) => void;
-  expectJsonResponse: true;
-}
-
-export interface FormatTestQueueItem extends BaseQueueItem {
-  request: InferenceFormatTestRequest;
-  resolve: (value: InferenceFormatTestResult) => void;
-  reject: (reason: Error) => void;
-  expectJsonResponse: true;
-}
-
-export interface TokenizeQueueItem extends BaseQueueItem {
-  request: InferenceTokenizeRequest;
-  resolve: (value: InferenceTokenizeResult) => void;
-  reject: (reason: Error) => void;
-  expectJsonResponse: true;
-}
-
-export interface CachePrefillQueueItem extends BaseQueueItem {
-  request: InferenceCachePrefillRequest;
-  resolve: (value: InferenceCachePrefillResult) => void;
-  reject: (reason: Error) => void;
-  expectJsonResponse: true;
-}
-
-export interface StreamingQueueItem extends BaseQueueItem {
-  request: MlxChatRequest | MlxCompletionRequest | LegacyMlxRequest;
-  resolve: (value: Readable) => void;
-  reject: (reason: Error) => void;
-  expectJsonResponse?: false;
-}
-
-export type QueueItem =
-  | CapabilitiesQueueItem
-  | FormatTestQueueItem
-  | TokenizeQueueItem
-  | CachePrefillQueueItem
-  | StreamingQueueItem;


### PR DESCRIPTION
## Summary

- `InferenceProcessClient` を新設（stdio 通信 + リクエストキュー統合）
- `process-communication.ts` / `request-queue.ts` を `local-inference/` に移動・一般化
- `pythonProjectDir` / `venvPath` をコンストラクタで指定可能に
- `MlxProcess` は MLX 固有の spawn 引数・`mapOptionsToPython` を渡す薄いラッパに
- **挙動変更なし**

Closes #309
Part of #302

## 構造

```
local-inference/
├── protocol.ts              # Phase 1
├── queue-types.ts           # キュー内部型
├── process-communication.ts # stdio 通信（パス設定可能）
├── request-queue.ts         # JSON-RPC キュー
└── process-client.ts        # 上記を統合するクライアント
```

## Test plan

- [x] `pnpm run build` / `test:run` / `typecheck` / `lint`（driver）
- [x] `request-queue.cancel.test.ts` を local-inference へ移行
- [x] `process-client.test.ts` で設定可能パスを確認

## 次のステップ（#302 Phase 3）

- Python `generate` ハンドラ追加
- completion 経路を `generate` に切替

Made with [Cursor](https://cursor.com)