### PR TITLE
feat(driver): LIP generate メソッド追加と completion 経路切替（Phase 3）

### DIFF
--- a/.changeset/lip-phase3-generate.md
+++ b/.changeset/lip-phase3-generate.md
@@ -1,0 +1,7 @@
+---
+"@modular-prompt/driver": minor
+---
+
+feat: LIP `generate` メソッドを追加し completion 経路を切替（Phase 3）
+
+Closes #311

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -117,6 +117,7 @@ export type {
   InferenceRequest,
   InferenceChatRequest,
   InferenceCompletionRequest,
+  InferenceGenerateRequest,
   InferenceToolDefinition,
   InferenceFormatTestResult,
   InferenceTokenizeResult,

--- a/packages/driver/src/local-inference/index.ts
+++ b/packages/driver/src/local-inference/index.ts
@@ -20,6 +20,7 @@ export type {
   InferenceTokenizeRequest,
   InferenceChatRequest,
   InferenceCompletionRequest,
+  InferenceGenerateRequest,
   InferenceCachePrefillRequest,
   InferenceCachePrefillResult,
   InferenceRequest,

--- a/packages/driver/src/local-inference/process-client.ts
+++ b/packages/driver/src/local-inference/process-client.ts
@@ -173,6 +173,15 @@ export class InferenceProcessClient {
     return this.requestQueue.addCompletionRequest(prompt, options, images, maxImageSize);
   }
 
+  async generate(
+    prompt: string | number[],
+    options?: unknown,
+    images?: string[],
+    maxImageSize?: number,
+  ): Promise<Readable> {
+    return this.requestQueue.addGenerateRequest(prompt, options, images, maxImageSize);
+  }
+
   async exit(): Promise<void> {
     await this.processComm.exit();
   }

--- a/packages/driver/src/local-inference/protocol.ts
+++ b/packages/driver/src/local-inference/protocol.ts
@@ -12,6 +12,7 @@ export type InferenceMethod =
   | 'format_test'
   | 'chat'
   | 'completion'
+  | 'generate'
   | 'cache_prefill'
   | 'tokenize';
 
@@ -118,6 +119,15 @@ export interface InferenceCompletionRequest extends InferenceBaseRequest {
   maxImageSize?: number;
 }
 
+/** 整形済み prompt（文字列 or トークン ID）のストリーム推論 */
+export interface InferenceGenerateRequest extends InferenceBaseRequest {
+  method: 'generate';
+  prompt: string | number[];
+  options?: InferenceSamplingOptions;
+  images?: string[];
+  maxImageSize?: number;
+}
+
 export interface InferenceCachePrefillRequest extends InferenceBaseRequest {
   method: 'cache_prefill';
   cache_path: string;
@@ -143,6 +153,7 @@ export type InferenceRequest =
   | InferenceTokenizeRequest
   | InferenceChatRequest
   | InferenceCompletionRequest
+  | InferenceGenerateRequest
   | InferenceCachePrefillRequest;
 
 /** MLX-LM が認識する tool_parser_type（capabilities 経由で参照）。

--- a/packages/driver/src/local-inference/queue-types.ts
+++ b/packages/driver/src/local-inference/queue-types.ts
@@ -8,6 +8,7 @@ import type {
   InferenceTokenizeResult,
   InferenceChatRequest,
   InferenceCompletionRequest,
+  InferenceGenerateRequest,
   InferenceCachePrefillRequest,
   InferenceCachePrefillResult,
   InferenceMessage,
@@ -60,7 +61,7 @@ export interface CachePrefillQueueItem extends BaseQueueItem {
 }
 
 export interface StreamingQueueItem extends BaseQueueItem {
-  request: InferenceChatRequest | InferenceCompletionRequest | LegacyStreamingRequest;
+  request: InferenceChatRequest | InferenceCompletionRequest | InferenceGenerateRequest | LegacyStreamingRequest;
   resolve: (value: Readable) => void;
   reject: (reason: Error) => void;
   expectJsonResponse?: false;

--- a/packages/driver/src/local-inference/request-queue.generate.test.ts
+++ b/packages/driver/src/local-inference/request-queue.generate.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Readable } from 'stream';
+import { InferenceRequestQueue } from './request-queue.js';
+
+describe('InferenceRequestQueue.addGenerateRequest', () => {
+  it('sends generate method with formatted prompt', async () => {
+    const sendToProcess = vi.fn();
+    const queue = new InferenceRequestQueue({
+      sendToProcess,
+      createNewStream: () => new Readable({ read() {} }),
+      cancelActiveStream: vi.fn(),
+    });
+
+    const streamPromise = queue.addGenerateRequest('Hello, world', { max_tokens: 8 });
+    await streamPromise;
+
+    expect(sendToProcess).toHaveBeenCalledOnce();
+    const payload = JSON.parse(String(sendToProcess.mock.calls[0][0]).trim());
+    expect(payload).toEqual({
+      method: 'generate',
+      prompt: 'Hello, world',
+      options: { max_tokens: 8 },
+    });
+  });
+});

--- a/packages/driver/src/local-inference/request-queue.generate.test.ts
+++ b/packages/driver/src/local-inference/request-queue.generate.test.ts
@@ -2,24 +2,57 @@ import { describe, it, expect, vi } from 'vitest';
 import { Readable } from 'stream';
 import { InferenceRequestQueue } from './request-queue.js';
 
-describe('InferenceRequestQueue.addGenerateRequest', () => {
-  it('sends generate method with formatted prompt', async () => {
-    const sendToProcess = vi.fn();
-    const queue = new InferenceRequestQueue({
-      sendToProcess,
-      createNewStream: () => new Readable({ read() {} }),
-      cancelActiveStream: vi.fn(),
-    });
+function createQueue(sendToProcess = vi.fn()) {
+  return new InferenceRequestQueue({
+    sendToProcess,
+    createNewStream: () => new Readable({ read() {} }),
+    cancelActiveStream: vi.fn(),
+  });
+}
 
-    const streamPromise = queue.addGenerateRequest('Hello, world', { max_tokens: 8 });
-    await streamPromise;
+function parseSentRequest(sendToProcess: ReturnType<typeof vi.fn>) {
+  return JSON.parse(String(sendToProcess.mock.calls[0][0]).trim());
+}
+
+describe('InferenceRequestQueue.addGenerateRequest', () => {
+  it('sends generate method with string prompt', async () => {
+    const sendToProcess = vi.fn();
+    const queue = createQueue(sendToProcess);
+
+    await queue.addGenerateRequest('Hello, world', { max_tokens: 8 });
 
     expect(sendToProcess).toHaveBeenCalledOnce();
-    const payload = JSON.parse(String(sendToProcess.mock.calls[0][0]).trim());
-    expect(payload).toEqual({
+    expect(parseSentRequest(sendToProcess)).toEqual({
       method: 'generate',
       prompt: 'Hello, world',
       options: { max_tokens: 8 },
+    });
+  });
+
+  it('sends generate method with token id prompt', async () => {
+    const sendToProcess = vi.fn();
+    const queue = createQueue(sendToProcess);
+
+    await queue.addGenerateRequest([1, 2, 3], { temperature: 0.5 });
+
+    expect(parseSentRequest(sendToProcess)).toEqual({
+      method: 'generate',
+      prompt: [1, 2, 3],
+      options: { temperature: 0.5 },
+    });
+  });
+
+  it('includes images and maxImageSize when provided', async () => {
+    const sendToProcess = vi.fn();
+    const queue = createQueue(sendToProcess);
+
+    await queue.addGenerateRequest('vlm prompt', undefined, ['/tmp/a.png'], 512);
+
+    expect(parseSentRequest(sendToProcess)).toEqual({
+      method: 'generate',
+      prompt: 'vlm prompt',
+      images: ['/tmp/a.png'],
+      maxImageSize: 512,
     });
   });
 });

--- a/packages/driver/src/local-inference/request-queue.ts
+++ b/packages/driver/src/local-inference/request-queue.ts
@@ -12,6 +12,7 @@ import type {
   InferenceTokenizeResult,
   InferenceChatRequest,
   InferenceCompletionRequest,
+  InferenceGenerateRequest,
   InferenceCachePrefillRequest,
   InferenceCachePrefillResult,
   InferenceMessage,
@@ -180,6 +181,32 @@ export class InferenceRequestQueue {
       try {
         const request: InferenceCompletionRequest = {
           method: 'completion',
+          prompt,
+          options: this.mapSamplingOptions(options),
+          ...(images?.length ? { images, maxImageSize } : {}),
+        };
+        this.queue.push({
+          request,
+          resolve,
+          reject,
+        } as StreamingQueueItem);
+        this.processNext();
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  addGenerateRequest(
+    prompt: string | number[],
+    options?: unknown,
+    images?: string[],
+    maxImageSize?: number,
+  ): Promise<Readable> {
+    return new Promise((resolve, reject) => {
+      try {
+        const request: InferenceGenerateRequest = {
+          method: 'generate',
           prompt,
           options: this.mapSamplingOptions(options),
           ...(images?.length ? { images, maxImageSize } : {}),

--- a/packages/driver/src/mlx-ml/mlx-driver-abort.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver-abort.test.ts
@@ -29,6 +29,7 @@ const mockProcess = {
   getCapabilities: vi.fn().mockResolvedValue(mockCapabilities),
   chat: vi.fn(),
   completion: vi.fn(),
+  generate: vi.fn(),
   cancelActiveRequest: vi.fn(),
   exit: vi.fn(),
 };

--- a/packages/driver/src/mlx-ml/mlx-driver-default-options.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver-default-options.test.ts
@@ -23,6 +23,7 @@ const mockProcess = {
   getCapabilities: vi.fn().mockResolvedValue(mockCapabilities),
   chat: vi.fn(),
   completion: vi.fn(),
+  generate: vi.fn(),
   cancelActiveRequest: vi.fn(),
   close: vi.fn().mockResolvedValue(undefined),
 };
@@ -45,7 +46,7 @@ describe('MlxDriver defaultOptions.mode', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProcess.chat.mockResolvedValue(createMockStream(['ok']));
-    mockProcess.completion.mockResolvedValue(createMockStream(['ok']));
+    mockProcess.generate.mockResolvedValue(createMockStream(['ok']));
   });
 
   it('does not pass mode to Python when set via defaultOptions', async () => {
@@ -56,9 +57,9 @@ describe('MlxDriver defaultOptions.mode', () => {
 
     await driver.query(prompt);
 
-    const completionOptions = mockProcess.completion.mock.calls[0]?.[1];
-    expect(completionOptions).toEqual({ maxTokens: 16 });
-    expect(completionOptions).not.toHaveProperty('mode');
+    const generateOptions = mockProcess.generate.mock.calls[0]?.[1];
+    expect(generateOptions).toEqual({ maxTokens: 16 });
+    expect(generateOptions).not.toHaveProperty('mode');
   });
 
   it('uses defaultOptions.mode for API selection', async () => {
@@ -69,7 +70,7 @@ describe('MlxDriver defaultOptions.mode', () => {
 
     await driver.query(prompt);
 
-    expect(mockProcess.completion).toHaveBeenCalled();
+    expect(mockProcess.generate).toHaveBeenCalled();
     expect(mockProcess.chat).not.toHaveBeenCalled();
   });
 });

--- a/packages/driver/src/mlx-ml/mlx-driver.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.test.ts
@@ -52,6 +52,7 @@ vi.mock('./process/index.js', () => ({
     }),
     chat: vi.fn(),
     completion: vi.fn(),
+    generate: vi.fn(),
     exit: vi.fn()
   }))
 }));

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -309,6 +309,7 @@ export class MlxDriver implements AIDriver {
     if (api === 'completion') {
       let formattedPrompt = formatCompletionPrompt(augmentedPrompt, this.formatterOptions);
       formattedPrompt = this.modelProcessor.applyCompletionSpecificProcessing(formattedPrompt);
+      // LIP generate（wire method: "generate"。Python 側は旧 completion と同一 handle_generate）
       stream = await this.process.generate(formattedPrompt, mlxOptions);
     } else {
       const messages = formatPromptAsMessages(augmentedPrompt, this.formatterOptions);

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -309,7 +309,7 @@ export class MlxDriver implements AIDriver {
     if (api === 'completion') {
       let formattedPrompt = formatCompletionPrompt(augmentedPrompt, this.formatterOptions);
       formattedPrompt = this.modelProcessor.applyCompletionSpecificProcessing(formattedPrompt);
-      stream = await this.process.completion(formattedPrompt, mlxOptions);
+      stream = await this.process.generate(formattedPrompt, mlxOptions);
     } else {
       const messages = formatPromptAsMessages(augmentedPrompt, this.formatterOptions);
       const vlm = this.isVLM();

--- a/packages/driver/src/mlx-ml/process/index.ts
+++ b/packages/driver/src/mlx-ml/process/index.ts
@@ -152,6 +152,15 @@ export class MlxProcess {
     return this.client.completion(prompt, options, images, maxImageSize);
   }
 
+  async generate(
+    prompt: string | number[],
+    options?: MlxMlModelOptions,
+    images?: string[],
+    maxImageSize?: number,
+  ): Promise<Readable> {
+    return this.client.generate(prompt, options, images, maxImageSize);
+  }
+
   async exit(): Promise<void> {
     return this.client.exit();
   }

--- a/packages/driver/src/mlx-ml/process/mlx-process.test.ts
+++ b/packages/driver/src/mlx-ml/process/mlx-process.test.ts
@@ -9,6 +9,7 @@ const clientStub = {
   cachePrefill: vi.fn(),
   chat: vi.fn(),
   completion: vi.fn(),
+  generate: vi.fn(),
   exit: vi.fn(),
   cancelActiveRequest: vi.fn(),
   getStatus: vi.fn(),

--- a/packages/driver/src/mlx-ml/process/types.ts
+++ b/packages/driver/src/mlx-ml/process/types.ts
@@ -12,6 +12,7 @@ import type {
   InferenceTokenizeRequest,
   InferenceChatRequest,
   InferenceCompletionRequest,
+  InferenceGenerateRequest,
   InferenceCachePrefillRequest,
 } from '../../local-inference/protocol.js';
 
@@ -62,10 +63,17 @@ export interface MlxCompletionRequest extends Omit<InferenceCompletionRequest, '
   options?: MlxMlModelOptions;
 }
 
+/** MLX ドライバー向け generate リクエスト */
+export interface MlxGenerateRequest extends Omit<InferenceGenerateRequest, 'options'> {
+  method: 'generate';
+  options?: MlxMlModelOptions;
+}
+
 export type MlxRequest =
   | InferenceCapabilitiesRequest
   | InferenceFormatTestRequest
   | InferenceTokenizeRequest
   | MlxChatRequest
   | MlxCompletionRequest
+  | MlxGenerateRequest
   | InferenceCachePrefillRequest;

--- a/packages/driver/src/mlx-ml/python/handlers/__init__.py
+++ b/packages/driver/src/mlx-ml/python/handlers/__init__.py
@@ -3,4 +3,5 @@ from handlers.capabilities import handle_capabilities
 from handlers.chat import handle_chat
 from handlers.completion import handle_completion
 from handlers.format_test import handle_format_test
+from handlers.generate import handle_generate
 from handlers.tokenize import handle_tokenize

--- a/packages/driver/src/mlx-ml/python/handlers/completion.py
+++ b/packages/driver/src/mlx-ml/python/handlers/completion.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import os
-import re
-import sys
-
 from backends.base import ModelBackend
-from handlers.cancel import poll_cancel
+from handlers.generate import handle_generate
 
 
 def handle_completion(
@@ -15,25 +11,5 @@ def handle_completion(
     images: list | None = None,
     max_image_size: int = 768,
 ) -> None:
-    """completion API の処理"""
-    if options is None:
-        options = {}
-
-    final_options = dict(options)
-    if images:
-        final_options["max_image_size"] = max_image_size
-        if os.getenv('MLX_DEBUG'):
-            display_prompt = re.sub(r'(<\|image_pad\|>)+', '<|image_pad|>...', prompt)
-            sys.stderr.write(f"--- vlm completion (images: {len(images)}, max_size: {max_image_size})\n{display_prompt}\n")
-    elif os.getenv('MLX_DEBUG'):
-        if isinstance(prompt, list):
-            sys.stderr.write(f"--- prompt: len={len(prompt)}\n")
-        else:
-            sys.stderr.write(f"--- prompt\n{prompt}\n")
-
-    for response in backend.stream_generate(prompt, final_options, images):
-        if poll_cancel():
-            break
-        print(response.text.replace("\0", ""), end="", flush=True)
-
-    print("\n", end="\0", flush=True)
+    """completion API（後方互換）— generate に委譲"""
+    handle_generate(backend, prompt, options, images, max_image_size)

--- a/packages/driver/src/mlx-ml/python/handlers/generate.py
+++ b/packages/driver/src/mlx-ml/python/handlers/generate.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+from backends.base import ModelBackend
+from handlers.cancel import poll_cancel
+
+
+def handle_generate(
+    backend: ModelBackend,
+    prompt: str | list[int],
+    options: dict | None = None,
+    images: list | None = None,
+    max_image_size: int = 768,
+) -> None:
+    """LIP generate: 整形済み prompt のストリーム推論"""
+    if options is None:
+        options = {}
+
+    final_options = dict(options)
+    if images:
+        final_options["max_image_size"] = max_image_size
+        if os.getenv('MLX_DEBUG'):
+            display_prompt = re.sub(r'(<\|image_pad\|>)+', '<|image_pad|>...', prompt)
+            sys.stderr.write(
+                f"--- vlm generate (images: {len(images)}, max_size: {max_image_size})\n{display_prompt}\n"
+            )
+    elif os.getenv('MLX_DEBUG'):
+        if isinstance(prompt, list):
+            sys.stderr.write(f"--- prompt: len={len(prompt)}\n")
+        else:
+            sys.stderr.write(f"--- prompt\n{prompt}\n")
+
+    for response in backend.stream_generate(prompt, final_options, images):
+        if poll_cancel():
+            break
+        print(response.text.replace("\0", ""), end="", flush=True)
+
+    print("\n", end="\0", flush=True)

--- a/packages/driver/src/mlx-ml/python/handlers/generate.py
+++ b/packages/driver/src/mlx-ml/python/handlers/generate.py
@@ -23,7 +23,10 @@ def handle_generate(
     if images:
         final_options["max_image_size"] = max_image_size
         if os.getenv('MLX_DEBUG'):
-            display_prompt = re.sub(r'(<\|image_pad\|>)+', '<|image_pad|>...', prompt)
+            if isinstance(prompt, str):
+                display_prompt = re.sub(r'(<\|image_pad\|>)+', '<|image_pad|>...', prompt)
+            else:
+                display_prompt = f"<token ids: len={len(prompt)}>"
             sys.stderr.write(
                 f"--- vlm generate (images: {len(images)}, max_size: {max_image_size})\n{display_prompt}\n"
             )

--- a/packages/driver/src/mlx-ml/python/server.py
+++ b/packages/driver/src/mlx-ml/python/server.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 from backends.base import ModelBackend
-from handlers import handle_cache_prefill, handle_capabilities, handle_chat, handle_completion, handle_format_test, handle_tokenize
+from handlers import handle_cache_prefill, handle_capabilities, handle_chat, handle_completion, handle_format_test, handle_generate, handle_tokenize
 from handlers.cancel import request_cancel, reset_cancel
 
 
@@ -110,6 +110,20 @@ class Server:
                     reasoning_effort=req.get('reasoning_effort'),
                     cache_path=req.get('cache_path'),
                     cache_trim_tokens=req.get('cache_trim_tokens'),
+                )
+
+            elif method == 'generate':
+                prompt = req.get('prompt')
+                if not prompt:
+                    self._error_response("'prompt' field is required for generate method")
+                    return
+                images = req.get('images', [])
+                handle_generate(
+                    self.backend,
+                    prompt,
+                    options=req.get('options', {}),
+                    images=images if images else None,
+                    max_image_size=req.get('maxImageSize', 768),
                 )
 
             elif method == 'completion':

--- a/packages/driver/src/mlx-ml/python/server.py
+++ b/packages/driver/src/mlx-ml/python/server.py
@@ -27,6 +27,15 @@ def read():
             continue
 
 
+def _is_valid_generate_prompt(prompt) -> bool:
+    """prompt は非空文字列または非空のトークン ID リスト"""
+    if isinstance(prompt, str):
+        return bool(prompt)
+    if isinstance(prompt, list):
+        return len(prompt) > 0
+    return False
+
+
 class Server:
     def __init__(self, backend: ModelBackend, capabilities: dict):
         self.backend = backend
@@ -114,7 +123,7 @@ class Server:
 
             elif method == 'generate':
                 prompt = req.get('prompt')
-                if not prompt:
+                if not _is_valid_generate_prompt(prompt):
                     self._error_response("'prompt' field is required for generate method")
                     return
                 images = req.get('images', [])

--- a/packages/driver/src/mlx-ml/python/tests/test_server.py
+++ b/packages/driver/src/mlx-ml/python/tests/test_server.py
@@ -72,3 +72,21 @@ class TestServerDispatch:
         server._dispatch({"method": "completion"})
         captured = capsys.readouterr()
         assert captured.out.endswith('\0')
+
+    def test_generate_missing_prompt(self, capsys):
+        server = self._make_server()
+        server._dispatch({"method": "generate"})
+        captured = capsys.readouterr()
+        assert captured.out.endswith('\0')
+
+    def test_generate_dispatch(self, capsys):
+        server = self._make_server()
+        with patch('server.handle_generate') as mock_generate:
+            server._dispatch({
+                "method": "generate",
+                "prompt": "hello",
+                "options": {"max_tokens": 4},
+            })
+            mock_generate.assert_called_once()
+        captured = capsys.readouterr()
+        assert captured.out == '' or captured.out.endswith('\0')

--- a/packages/driver/src/mlx-ml/python/utils/token_utils.py
+++ b/packages/driver/src/mlx-ml/python/utils/token_utils.py
@@ -342,7 +342,7 @@ def get_capabilities(tokenizer):
         dict: capabilities情報
     """
     # 基本メソッド
-    methods = ["capabilities", "completion", "format_test"]
+    methods = ["capabilities", "completion", "generate", "format_test"]
 
     # apply_chat_templateがある場合はchatメソッドを追加
     if hasattr(tokenizer, 'apply_chat_template'):


### PR DESCRIPTION
## Summary

- Python: `handlers/generate.py` を追加（整形済み prompt のストリーム推論）
- `completion` ハンドラは `generate` に委譲（後方互換維持）
- LIP: `InferenceGenerateRequest` / `InferenceProcessClient.generate()`
- `MlxDriver` の instruct/completion 経路を `generate` に切替（`chat` は維持）

Closes #311
Part of #302

## 変更の要点

| 層 | 変更 |
|----|------|
| Python | `server.py` に `generate` ディスパッチ、capabilities に `generate` を追加 |
| TS 通信 | `addGenerateRequest` → wire `{"method":"generate","prompt":...}` |
| MlxDriver | `process.completion()` → `process.generate()` |

`completion` API（Python / TS）は削除せず残しています。

## Test plan

- [x] `pnpm run build` / `test:run` / `typecheck`（driver）
- [x] `request-queue.generate.test.ts` で wire 形式を確認
- [x] `mlx-driver-default-options.test.ts` を `generate` 呼び出しに更新
- [x] Python `tests/test_server.py`（11 passed）

## 次のステップ（#302 Phase 4）

- `render` 分離と暗黙 `chat` 整形の廃止

Made with [Cursor](https://cursor.com)