### PR TITLE
refactor(driver): LIP Phase 5 — LocalInferenceDriver 抽出

### DIFF
--- a/.changeset/lip-phase5-local-inference-driver.md
+++ b/.changeset/lip-phase5-local-inference-driver.md
@@ -1,0 +1,9 @@
+---
+"@modular-prompt/driver": minor
+---
+
+LIP Phase 5: LocalInferenceDriver 抽出
+
+- `local-inference/driver.ts` に共通 AIDriver 骨格を新設
+- `MlxDriver` を MLX 固有設定の薄いラッパにリファクタ
+- ストリーム META 処理を `stream-utils.ts` に分離

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -129,6 +129,15 @@ export type {
 export {
   InferenceProcessClient,
   type InferenceProcessClientConfig,
+  LocalInferenceDriver,
+  type LocalInferenceDriverConfig,
+  type InferenceProcessPort,
+  type LocalInferenceAdapters,
+  type LocalInferenceCacheSupport,
+  createStreamIterable,
+  extractStreamMeta,
+  META_MARKER,
+  hasMessageElement,
 } from './local-inference/index.js';
 
 // Python runtime (MLX venv under ~/.modular-prompt)

--- a/packages/driver/src/local-inference/adapters.ts
+++ b/packages/driver/src/local-inference/adapters.ts
@@ -1,6 +1,6 @@
 import type { CompiledPrompt } from '@modular-prompt/core';
 import type { ChatMessage, FormatterOptions } from '../formatter/types.js';
-import type { ToolCall, ToolDefinition } from '../types.js';
+import type { ToolCall, ToolDefinition, ApiStrategy, QueryMode } from '../types.js';
 import type {
   InferenceCapabilities,
   InferenceMessage,
@@ -53,8 +53,8 @@ export interface LocalInferenceAdapters {
     specialTokens: InferenceCapabilities['special_tokens'],
   ): string;
   selectApi(
-    strategy: string,
-    mode: string | undefined,
+    strategy: ApiStrategy,
+    mode: QueryMode | undefined,
     hasChatTemplate: boolean,
     hasCompletionProc: boolean,
   ): 'chat' | 'completion';

--- a/packages/driver/src/local-inference/adapters.ts
+++ b/packages/driver/src/local-inference/adapters.ts
@@ -1,0 +1,99 @@
+import type { CompiledPrompt } from '@modular-prompt/core';
+import type { ChatMessage, FormatterOptions } from '../formatter/types.js';
+import type { ToolCall, ToolDefinition } from '../types.js';
+import type {
+  InferenceCapabilities,
+  InferenceMessage,
+  InferenceToolDefinition,
+  ToolCallFormat,
+} from './protocol.js';
+import type { InferenceProcessPort } from './process-port.js';
+
+export interface InferenceModelProcessor {
+  applyChatSpecificProcessing(messages: InferenceMessage[]): InferenceMessage[];
+  applyCompletionSpecificProcessing(prompt: string): string;
+  hasCompletionProcessor(): boolean;
+  hasChatProcessor(): boolean;
+  setRuntimeContext(context: {
+    chatRestrictions?: InferenceCapabilities['chat_restrictions'];
+    modelKind?: 'lm' | 'vlm';
+  }): void;
+}
+
+export interface InferenceResponseParseResult {
+  content: string;
+  thinkingContent?: string;
+  toolCalls?: ToolCall[];
+}
+
+export type InferenceResponseProcessor = (content: string) => InferenceResponseParseResult;
+
+export interface LocalInferenceAdapters {
+  mergeQueryOptions(
+    defaults: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Record<string, unknown>;
+  toSamplingOptions(merged: Record<string, unknown>): Record<string, unknown>;
+  createModelProcessor(model: string): InferenceModelProcessor;
+  selectResponseProcessor(
+    model: string,
+    runtimeInfo: InferenceCapabilities | null,
+    options: { enableToolParsing: boolean },
+  ): InferenceResponseProcessor;
+  convertToolDefinitions(tools: ToolDefinition[]): InferenceToolDefinition[];
+  convertMessages(messages: ChatMessage[], vlm: boolean): InferenceMessage[];
+  extractImagePaths(content: string | unknown): string[];
+  formatToolDefinitionsAsText(
+    tools: ToolDefinition[],
+    specialTokens: InferenceCapabilities['special_tokens'] | undefined,
+    toolCallFormat?: ToolCallFormat,
+  ): string;
+  generateMergedPrompt(
+    messages: InferenceMessage[],
+    specialTokens: InferenceCapabilities['special_tokens'],
+  ): string;
+  selectApi(
+    strategy: string,
+    mode: string | undefined,
+    hasChatTemplate: boolean,
+    hasCompletionProc: boolean,
+  ): 'chat' | 'completion';
+}
+
+export interface CachePrepareParams {
+  model: string;
+  instructions: CompiledPrompt['instructions'];
+  data: CompiledPrompt['data'];
+  tools?: ToolDefinition[];
+  reasoningEffort?: 'low' | 'medium' | 'high';
+  readOnly?: boolean;
+}
+
+export interface CachePrepareHandle {
+  ref?: string;
+  trimTokens?: number;
+}
+
+export interface LocalInferenceCacheSupport {
+  bind(
+    process: InferenceProcessPort,
+    formatterOptions: FormatterOptions,
+    preprocess: (messages: InferenceMessage[]) => InferenceMessage[],
+  ): Promise<void>;
+  shouldDisableForVlm(modelKind?: 'lm' | 'vlm'): boolean;
+  recordQuery(): void;
+  getGrowthBefore(): number;
+  getWriteTokensSince(growthBefore: number): number;
+  prepare(params: CachePrepareParams): Promise<CachePrepareHandle>;
+  readTokenCount(cachePath: string): number;
+  recordPromptTokens(promptTokens: number, cacheTokensUsed: number): void;
+  /** 終了時の統計ログ（オプション。MlxDriver は独自ログを使用） */
+  logStats(): void;
+  close(): Promise<void>;
+}
+
+export interface CapabilitiesLoadedContext {
+  formatterOptions: FormatterOptions;
+  modelProcessor: InferenceModelProcessor;
+  process: InferenceProcessPort;
+}

--- a/packages/driver/src/local-inference/driver.test.ts
+++ b/packages/driver/src/local-inference/driver.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Readable } from 'stream';
+import type { CompiledPrompt } from '@modular-prompt/core';
+import { LocalInferenceDriver } from './driver.js';
+import type { LocalInferenceAdapters } from './adapters.js';
+import type { InferenceProcessPort } from './process-port.js';
+
+const mockCapabilities = {
+  methods: ['render', 'generate', 'capabilities'],
+  special_tokens: {},
+  features: {
+    apply_chat_template: true,
+    vocab_size: 32000,
+    model_max_length: 4096,
+    chat_template: {
+      supported_roles: ['system', 'user', 'assistant'],
+      preview: null,
+      constraints: {},
+    },
+  },
+};
+
+function createMockStream(chunks: string[]): Readable {
+  return Readable.from(chunks);
+}
+
+function createMockProcess(): InferenceProcessPort {
+  return {
+    ensureInitialized: vi.fn().mockResolvedValue(undefined),
+    getCapabilities: vi.fn().mockResolvedValue(mockCapabilities),
+    render: vi.fn().mockResolvedValue({ formatted_prompt: 'rendered-prompt', error: null }),
+    generate: vi.fn().mockResolvedValue(createMockStream(['ok'])),
+    cancelActiveRequest: vi.fn(),
+    exit: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockAdapters(overrides?: Partial<LocalInferenceAdapters>): LocalInferenceAdapters {
+  return {
+    mergeQueryOptions: (defaults, options) => ({ ...defaults, ...options }),
+    toSamplingOptions: (merged) => ({ maxTokens: merged.maxTokens as number | undefined }),
+    createModelProcessor: () => ({
+      applyChatSpecificProcessing: (messages) => messages,
+      applyCompletionSpecificProcessing: (prompt) => prompt,
+      hasCompletionProcessor: () => false,
+      hasChatProcessor: () => false,
+      setRuntimeContext: vi.fn(),
+    }),
+    selectResponseProcessor: () => (content) => ({ content }),
+    convertToolDefinitions: vi.fn(),
+    convertMessages: (messages) =>
+      messages.map((m) => ({ role: m.role, content: m.content as string })),
+    extractImagePaths: () => [],
+    formatToolDefinitionsAsText: () => '',
+    generateMergedPrompt: () => '<!-- begin of USER -->\ntest\n<!-- end of USER -->',
+    selectApi: (strategy, mode, hasChatTemplate) => {
+      if (mode === 'instruct') return 'completion';
+      if (mode === 'chat') return 'chat';
+      return hasChatTemplate ? 'chat' : 'completion';
+    },
+    ...overrides,
+  };
+}
+
+const prompt: CompiledPrompt = {
+  instructions: [{ type: 'text', content: 'test' }],
+  data: [],
+  output: [],
+};
+
+describe('LocalInferenceDriver', () => {
+  let mockProcess: InferenceProcessPort;
+  let mockAdapters: LocalInferenceAdapters;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcess = createMockProcess();
+    mockAdapters = createMockAdapters();
+  });
+
+  function createDriver(defaultOptions?: Record<string, unknown>) {
+    return new LocalInferenceDriver({
+      model: 'test-model',
+      process: mockProcess,
+      adapters: mockAdapters,
+      defaultOptions,
+      loggerPrefix: 'TEST',
+    });
+  }
+
+  it('uses render + generate for chat path', async () => {
+    const driver = createDriver({ mode: 'chat' });
+    await driver.query(prompt);
+
+    expect(mockProcess.render).toHaveBeenCalled();
+    expect(mockProcess.generate).toHaveBeenCalled();
+    expect(mockProcess.generate).toHaveBeenCalledWith(
+      'rendered-prompt',
+      expect.any(Object),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('uses generate only for completion path', async () => {
+    const driver = createDriver({ mode: 'instruct' });
+    await driver.query(prompt);
+
+    expect(mockProcess.render).not.toHaveBeenCalled();
+    expect(mockProcess.generate).toHaveBeenCalled();
+  });
+
+  it('uses generateMergedPrompt when chat template is unavailable', async () => {
+    vi.mocked(mockProcess.getCapabilities).mockResolvedValue({
+      ...mockCapabilities,
+      features: { ...mockCapabilities.features, apply_chat_template: false },
+    });
+
+    const driver = createDriver({ mode: 'chat' });
+    await driver.query(prompt);
+
+    expect(mockProcess.render).not.toHaveBeenCalled();
+    expect(mockProcess.generate).toHaveBeenCalledWith(
+      expect.stringContaining('<!-- begin of USER -->'),
+      expect.any(Object),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('strips trustRemoteCode before generate after render', async () => {
+    const driver = createDriver({ mode: 'chat' });
+    await driver.query(prompt, { trustRemoteCode: true } as never);
+
+    const generateOptions = vi.mocked(mockProcess.generate).mock.calls[0]?.[1];
+    expect(generateOptions).not.toHaveProperty('trustRemoteCode');
+  });
+});

--- a/packages/driver/src/local-inference/driver.ts
+++ b/packages/driver/src/local-inference/driver.ts
@@ -123,7 +123,7 @@ export class LocalInferenceDriver implements AIDriver {
 
   protected determineApi(options?: QueryOptions): 'chat' | 'completion' {
     return this.adapters.selectApi(
-      options?.apiStrategy || 'auto',
+      options?.apiStrategy ?? 'auto',
       options?.mode,
       !!this.runtimeInfo?.features.apply_chat_template,
       this.modelProcessor.hasCompletionProcessor(),

--- a/packages/driver/src/local-inference/driver.ts
+++ b/packages/driver/src/local-inference/driver.ts
@@ -1,0 +1,429 @@
+import { Readable } from 'stream';
+import type { CompiledPrompt } from '@modular-prompt/core';
+import { extractJSON } from '@modular-prompt/utils';
+import type { FormatterOptions } from '../formatter/types.js';
+import { formatPromptAsMessages } from '../formatter/converter.js';
+import { formatCompletionPrompt } from '../formatter/completion-formatter.js';
+import { extractCacheablePrefix } from '../cache-utils.js';
+import { QueryLogger } from '../query-logger.js';
+import type { AIDriver, FinishReason, QueryOptions, QueryResult, StreamResult } from '../types.js';
+import { isToolResult } from '../types.js';
+import {
+  buildQueryUsage,
+  createAbortedStreamResult,
+  isAborted,
+  watchAbortSignal,
+} from '../query-utils.js';
+import type {
+  CapabilitiesLoadedContext,
+  LocalInferenceAdapters,
+  LocalInferenceCacheSupport,
+} from './adapters.js';
+import type { InferenceCapabilities } from './protocol.js';
+import type { InferenceProcessPort } from './process-port.js';
+import { createStreamIterable } from './stream-utils.js';
+
+export interface LocalInferenceDriverConfig {
+  model: string;
+  process: InferenceProcessPort;
+  adapters: LocalInferenceAdapters;
+  formatterOptions?: FormatterOptions;
+  maxImageSize?: number;
+  defaultOptions?: Record<string, unknown>;
+  loggerPrefix?: string;
+  cache?: LocalInferenceCacheSupport;
+  onCapabilitiesLoaded?: (
+    runtimeInfo: InferenceCapabilities,
+    ctx: CapabilitiesLoadedContext,
+  ) => Promise<void>;
+}
+
+export class LocalInferenceDriver implements AIDriver {
+  protected readonly process: InferenceProcessPort;
+  protected readonly model: string;
+  protected readonly adapters: LocalInferenceAdapters;
+  protected readonly formatterOptions: FormatterOptions;
+  protected readonly maxImageSize: number;
+  private onCapabilitiesLoaded?: LocalInferenceDriverConfig['onCapabilitiesLoaded'];
+  private cacheSupport?: LocalInferenceCacheSupport;
+
+  protected runtimeInfo: InferenceCapabilities | null = null;
+  protected modelProcessor: ReturnType<LocalInferenceAdapters['createModelProcessor']>;
+  protected queryLogger: QueryLogger;
+  private _defaultOptions: Record<string, unknown>;
+  private capabilitiesLoaded = false;
+
+  get defaultOptions(): Record<string, unknown> {
+    return this._defaultOptions;
+  }
+
+  set defaultOptions(value: Record<string, unknown>) {
+    this._defaultOptions = value ?? {};
+  }
+
+  constructor(config: LocalInferenceDriverConfig) {
+    this.model = config.model;
+    this.process = config.process;
+    this.adapters = config.adapters;
+    this._defaultOptions = config.defaultOptions ?? {};
+    this.formatterOptions = config.formatterOptions ?? {};
+    this.maxImageSize = config.maxImageSize ?? 768;
+    this.cacheSupport = config.cache;
+    this.onCapabilitiesLoaded = config.onCapabilitiesLoaded;
+    this.modelProcessor = config.adapters.createModelProcessor(config.model);
+    this.queryLogger = new QueryLogger(config.loggerPrefix ?? 'LIP');
+  }
+
+  protected disableCacheSupport(): void {
+    this.cacheSupport = undefined;
+  }
+
+  protected async ensureInitialized(): Promise<void> {
+    await this.process.ensureInitialized();
+
+    if (this.capabilitiesLoaded) {
+      return;
+    }
+
+    try {
+      this.runtimeInfo = await this.process.getCapabilities();
+      this.capabilitiesLoaded = true;
+
+      if (this.runtimeInfo.special_tokens) {
+        this.formatterOptions.specialTokens = this.runtimeInfo.special_tokens;
+      }
+
+      this.modelProcessor.setRuntimeContext({
+        chatRestrictions: this.runtimeInfo.chat_restrictions,
+        modelKind: this.runtimeInfo.model_kind,
+      });
+
+      if (this.onCapabilitiesLoaded) {
+        await this.onCapabilitiesLoaded(this.runtimeInfo, {
+          formatterOptions: this.formatterOptions,
+          modelProcessor: this.modelProcessor,
+          process: this.process,
+        });
+      }
+    } catch (error) {
+      this.queryLogger.log.error(
+        'Failed to get runtime info:',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  protected getRuntimeInfo(): InferenceCapabilities | null {
+    return this.runtimeInfo;
+  }
+
+  protected isVLM(): boolean {
+    return this.runtimeInfo?.model_kind === 'vlm';
+  }
+
+  protected determineApi(options?: QueryOptions): 'chat' | 'completion' {
+    return this.adapters.selectApi(
+      options?.apiStrategy || 'auto',
+      options?.mode,
+      !!this.runtimeInfo?.features.apply_chat_template,
+      this.modelProcessor.hasCompletionProcessor(),
+    );
+  }
+
+  protected hasNativeToolSupport(): boolean {
+    return !!this.runtimeInfo?.features?.chat_template?.tool_call_format?.call_start;
+  }
+
+  protected async executeQuery(
+    prompt: CompiledPrompt,
+    samplingOptions: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<{ stream: Readable; cacheTokensUsed: number; cacheWriteTokens: number }> {
+    const api = this.determineApi(options as QueryOptions | undefined);
+    const queryOptions = options as QueryOptions | undefined;
+
+    const tools = queryOptions?.tools
+      ? this.adapters.convertToolDefinitions(queryOptions.tools)
+      : undefined;
+
+    let augmentedPrompt = prompt;
+    if (
+      queryOptions?.tools &&
+      queryOptions.tools.length > 0 &&
+      (api === 'completion' || !this.hasNativeToolSupport())
+    ) {
+      const toolsText = this.adapters.formatToolDefinitionsAsText(
+        queryOptions.tools,
+        this.runtimeInfo?.special_tokens,
+        this.runtimeInfo?.features?.chat_template?.tool_call_format,
+      );
+      augmentedPrompt = {
+        ...prompt,
+        instructions: [...prompt.instructions, { type: 'text' as const, content: toolsText }],
+      };
+    }
+
+    this.cacheSupport?.recordQuery();
+
+    if (api === 'completion') {
+      let formattedPrompt = formatCompletionPrompt(augmentedPrompt, this.formatterOptions);
+      formattedPrompt = this.modelProcessor.applyCompletionSpecificProcessing(formattedPrompt);
+      const stream = await this.process.generate(formattedPrompt, samplingOptions);
+      return { stream, cacheTokensUsed: 0, cacheWriteTokens: 0 };
+    }
+
+    const messages = formatPromptAsMessages(augmentedPrompt, this.formatterOptions);
+    const vlm = this.isVLM();
+    let inferenceMessages = this.adapters.convertMessages(messages, vlm);
+    inferenceMessages = this.modelProcessor.applyChatSpecificProcessing(inferenceMessages);
+    const nativeTools = this.hasNativeToolSupport() && tools?.length ? tools : undefined;
+    const images = vlm
+      ? messages.flatMap((m) =>
+          'content' in m && !isToolResult(m)
+            ? this.adapters.extractImagePaths(m.content)
+            : [],
+        )
+      : [];
+
+    let cachePath: string | undefined;
+    let cacheTrimTokens: number | undefined;
+    let cacheWriteTokens = 0;
+    const cacheGrowthBefore = this.cacheSupport?.getGrowthBefore() ?? 0;
+    const trustRemoteCode = samplingOptions.trustRemoteCode;
+
+    if (this.cacheSupport && queryOptions?.cache !== false && trustRemoteCode === undefined) {
+      const prefix = extractCacheablePrefix(augmentedPrompt);
+      const hasCacheableContent = prefix.instructions.length > 0 || prefix.data.length > 0;
+
+      if (hasCacheableContent) {
+        const cacheStart = performance.now();
+        const handle = await this.cacheSupport.prepare({
+          model: this.model,
+          instructions: prefix.instructions,
+          data: prefix.data,
+          tools: nativeTools ? queryOptions!.tools : undefined,
+          reasoningEffort: queryOptions?.reasoningEffort,
+          readOnly: queryOptions?.cache === 'read-only',
+        });
+        cachePath = handle.ref || undefined;
+        cacheTrimTokens = handle.trimTokens;
+        if (cachePath) {
+          this.queryLogger.log.debug(
+            `cache prepare ${(performance.now() - cacheStart).toFixed(0)}ms`,
+            `(${prefix.instructions.length}i+${prefix.data.length}d)`,
+            cacheTrimTokens != null ? `trim=${cacheTrimTokens}` : '',
+          );
+        }
+      }
+    }
+
+    if (this.cacheSupport) {
+      cacheWriteTokens = this.cacheSupport.getWriteTokensSince(cacheGrowthBefore);
+    }
+
+    let formattedPrompt: string;
+    if (this.runtimeInfo?.features.apply_chat_template) {
+      const renderResult = await this.process.render(
+        inferenceMessages,
+        samplingOptions,
+        nativeTools,
+        queryOptions?.reasoningEffort,
+      );
+      if (renderResult.error || renderResult.formatted_prompt == null) {
+        throw new Error(renderResult.error ?? 'render failed');
+      }
+      formattedPrompt = String(renderResult.formatted_prompt);
+    } else {
+      formattedPrompt = this.adapters.generateMergedPrompt(
+        inferenceMessages,
+        this.runtimeInfo?.special_tokens ?? {},
+      );
+    }
+
+    const generateOptions = { ...samplingOptions };
+    delete generateOptions.trustRemoteCode;
+
+    const stream = await this.process.generate(
+      formattedPrompt,
+      generateOptions,
+      images.length > 0 ? images : undefined,
+      images.length > 0 ? this.maxImageSize : undefined,
+      cachePath,
+      cacheTrimTokens,
+    );
+
+    const cacheTokensUsed = cachePath
+      ? (cacheTrimTokens ?? (this.cacheSupport ? this.cacheSupport.readTokenCount(cachePath) : 0))
+      : 0;
+
+    return { stream, cacheTokensUsed, cacheWriteTokens };
+  }
+
+  async query(prompt: CompiledPrompt, options?: QueryOptions): Promise<QueryResult> {
+    const { stream, result } = await this.streamQuery(prompt, options);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of stream) {
+      // Consume stream so result resolves
+    }
+    return result;
+  }
+
+  async streamQuery(prompt: CompiledPrompt, options?: QueryOptions): Promise<StreamResult> {
+    await this.ensureInitialized();
+
+    const signal = options?.signal;
+    if (isAborted(signal)) {
+      return createAbortedStreamResult(this.queryLogger.collect());
+    }
+
+    let abortRequested = false;
+    const cleanupAbort = watchAbortSignal(signal, () => {
+      abortRequested = true;
+      this.process.cancelActiveRequest();
+    });
+    const checkAborted = () => abortRequested || isAborted(signal);
+
+    const merged = this.adapters.mergeQueryOptions(
+      this._defaultOptions,
+      options as Record<string, unknown> | undefined,
+    );
+    const samplingOptions = this.adapters.toSamplingOptions(merged);
+    this.queryLogger.mark(merged);
+
+    const queryStart = performance.now();
+    const { stream, cacheTokensUsed, cacheWriteTokens } = await this.executeQuery(
+      prompt,
+      samplingOptions,
+      merged,
+    );
+
+    if (checkAborted()) {
+      this.process.cancelActiveRequest();
+    }
+
+    const streamStart = performance.now();
+    this.queryLogger.log.debug(`setup ${(streamStart - queryStart).toFixed(0)}ms`);
+
+    const { iterable, completion } = createStreamIterable(stream, checkAborted);
+
+    const queryLogger = this.queryLogger;
+    let firstChunkTime = 0;
+    const wrappedIterable: AsyncIterable<string> = {
+      [Symbol.asyncIterator]() {
+        const inner = iterable[Symbol.asyncIterator]();
+        let firstChunk = true;
+        return {
+          async next() {
+            if (checkAborted()) {
+              void inner.return?.();
+              return { done: true as const, value: undefined };
+            }
+            const result = await inner.next();
+            if (!result.done) {
+              if (firstChunk) {
+                firstChunk = false;
+                firstChunkTime = performance.now();
+                queryLogger.log.debug(`TTFT ${(firstChunkTime - streamStart).toFixed(0)}ms`);
+              }
+            } else {
+              const now = performance.now();
+              if (firstChunkTime > 0) {
+                const genMs = now - firstChunkTime;
+                queryLogger.log.debug(
+                  `generation ${genMs.toFixed(0)}ms (query total ${(now - queryStart).toFixed(0)}ms)`,
+                );
+              } else {
+                queryLogger.log.debug(`query total ${(performance.now() - queryStart).toFixed(0)}ms`);
+              }
+            }
+            return result;
+          },
+          async return(value?: string) {
+            cleanupAbort();
+            return inner.return?.(value) ?? { done: true as const, value: undefined };
+          },
+          async throw(e?: unknown) {
+            cleanupAbort();
+            return inner.throw?.(e) ?? { done: true as const, value: undefined };
+          },
+        };
+      },
+    };
+
+    const cache = this.cacheSupport;
+    const resultPromise = completion
+      .then(({ content, meta, error }) => {
+        const aborted = checkAborted();
+        if (error && !aborted) {
+          this.queryLogger.log.error('Stream error:', error.message);
+          throw error;
+        }
+
+        if (cache && meta.prompt_tokens != null) {
+          cache.recordPromptTokens(meta.prompt_tokens, cacheTokensUsed);
+        }
+
+        if (meta.generation_tokens != null && firstChunkTime > 0) {
+          const genMs = performance.now() - firstChunkTime;
+          const actualTps = ((meta.generation_tokens / genMs) * 1000).toFixed(1);
+          this.queryLogger.log.debug(`${meta.generation_tokens} tokens, ${actualTps} tok/s`);
+        }
+
+        const hasTools = options?.tools && options.tools.length > 0;
+        const responseProcessor = this.adapters.selectResponseProcessor(this.model, this.runtimeInfo, {
+          enableToolParsing: !!hasTools,
+        });
+        const parsed = responseProcessor(content);
+        const finalContent = parsed.content;
+        const thinkingContent = parsed.thinkingContent;
+        const toolCalls = parsed.toolCalls;
+
+        if (thinkingContent) {
+          this.queryLogger.log.verbose('Thinking content:', thinkingContent);
+        }
+
+        let structuredOutput: unknown | undefined;
+        if (prompt.metadata?.outputSchema && finalContent) {
+          const extracted = extractJSON(finalContent, { multiple: false });
+          if (extracted.source !== 'none' && extracted.data !== null) {
+            structuredOutput = extracted.data;
+          }
+        }
+
+        const finishReason: FinishReason = aborted
+          ? 'error'
+          : toolCalls
+            ? 'tool_calls'
+            : 'stop';
+
+        return {
+          content: finalContent,
+          thinkingContent,
+          structuredOutput,
+          toolCalls,
+          finishReason,
+          usage: buildQueryUsage({
+            promptTokens: meta.prompt_tokens,
+            completionTokens: meta.generation_tokens,
+            cacheReadTokens: cacheTokensUsed,
+            cacheWriteTokens,
+          }),
+          ...this.queryLogger.collect(),
+        };
+      })
+      .finally(() => {
+        cleanupAbort();
+      });
+
+    return {
+      stream: wrappedIterable,
+      result: resultPromise,
+    };
+  }
+
+  async close(): Promise<void> {
+    this.cacheSupport?.logStats();
+    await this.cacheSupport?.close();
+    await this.process.exit();
+  }
+}

--- a/packages/driver/src/local-inference/index.ts
+++ b/packages/driver/src/local-inference/index.ts
@@ -65,3 +65,20 @@ export {
   InferenceProcessClient,
   type InferenceProcessClientConfig,
 } from './process-client.js';
+
+/** バックエンド非依存の LIP ドライバー骨格（公開 API） */
+export {
+  LocalInferenceDriver,
+  type LocalInferenceDriverConfig,
+} from './driver.js';
+
+export type { InferenceProcessPort } from './process-port.js';
+export type {
+  LocalInferenceAdapters,
+  LocalInferenceCacheSupport,
+  InferenceModelProcessor,
+  InferenceResponseProcessor,
+} from './adapters.js';
+
+export { createStreamIterable, extractStreamMeta, META_MARKER } from './stream-utils.js';
+export { hasMessageElement } from './prompt-utils.js';

--- a/packages/driver/src/local-inference/process-port.ts
+++ b/packages/driver/src/local-inference/process-port.ts
@@ -1,0 +1,30 @@
+import type { Readable } from 'stream';
+import type {
+  InferenceCapabilities,
+  InferenceMessage,
+  InferenceRenderResult,
+  InferenceToolDefinition,
+} from './protocol.js';
+
+/** LIP プロセスへの最小ポート（MlxProcess / 将来 PyTorchProcess が実装） */
+export interface InferenceProcessPort {
+  ensureInitialized(): Promise<void>;
+  getCapabilities(): Promise<InferenceCapabilities>;
+  render(
+    messages: InferenceMessage[],
+    options?: Record<string, unknown>,
+    tools?: InferenceToolDefinition[],
+    reasoningEffort?: 'low' | 'medium' | 'high',
+  ): Promise<InferenceRenderResult>;
+  generate(
+    prompt: string | number[],
+    options?: Record<string, unknown>,
+    images?: string[],
+    maxImageSize?: number,
+    cachePath?: string,
+    cacheTrimTokens?: number,
+    primer?: string,
+  ): Promise<Readable>;
+  cancelActiveRequest(): void;
+  exit(): Promise<void>;
+}

--- a/packages/driver/src/local-inference/prompt-utils.ts
+++ b/packages/driver/src/local-inference/prompt-utils.ts
@@ -1,0 +1,20 @@
+import type { CompiledPrompt } from '@modular-prompt/core';
+
+/**
+ * Check if the prompt contains MessageElement
+ */
+export function hasMessageElement(prompt: CompiledPrompt): boolean {
+  const checkElements = (elements: unknown[]): boolean => {
+    if (!elements) return false;
+    return elements.some((element) => {
+      const el = element as { type?: string };
+      return el?.type === 'message';
+    });
+  };
+
+  return (
+    checkElements(prompt.instructions) ||
+    checkElements(prompt.data) ||
+    checkElements(prompt.output)
+  );
+}

--- a/packages/driver/src/local-inference/stream-utils.test.ts
+++ b/packages/driver/src/local-inference/stream-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { Readable } from 'stream';
+import { extractStreamMeta, createStreamIterable, META_MARKER } from './stream-utils.js';
+
+describe('stream-utils', () => {
+  it('extractStreamMeta parses trailing meta JSON', () => {
+    const raw = `hello${META_MARKER}{"prompt_tokens":10,"generation_tokens":3}`;
+    const { content, meta } = extractStreamMeta(raw);
+    expect(content).toBe('hello');
+    expect(meta).toEqual({ prompt_tokens: 10, generation_tokens: 3 });
+  });
+
+  it('extractStreamMeta returns content unchanged when no marker', () => {
+    const { content, meta } = extractStreamMeta('plain text');
+    expect(content).toBe('plain text');
+    expect(meta).toEqual({});
+  });
+
+  it('createStreamIterable strips meta from yielded chunks', async () => {
+    const stream = Readable.from([`partial `, `answer${META_MARKER}{"prompt_tokens":1,"generation_tokens":2}`]);
+    const { iterable, completion } = createStreamIterable(stream);
+
+    const chunks: string[] = [];
+    for await (const chunk of iterable) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join('')).toBe('partial answer');
+    await expect(completion).resolves.toMatchObject({
+      content: 'partial answer',
+      meta: { prompt_tokens: 1, generation_tokens: 2 },
+      error: null,
+    });
+  });
+});

--- a/packages/driver/src/local-inference/stream-utils.ts
+++ b/packages/driver/src/local-inference/stream-utils.ts
@@ -1,0 +1,85 @@
+import { Readable } from 'stream';
+
+export interface StreamMeta {
+  prompt_tokens?: number;
+  generation_tokens?: number;
+}
+
+export const META_MARKER = '\x1e__META__:';
+
+export function extractStreamMeta(content: string): { content: string; meta: StreamMeta } {
+  const idx = content.lastIndexOf(META_MARKER);
+  if (idx === -1) return { content, meta: {} };
+  const jsonStr = content.slice(idx + META_MARKER.length);
+  try {
+    return { content: content.slice(0, idx), meta: JSON.parse(jsonStr) };
+  } catch {
+    return { content: content.slice(0, idx), meta: {} };
+  }
+}
+
+export function createStreamIterable(
+  stream: Readable,
+  isAborted?: () => boolean,
+): {
+  iterable: AsyncIterable<string>;
+  completion: Promise<{ content: string; meta: StreamMeta; error: Error | null }>;
+} {
+  const chunks: string[] = [];
+  let resolveCompletion: (value: { content: string; meta: StreamMeta; error: Error | null }) => void;
+  let settled = false;
+
+  const settle = (error: Error | null) => {
+    if (settled) return;
+    settled = true;
+    const raw = chunks.join('');
+    const { content, meta } = extractStreamMeta(raw);
+    const aborted = isAborted?.() ?? false;
+    resolveCompletion({ content, meta, error: aborted ? null : error });
+  };
+
+  const completion = new Promise<{ content: string; meta: StreamMeta; error: Error | null }>((resolve) => {
+    resolveCompletion = resolve;
+  });
+
+  const iterable = {
+    async *[Symbol.asyncIterator](): AsyncIterator<string> {
+      try {
+        let buffer = '';
+        let markerFound = false;
+        for await (const chunk of stream) {
+          if (isAborted?.()) {
+            break;
+          }
+          const str = chunk.toString();
+          chunks.push(str);
+          if (markerFound) continue;
+          buffer += str;
+          const markerIdx = buffer.indexOf(META_MARKER);
+          if (markerIdx !== -1) {
+            const text = buffer.slice(0, markerIdx);
+            if (text) yield text;
+            markerFound = true;
+          } else {
+            const safeLen = buffer.length - (META_MARKER.length - 1);
+            if (safeLen > 0) {
+              yield buffer.slice(0, safeLen);
+              buffer = buffer.slice(safeLen);
+            }
+          }
+        }
+        if (!markerFound && buffer) yield buffer;
+      } catch (error) {
+        settle(error as Error);
+        const aborted = isAborted?.() ?? false;
+        if (!aborted) {
+          throw error;
+        }
+      } finally {
+        settle(null);
+      }
+    },
+  };
+
+  return { iterable, completion };
+}

--- a/packages/driver/src/mlx-ml/mlx-cache-support.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-support.ts
@@ -1,0 +1,69 @@
+import type { FormatterOptions } from '../formatter/types.js';
+import type { InferenceMessage } from '../local-inference/protocol.js';
+import type {
+  CachePrepareHandle,
+  LocalInferenceCacheSupport,
+} from '../local-inference/adapters.js';
+import type { InferenceProcessPort } from '../local-inference/process-port.js';
+import { MlxCacheController } from './mlx-cache-controller.js';
+import type { PromptCacheController } from '../cache-controller.js';
+
+export function createMlxCacheSupport(
+  controller: PromptCacheController,
+): LocalInferenceCacheSupport | undefined {
+  if (!(controller instanceof MlxCacheController)) {
+    return undefined;
+  }
+
+  const mlxCache = controller;
+  return {
+    async bind(process, formatterOptions, preprocess) {
+      await mlxCache.bind(
+        process as Parameters<MlxCacheController['bind']>[0],
+        formatterOptions,
+        preprocess,
+      );
+    },
+    shouldDisableForVlm: (modelKind) => modelKind === 'vlm',
+    recordQuery: () => mlxCache.recordQuery?.(),
+    getGrowthBefore: () => mlxCache.getStats().cacheGrowthTokens,
+    getWriteTokensSince: (growthBefore) =>
+      Math.max(0, mlxCache.getStats().cacheGrowthTokens - growthBefore),
+    prepare: (params) => mlxCache.prepare(params) as Promise<CachePrepareHandle>,
+    readTokenCount: (cachePath) => mlxCache.readCacheTokenCount(cachePath),
+    recordPromptTokens: (promptTokens, cacheTokensUsed) => {
+      mlxCache.recordPromptTokens(promptTokens, cacheTokensUsed);
+    },
+    logStats: () => {
+      // MlxDriver.close() で QueryLogger 経由のログを行う
+    },
+    close: () => mlxCache.close(),
+  };
+}
+
+export function bindMlxCacheOnCapabilitiesLoaded(
+  cache: LocalInferenceCacheSupport,
+  cacheBound: { bound: boolean },
+  runtimeInfo: { model_kind?: 'lm' | 'vlm' },
+  ctx: {
+    process: InferenceProcessPort;
+    formatterOptions: FormatterOptions;
+    modelProcessor: { applyChatSpecificProcessing(messages: InferenceMessage[]): InferenceMessage[] };
+  },
+  onVlmDisabled: () => void,
+): Promise<void> {
+  if (cacheBound.bound) {
+    return Promise.resolve();
+  }
+  if (cache.shouldDisableForVlm(runtimeInfo.model_kind)) {
+    onVlmDisabled();
+    return Promise.resolve();
+  }
+  return cache
+    .bind(ctx.process, ctx.formatterOptions, (msgs) =>
+      ctx.modelProcessor.applyChatSpecificProcessing(msgs),
+    )
+    .then(() => {
+      cacheBound.bound = true;
+    });
+}

--- a/packages/driver/src/mlx-ml/mlx-cache-support.ts
+++ b/packages/driver/src/mlx-ml/mlx-cache-support.ts
@@ -8,6 +8,11 @@ import type { InferenceProcessPort } from '../local-inference/process-port.js';
 import { MlxCacheController } from './mlx-cache-controller.js';
 import type { PromptCacheController } from '../cache-controller.js';
 
+/**
+ * MLX 向け KV キャッシュ連携を構築する。
+ * `PromptCacheController` が `MlxCacheController` でない場合は undefined（旧挙動と同様）。
+ * PyTorch 等の別バックエンド用 adapter は将来ここに並列で追加する。
+ */
 export function createMlxCacheSupport(
   controller: PromptCacheController,
 ): LocalInferenceCacheSupport | undefined {

--- a/packages/driver/src/mlx-ml/mlx-driver.test.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.test.ts
@@ -94,7 +94,7 @@ describe('MlxDriver', () => {
       await ensureInitialized();
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to get MLX runtime info:')
+        expect.stringContaining('Failed to get runtime info:')
       );
 
       consoleSpy.mockRestore();

--- a/packages/driver/src/mlx-ml/mlx-driver.ts
+++ b/packages/driver/src/mlx-ml/mlx-driver.ts
@@ -1,55 +1,18 @@
-import { Readable } from 'stream';
-import type { AIDriver, QueryOptions, QueryResult, StreamResult, FinishReason } from '../types.js';
-import { isToolResult } from '../types.js';
-import type { FormatterOptions } from '../formatter/types.js';
-import { formatPromptAsMessages } from '../formatter/converter.js';
-import { formatCompletionPrompt } from '../formatter/completion-formatter.js';
-import { MlxProcess } from './process/index.js';
-import type { MlxMlModelOptions, MlxModelCapabilities } from './types.js';
-import { mergeMlxQueryOptions, toMlxSamplingOptions, type MlxQueryOptions } from './mlx-options.js';
-import type { MlxRuntimeInfo } from './process/types.js';
-import { createModelSpecificProcessor, selectApi } from './process/model-specific.js';
-import { generateMergedPrompt } from './process/prompt-builder.js';
-import { selectResponseProcessor } from './process/model-handlers.js';
-import type { CompiledPrompt } from '@modular-prompt/core';
-import { extractJSON } from '@modular-prompt/utils';
-import { formatToolDefinitionsAsText } from './tool-call-parser/index.js';
-import { convertMessages, convertToolDefinitions, extractImagePaths } from './mlx-message-utils.js';
-import { QueryLogger } from '../query-logger.js';
+import { LocalInferenceDriver } from '../local-inference/driver.js';
+import { hasMessageElement } from '../local-inference/prompt-utils.js';
 import type { PromptCacheController } from '../cache-controller.js';
-import { extractCacheablePrefix } from '../cache-utils.js';
-import { MlxCacheController } from './mlx-cache-controller.js';
+import type { MlxModelCapabilities } from './types.js';
+import type { MlxQueryOptions } from './mlx-options.js';
+import type { FormatterOptions } from '../formatter/types.js';
+import { MlxProcess } from './process/index.js';
+import { mlxLocalInferenceAdapters } from './mlx-local-inference-adapters.js';
 import {
-  buildQueryUsage,
-  createAbortedStreamResult,
-  isAborted,
-  watchAbortSignal,
-} from '../query-utils.js';
+  bindMlxCacheOnCapabilitiesLoaded,
+  createMlxCacheSupport,
+} from './mlx-cache-support.js';
+import { MlxCacheController } from './mlx-cache-controller.js';
 
-// ========================================================================
-// Utility Functions (exported for testing)
-// ========================================================================
-
-/**
- * Check if the prompt contains MessageElement
- */
-export function hasMessageElement(prompt: CompiledPrompt): boolean {
-  const checkElements = (elements: unknown[]): boolean => {
-    if (!elements) return false;
-    return elements.some(element => {
-      const el = element as { type?: string };
-      return el?.type === 'message';
-    });
-  };
-
-  return checkElements(prompt.instructions) ||
-    checkElements(prompt.data) ||
-    checkElements(prompt.output);
-}
-
-// ========================================================================
-// Main Class
-// ========================================================================
+export { hasMessageElement };
 
 /**
  * MLX ML driver configuration
@@ -71,510 +34,66 @@ export interface MlxDriverConfig {
 }
 
 /**
- * Creates an async iterable from a readable stream with content collection
+ * MLX ML driver using Python subprocess.
+ * 共通ロジックは LocalInferenceDriver に委譲する。
  */
-interface StreamMeta {
-  prompt_tokens?: number;
-  generation_tokens?: number;
-}
-
-const META_MARKER = '\x1e__META__:';
-
-function extractStreamMeta(content: string): { content: string; meta: StreamMeta } {
-  const idx = content.lastIndexOf(META_MARKER);
-  if (idx === -1) return { content, meta: {} };
-  const jsonStr = content.slice(idx + META_MARKER.length);
-  try {
-    return { content: content.slice(0, idx), meta: JSON.parse(jsonStr) };
-  } catch {
-    return { content: content.slice(0, idx), meta: {} };
-  }
-}
-
-function createStreamIterable(
-  stream: Readable,
-  isAborted?: () => boolean,
-): {
-  iterable: AsyncIterable<string>;
-  completion: Promise<{ content: string; meta: StreamMeta; error: Error | null }>;
-} {
-  const chunks: string[] = [];
-  let resolveCompletion: (value: { content: string; meta: StreamMeta; error: Error | null }) => void;
-  let settled = false;
-
-  const settle = (error: Error | null) => {
-    if (settled) return;
-    settled = true;
-    const raw = chunks.join('');
-    const { content, meta } = extractStreamMeta(raw);
-    const aborted = isAborted?.() ?? false;
-    resolveCompletion({ content, meta, error: aborted ? null : error });
-  };
-
-  const completion = new Promise<{ content: string; meta: StreamMeta; error: Error | null }>((resolve) => {
-    resolveCompletion = resolve;
-  });
-
-  const iterable = {
-    async *[Symbol.asyncIterator](): AsyncIterator<string> {
-      try {
-        let buffer = '';
-        let markerFound = false;
-        for await (const chunk of stream) {
-          if (isAborted?.()) {
-            break;
-          }
-          const str = chunk.toString();
-          chunks.push(str);
-          if (markerFound) continue;
-          buffer += str;
-          const markerIdx = buffer.indexOf(META_MARKER);
-          if (markerIdx !== -1) {
-            const text = buffer.slice(0, markerIdx);
-            if (text) yield text;
-            markerFound = true;
-          } else {
-            const safeLen = buffer.length - (META_MARKER.length - 1);
-            if (safeLen > 0) {
-              yield buffer.slice(0, safeLen);
-              buffer = buffer.slice(safeLen);
-            }
-          }
-        }
-        if (!markerFound && buffer) yield buffer;
-      } catch (error) {
-        settle(error as Error);
-        const aborted = isAborted?.() ?? false;
-        if (!aborted) {
-          throw error;
-        }
-      } finally {
-        settle(null);
-      }
-    }
-  };
-
-  return { iterable, completion };
-}
-
-/**
- * MLX ML driver using Python subprocess
- */
-export class MlxDriver implements AIDriver {
-  private process: MlxProcess;
-  private model: string;
-  private _defaultOptions: Partial<MlxQueryOptions>;
-  private runtimeInfo: MlxRuntimeInfo | null = null;
-  private modelProcessor;
-  private formatterOptions: FormatterOptions;
-  private maxImageSize: number;
-  private queryLogger = new QueryLogger('MLX');
-  private cacheController?: PromptCacheController;
-  private cacheControllerBound = false;
-
-  get defaultOptions(): Partial<MlxQueryOptions> {
-    return this._defaultOptions;
-  }
-
-  set defaultOptions(value: Partial<MlxQueryOptions>) {
-    this._defaultOptions = value ?? {};
-  }
+export class MlxDriver extends LocalInferenceDriver {
+  private cacheControllerRaw?: PromptCacheController;
+  private cacheDisabledForVlm = false;
+  private readonly cacheBindingState = { bound: false };
 
   constructor(config: MlxDriverConfig) {
-    this.model = config.model;
-    this._defaultOptions = config.defaultOptions ?? {};
-    this.formatterOptions = config.formatterOptions || {};
-    this.maxImageSize = config.maxImageSize ?? 768;
-    this.process = new MlxProcess(config.model, {
+    const mlxProcess = new MlxProcess(config.model, {
       textOnly: config.textOnly,
       drafterModel: config.drafterModel,
-      draftBlockSize: config.draftBlockSize
+      draftBlockSize: config.draftBlockSize,
     });
-    this.modelProcessor = createModelSpecificProcessor(config.model);
-    this.cacheController = config.cacheController;
+    const cacheSupport = config.cacheController
+      ? createMlxCacheSupport(config.cacheController)
+      : undefined;
+
+    super({
+      model: config.model,
+      process: mlxProcess,
+      adapters: mlxLocalInferenceAdapters,
+      formatterOptions: config.formatterOptions,
+      maxImageSize: config.maxImageSize,
+      defaultOptions: config.defaultOptions,
+      loggerPrefix: 'MLX',
+      cache: cacheSupport,
+      onCapabilitiesLoaded: async (runtimeInfo, ctx) => {
+        if (!cacheSupport) return;
+        await bindMlxCacheOnCapabilitiesLoaded(
+          cacheSupport,
+          this.cacheBindingState,
+          runtimeInfo,
+          ctx,
+          () => {
+            this.queryLogger.log.info(
+              'VLM models do not support prompt caching — cacheController disabled',
+            );
+            this.cacheDisabledForVlm = true;
+            this.disableCacheSupport();
+          },
+        );
+      },
+    });
+
+    this.cacheControllerRaw = config.cacheController;
+
     if (config.drafterModel) {
       this.queryLogger.log.info(`Drafter model: ${config.drafterModel}`);
     }
   }
 
-  /**
-   * Initialize process and cache runtime info
-   */
-  private async ensureInitialized(): Promise<void> {
-    // Ensure process is initialized
-    await this.process.ensureInitialized();
-
-    // Cache runtime info if not already cached
-    if (!this.runtimeInfo) {
-      try {
-        this.runtimeInfo = await this.process.getCapabilities();
-
-        // Update formatterOptions with special tokens from runtime info
-        if (this.runtimeInfo.special_tokens) {
-          this.formatterOptions.specialTokens = this.runtimeInfo.special_tokens;
-        }
-
-        // Update model processor with runtime context
-        this.modelProcessor.setRuntimeContext({
-          chatRestrictions: this.runtimeInfo.chat_restrictions,
-          modelKind: this.runtimeInfo.model_kind,
-        });
-
-        // Bind cache controller if provided and not yet bound
-        // NOTE: instanceof guard means VLM check only covers MlxCacheController.
-        // A custom PromptCacheController on a VLM model would bypass this — add a
-        // model-kind guard here if another implementation is introduced.
-        if (this.cacheController instanceof MlxCacheController && !this.cacheControllerBound) {
-          if (this.runtimeInfo.model_kind === 'vlm') {
-            this.queryLogger.log.info('VLM models do not support prompt caching — cacheController disabled');
-            this.cacheController = undefined;
-          } else {
-            await this.cacheController.bind(
-              this.process,
-              this.formatterOptions,
-              (msgs) => this.modelProcessor.applyChatSpecificProcessing(msgs),
-            );
-            this.cacheControllerBound = true;
-          }
-        }
-      } catch (error) {
-        this.queryLogger.log.error('Failed to get MLX runtime info:', error instanceof Error ? error.message : String(error));
-      }
-    }
+  get defaultOptions(): Partial<MlxQueryOptions> {
+    return super.defaultOptions as Partial<MlxQueryOptions>;
   }
 
-  /**
-   * VLMモデルかどうかを判定
-   */
-  private isVLM(): boolean {
-    return this.runtimeInfo?.model_kind === 'vlm';
+  set defaultOptions(value: Partial<MlxQueryOptions>) {
+    super.defaultOptions = value ?? {};
   }
 
-  /**
-   * Determine which API to use (chat or completion)
-   * Simple logic based on runtime info only
-   */
-  private determineApi(options?: QueryOptions): 'chat' | 'completion' {
-    return selectApi(
-      options?.apiStrategy || 'auto',
-      options?.mode,
-      !!this.runtimeInfo?.features.apply_chat_template,
-      this.modelProcessor.hasCompletionProcessor()
-    );
-  }
-
-  /**
-   * モデルがnativeツール対応かを判定
-   * tool_call_format（Python側検出結果）を唯一の判断基準とする
-   */
-  private hasNativeToolSupport(): boolean {
-    return !!this.runtimeInfo?.features?.chat_template?.tool_call_format?.call_start;
-  }
-  
-  /**
-   * Execute query and return stream
-   * Common logic for query and streamQuery
-   */
-  private async executeQuery(
-    prompt: CompiledPrompt,
-    mlxOptions: MlxMlModelOptions,
-    options?: MlxQueryOptions
-  ): Promise<{ stream: Readable; cacheTokensUsed: number; cacheWriteTokens: number }> {
-    // APIを選択
-    const api = this.determineApi(options);
-
-    // tools変換
-    const tools = options?.tools ? convertToolDefinitions(options.tools) : undefined;
-
-    // completion API または nativeツール非対応の場合、tool定義をテキストとしてプロンプトに注入
-    let augmentedPrompt = prompt;
-    if (options?.tools && options.tools.length > 0 && (api === 'completion' || !this.hasNativeToolSupport())) {
-      const toolsText = formatToolDefinitionsAsText(
-        options.tools,
-        this.runtimeInfo?.special_tokens,
-        this.runtimeInfo?.features?.chat_template?.tool_call_format
-      );
-      augmentedPrompt = {
-        ...prompt,
-        instructions: [
-          ...prompt.instructions,
-          { type: 'text' as const, content: toolsText }
-        ]
-      };
-    }
-
-    // Record all queries, regardless of API mode or cache usage
-    this.cacheController?.recordQuery?.();
-
-    let stream: Readable;
-    if (api === 'completion') {
-      let formattedPrompt = formatCompletionPrompt(augmentedPrompt, this.formatterOptions);
-      formattedPrompt = this.modelProcessor.applyCompletionSpecificProcessing(formattedPrompt);
-      // LIP generate（wire method: "generate"。Python 側は旧 completion と同一 handle_generate）
-      stream = await this.process.generate(formattedPrompt, mlxOptions);
-    } else {
-      const messages = formatPromptAsMessages(augmentedPrompt, this.formatterOptions);
-      const vlm = this.isVLM();
-      let mlxMessages = convertMessages(messages, vlm);
-      mlxMessages = this.modelProcessor.applyChatSpecificProcessing(mlxMessages);
-      const nativeTools = this.hasNativeToolSupport() && tools?.length ? tools : undefined;
-      const images = vlm
-        ? messages.flatMap(m => 'content' in m && !isToolResult(m) ? extractImagePaths(m.content) : [])
-        : [];
-
-      // Cache: chat APIのみ、以下の条件を全て満たす場合にキャッシュを使用
-      // - options.cache !== false（呼び出し側が明示的に無効化していない）
-      // - trustRemoteCode未指定（明示的なtrue/falseどちらもapply_chat_template kwargsに影響）
-      let cachePath: string | undefined;
-      let cacheTrimTokens: number | undefined;
-      let cacheWriteTokens = 0;
-      const cacheGrowthBefore = this.cacheController instanceof MlxCacheController
-        ? this.cacheController.getStats().cacheGrowthTokens
-        : 0;
-      const trustRemoteCode = mlxOptions.trustRemoteCode;
-      if (this.cacheController && options?.cache !== false && trustRemoteCode === undefined) {
-        const prefix = extractCacheablePrefix(augmentedPrompt);
-        const hasCacheableContent =
-          prefix.instructions.length > 0 ||
-          prefix.data.length > 0;
-
-        if (hasCacheableContent) {
-          const cacheStart = performance.now();
-          const handle = await this.cacheController.prepare({
-            model: this.model,
-            instructions: prefix.instructions,
-            data: prefix.data,
-            tools: nativeTools ? options!.tools : undefined,
-            reasoningEffort: options?.reasoningEffort,
-            readOnly: options?.cache === 'read-only',
-          });
-          cachePath = handle.ref || undefined;
-          cacheTrimTokens = handle.trimTokens;
-          if (cachePath) {
-            this.queryLogger.log.debug(
-              `cache prepare ${(performance.now() - cacheStart).toFixed(0)}ms`,
-              `(${prefix.instructions.length}i+${prefix.data.length}d)`,
-              cacheTrimTokens != null ? `trim=${cacheTrimTokens}` : '',
-            );
-          }
-        }
-      }
-
-      if (this.cacheController instanceof MlxCacheController) {
-        cacheWriteTokens = Math.max(
-          0,
-          this.cacheController.getStats().cacheGrowthTokens - cacheGrowthBefore,
-        );
-      }
-
-      let formattedPrompt: string;
-      if (this.runtimeInfo?.features.apply_chat_template) {
-        const renderResult = await this.process.render(
-          mlxMessages,
-          mlxOptions,
-          nativeTools,
-          options?.reasoningEffort,
-        );
-        if (renderResult.error || renderResult.formatted_prompt == null) {
-          throw new Error(renderResult.error ?? 'render failed');
-        }
-        formattedPrompt = String(renderResult.formatted_prompt);
-      } else {
-        formattedPrompt = generateMergedPrompt(
-          mlxMessages,
-          this.runtimeInfo?.special_tokens ?? {},
-        );
-      }
-
-      const generateOptions = { ...mlxOptions };
-      delete generateOptions.trustRemoteCode;
-
-      stream = await this.process.generate(
-        formattedPrompt,
-        generateOptions,
-        images.length > 0 ? images : undefined,
-        images.length > 0 ? this.maxImageSize : undefined,
-        cachePath,
-        cacheTrimTokens,
-      );
-
-      const cacheTokensUsed = cachePath
-        ? (cacheTrimTokens ?? (this.cacheController instanceof MlxCacheController
-          ? this.cacheController.readCacheTokenCount(cachePath) : 0))
-        : 0;
-      return { stream, cacheTokensUsed, cacheWriteTokens };
-    }
-
-    return { stream, cacheTokensUsed: 0, cacheWriteTokens: 0 };
-  }
-
-  /**
-   * Query the AI model with a compiled prompt
-   */
-  async query(prompt: CompiledPrompt, options?: QueryOptions): Promise<QueryResult> {
-    // Use streamQuery for consistency with other drivers
-    const { stream, result } = await this.streamQuery(prompt, options);
-
-    // Consume the stream to trigger completion
-    // This is necessary because the result promise only resolves when the stream is fully consumed
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for await (const _chunk of stream) {
-      // Just consume the stream, don't need to do anything with the chunks
-    }
-
-    return result;
-  }
-  /**
-   * Stream query implementation
-   */
-  async streamQuery(
-    prompt: CompiledPrompt,
-    options?: QueryOptions
-  ): Promise<StreamResult> {
-    await this.ensureInitialized();
-
-    const signal = options?.signal;
-    if (isAborted(signal)) {
-      return createAbortedStreamResult(this.queryLogger.collect());
-    }
-
-    let abortRequested = false;
-    const cleanupAbort = watchAbortSignal(signal, () => {
-      abortRequested = true;
-      this.process.cancelActiveRequest();
-    });
-    const checkAborted = () => abortRequested || isAborted(signal);
-
-    const merged = mergeMlxQueryOptions(this._defaultOptions, options);
-    const mlxOptions = toMlxSamplingOptions(merged);
-    this.queryLogger.mark(merged as Record<string, unknown>);
-
-    const queryStart = performance.now();
-    const { stream, cacheTokensUsed, cacheWriteTokens } = await this.executeQuery(prompt, mlxOptions, merged);
-
-    if (checkAborted()) {
-      this.process.cancelActiveRequest();
-    }
-
-    const streamStart = performance.now();
-    this.queryLogger.log.debug(`setup ${(streamStart - queryStart).toFixed(0)}ms`);
-
-    const { iterable, completion } = createStreamIterable(stream, checkAborted);
-
-    const queryLogger = this.queryLogger;
-    let firstChunkTime = 0;
-    const wrappedIterable: AsyncIterable<string> = {
-      [Symbol.asyncIterator]() {
-        const inner = iterable[Symbol.asyncIterator]();
-        let firstChunk = true;
-        return {
-          async next() {
-            if (checkAborted()) {
-              void inner.return?.();
-              return { done: true as const, value: undefined };
-            }
-            const result = await inner.next();
-            if (!result.done) {
-              if (firstChunk) {
-                firstChunk = false;
-                firstChunkTime = performance.now();
-                queryLogger.log.debug(`TTFT ${(firstChunkTime - streamStart).toFixed(0)}ms`);
-              }
-            }
-            if (result.done) {
-              const now = performance.now();
-              if (firstChunkTime > 0) {
-                const genMs = now - firstChunkTime;
-                queryLogger.log.debug(`generation ${genMs.toFixed(0)}ms (query total ${(now - queryStart).toFixed(0)}ms)`);
-              } else {
-                queryLogger.log.debug(`query total ${(performance.now() - queryStart).toFixed(0)}ms`);
-              }
-            }
-            return result;
-          },
-          async return(value?: string) {
-            cleanupAbort();
-            return inner.return?.(value) ?? { done: true as const, value: undefined };
-          },
-          async throw(e?: unknown) {
-            cleanupAbort();
-            return inner.throw?.(e) ?? { done: true as const, value: undefined };
-          },
-        };
-      },
-    };
-
-    const cacheController = this.cacheController;
-    const resultPromise = completion
-      .then(({ content, meta, error }) => {
-        const aborted = checkAborted();
-        if (error && !aborted) {
-          this.queryLogger.log.error('Stream error:', error.message);
-          throw error;
-        }
-
-        if (cacheController instanceof MlxCacheController && meta.prompt_tokens != null) {
-          cacheController.recordPromptTokens(meta.prompt_tokens, cacheTokensUsed);
-        }
-
-        if (meta.generation_tokens != null && firstChunkTime > 0) {
-          const genMs = performance.now() - firstChunkTime;
-          const actualTps = (meta.generation_tokens / genMs * 1000).toFixed(1);
-          this.queryLogger.log.debug(
-            `${meta.generation_tokens} tokens, ${actualTps} tok/s`
-          );
-        }
-
-        const hasTools = options?.tools && options.tools.length > 0;
-        const responseProcessor = selectResponseProcessor(this.model, this.runtimeInfo, { enableToolParsing: !!hasTools });
-        const parsed = responseProcessor(content);
-        const finalContent = parsed.content;
-        const thinkingContent = parsed.thinkingContent;
-        const toolCalls = parsed.toolCalls;
-
-        if (thinkingContent) {
-          this.queryLogger.log.verbose('Thinking content:', thinkingContent);
-        }
-
-        let structuredOutput: unknown | undefined;
-        if (prompt.metadata?.outputSchema && finalContent) {
-          const extracted = extractJSON(finalContent, { multiple: false });
-          if (extracted.source !== 'none' && extracted.data !== null) {
-            structuredOutput = extracted.data;
-          }
-        }
-
-        const finishReason: FinishReason = aborted
-          ? 'error'
-          : toolCalls
-            ? 'tool_calls'
-            : 'stop';
-
-        return {
-          content: finalContent,
-          thinkingContent,
-          structuredOutput,
-          toolCalls,
-          finishReason,
-          usage: buildQueryUsage({
-            promptTokens: meta.prompt_tokens,
-            completionTokens: meta.generation_tokens,
-            cacheReadTokens: cacheTokensUsed,
-            cacheWriteTokens,
-          }),
-          ...this.queryLogger.collect(),
-        };
-      })
-      .finally(() => {
-        cleanupAbort();
-      });
-
-    return {
-      stream: wrappedIterable,
-      result: resultPromise,
-    };
-  }
-  
   /**
    * Get model capabilities (public API)
    *
@@ -583,68 +102,75 @@ export class MlxDriver implements AIDriver {
   async getCapabilities(): Promise<MlxModelCapabilities> {
     await this.ensureInitialized();
 
-    if (!this.runtimeInfo) {
+    const runtimeInfo = this.getRuntimeInfo();
+    if (!runtimeInfo) {
       throw new Error('Failed to retrieve model capabilities');
     }
 
-    // Convert snake_case to camelCase
     return {
-      methods: this.runtimeInfo.methods,
-      specialTokens: this.runtimeInfo.special_tokens,
+      methods: runtimeInfo.methods,
+      specialTokens: runtimeInfo.special_tokens,
       features: {
-        hasChatTemplate: this.runtimeInfo.features.apply_chat_template,
-        vocabSize: this.runtimeInfo.features.vocab_size,
-        modelMaxLength: this.runtimeInfo.features.model_max_length,
-        chatTemplate: this.runtimeInfo.features.chat_template ? {
-          supportedRoles: this.runtimeInfo.features.chat_template.supported_roles,
-          preview: this.runtimeInfo.features.chat_template.preview,
-          constraints: this.runtimeInfo.features.chat_template.constraints,
-          toolCallFormat: this.runtimeInfo.features.chat_template.tool_call_format ? {
-            toolParserType: this.runtimeInfo.features.chat_template.tool_call_format.tool_parser_type,
-            callStart: this.runtimeInfo.features.chat_template.tool_call_format.call_start,
-            callEnd: this.runtimeInfo.features.chat_template.tool_call_format.call_end,
-            responseStart: this.runtimeInfo.features.chat_template.tool_call_format.response_start,
-            responseEnd: this.runtimeInfo.features.chat_template.tool_call_format.response_end,
-          } : undefined
-        } : undefined
+        hasChatTemplate: runtimeInfo.features.apply_chat_template,
+        vocabSize: runtimeInfo.features.vocab_size,
+        modelMaxLength: runtimeInfo.features.model_max_length,
+        chatTemplate: runtimeInfo.features.chat_template
+          ? {
+              supportedRoles: runtimeInfo.features.chat_template.supported_roles,
+              preview: runtimeInfo.features.chat_template.preview,
+              constraints: runtimeInfo.features.chat_template.constraints,
+              toolCallFormat: runtimeInfo.features.chat_template.tool_call_format
+                ? {
+                    toolParserType:
+                      runtimeInfo.features.chat_template.tool_call_format.tool_parser_type,
+                    callStart: runtimeInfo.features.chat_template.tool_call_format.call_start,
+                    callEnd: runtimeInfo.features.chat_template.tool_call_format.call_end,
+                    responseStart:
+                      runtimeInfo.features.chat_template.tool_call_format.response_start,
+                    responseEnd: runtimeInfo.features.chat_template.tool_call_format.response_end,
+                  }
+                : undefined,
+            }
+          : undefined,
       },
-      chatRestrictions: this.runtimeInfo.chat_restrictions ? {
-        singleSystemAtStart: this.runtimeInfo.chat_restrictions.single_system_at_start,
-        maxSystemMessages: this.runtimeInfo.chat_restrictions.max_system_messages,
-        alternatingTurns: this.runtimeInfo.chat_restrictions.alternating_turns,
-        requiresUserLast: this.runtimeInfo.chat_restrictions.requires_user_last,
-        allowEmptyMessages: this.runtimeInfo.chat_restrictions.allow_empty_messages,
-      } : undefined
+      chatRestrictions: runtimeInfo.chat_restrictions
+        ? {
+            singleSystemAtStart: runtimeInfo.chat_restrictions.single_system_at_start,
+            maxSystemMessages: runtimeInfo.chat_restrictions.max_system_messages,
+            alternatingTurns: runtimeInfo.chat_restrictions.alternating_turns,
+            requiresUserLast: runtimeInfo.chat_restrictions.requires_user_last,
+            allowEmptyMessages: runtimeInfo.chat_restrictions.allow_empty_messages,
+          }
+        : undefined,
     };
   }
 
+  override async close(): Promise<void> {
+    this.logCacheStats();
+    if (this.cacheDisabledForVlm) {
+      await this.cacheControllerRaw?.close();
+    }
+    await super.close();
+  }
+
   private logCacheStats(): void {
-    if (!(this.cacheController instanceof MlxCacheController)) return;
-    const s = this.cacheController.getStats();
+    if (this.cacheDisabledForVlm) return;
+    if (!(this.cacheControllerRaw instanceof MlxCacheController)) return;
+    const s = this.cacheControllerRaw.getStats();
     if (s.totalQueries === 0) return;
 
-    const queryBreakdown = s.incremental + s.fresh > 0
-      ? ` (incremental ${s.incremental}, fresh ${s.fresh})`
-      : '';
-    const parts: string[] = [
-      `cache stats: ${s.totalQueries} queries${queryBreakdown}`,
-    ];
+    const queryBreakdown =
+      s.incremental + s.fresh > 0 ? ` (incremental ${s.incremental}, fresh ${s.fresh})` : '';
+    const parts: string[] = [`cache stats: ${s.totalQueries} queries${queryBreakdown}`];
     if (s.totalPromptTokens > 0) {
       const reusedRate = ((s.prefillReusedTokens / s.totalPromptTokens) * 100).toFixed(0);
-      parts.push(`prompt ${s.totalPromptTokens} tokens, ${s.prefillReusedTokens} reused (${reusedRate}%)`);
+      parts.push(
+        `prompt ${s.totalPromptTokens} tokens, ${s.prefillReusedTokens} reused (${reusedRate}%)`,
+      );
     }
     if (s.cacheGrowthTokens > 0) {
       parts.push(`cache +${s.cacheGrowthTokens} tokens`);
     }
     this.queryLogger.log.verbose(parts.join(' | '));
-  }
-
-  /**
-   * Close the process
-   */
-  async close(): Promise<void> {
-    this.logCacheStats();
-    await this.cacheController?.close();
-    await this.process.exit();
   }
 }

--- a/packages/driver/src/mlx-ml/mlx-local-inference-adapters.ts
+++ b/packages/driver/src/mlx-ml/mlx-local-inference-adapters.ts
@@ -1,0 +1,26 @@
+import { mergeMlxQueryOptions, toMlxSamplingOptions } from './mlx-options.js';
+import { createModelSpecificProcessor, selectApi } from './process/model-specific.js';
+import { selectResponseProcessor } from './process/model-handlers.js';
+import { generateMergedPrompt } from './process/prompt-builder.js';
+import { formatToolDefinitionsAsText } from './tool-call-parser/index.js';
+import {
+  convertMessages,
+  convertToolDefinitions,
+  extractImagePaths,
+} from './mlx-message-utils.js';
+import type { LocalInferenceAdapters } from '../local-inference/adapters.js';
+
+export const mlxLocalInferenceAdapters: LocalInferenceAdapters = {
+  mergeQueryOptions: (defaults, options) =>
+    mergeMlxQueryOptions(defaults, options) as Record<string, unknown>,
+  toSamplingOptions: (merged) => toMlxSamplingOptions(merged) as Record<string, unknown>,
+  createModelProcessor: (model) => createModelSpecificProcessor(model),
+  selectResponseProcessor: (model, runtimeInfo, opts) =>
+    selectResponseProcessor(model, runtimeInfo, opts),
+  convertToolDefinitions,
+  convertMessages,
+  extractImagePaths,
+  formatToolDefinitionsAsText,
+  generateMergedPrompt,
+  selectApi,
+};

--- a/packages/driver/src/mlx-ml/process/model-specific.ts
+++ b/packages/driver/src/mlx-ml/process/model-specific.ts
@@ -5,6 +5,7 @@
  * Python側のapply_model_specific_processingをTypeScript側に移行
  */
 
+import type { ApiStrategy, QueryMode } from '../../types.js';
 import type { MlxMessage, MlxRuntimeInfo } from './types.js';
 import { mergeSystemMessages, selectChatProcessor, selectCompletionProcessor } from './model-handlers.js';
 
@@ -20,8 +21,8 @@ type ChatRestrictions = MlxRuntimeInfo['chat_restrictions'];
  * 4. auto → chat templateがあればchat、なければcompletion
  */
 export function selectApi(
-  strategy: string,
-  mode: string | undefined,
+  strategy: ApiStrategy,
+  mode: QueryMode | undefined,
   hasChatTemplate: boolean,
   hasCompletionProc: boolean
 ): 'chat' | 'completion' {

--- a/packages/driver/src/types.ts
+++ b/packages/driver/src/types.ts
@@ -143,6 +143,11 @@ export type FinishReason = 'stop' | 'length' | 'error' | 'tool_calls';
 export type QueryMode = 'default' | 'thinking' | 'instruct' | 'chat';
 
 /**
+ * API selection strategy (MLX / LocalInference drivers)
+ */
+export type ApiStrategy = 'auto' | 'force-chat' | 'force-completion';
+
+/**
  * Options for querying AI model
  */
 export interface QueryOptions {
@@ -159,7 +164,7 @@ export interface QueryOptions {
    * - 'force-chat': Force chat API
    * - 'force-completion': Force completion API
    */
-  apiStrategy?: 'auto' | 'force-chat' | 'force-completion';
+  apiStrategy?: ApiStrategy;
   /** Available tool definitions */
   tools?: ToolDefinition[];
   /** Tool usage strategy */


### PR DESCRIPTION
## Summary

- `LocalInferenceDriver` を新設し、render+generate フロー・ストリーム処理・キャッシュ連携の共通骨格を集約
- `MlxDriver` は MLX プロセス起動・capabilities 変換・キャッシュバインドの薄いラッパに
- `stream-utils.ts` に META マーカー処理を分離

Closes #315
Part of #302

## 変更の要点

| 層 | 変更 |
|----|------|
| `local-inference/driver.ts` | `AIDriver` 実装（adapter 注入でバックエンド非依存） |
| `local-inference/adapters.ts` | モデル処理・ツール・API 選択のポート定義 |
| `mlx-ml/mlx-driver.ts` | ~650行 → ~170行（`getCapabilities` / キャッシュ / drafter のみ） |
| `mlx-local-inference-adapters.ts` | MLX 固有 adapter 実装の束ね |

**挙動変更なし**（リファクタリングのみ）

## Test plan

- [x] `pnpm run build` / `lint` / `test:run` / `typecheck`（driver: 674 tests pass）
- [x] `local-inference/driver.test.ts` — render+generate / completion / generateMergedPrompt 経路
- [x] `local-inference/stream-utils.test.ts` — META パース・ストリーム分割
- [x] 既存 `mlx-driver-*.test.ts` すべて pass
- [x] **実機 MLX 統合テスト**（`mlx-driver-params.test.ts` 5 passed、ローカル darwin）

### マージ前の実機確認（推奨）

```bash
cd packages/driver
SKIP_MLX_TESTS=false pnpm run test:run src/mlx-ml/mlx-driver-params.test.ts
SKIP_MLX_TESTS=false pnpm run test:run src/mlx-ml/mlx-driver-structured-outputs.integration.test.ts
```


Made with [Cursor](https://cursor.com)