### PR TITLE
fix(driver): runtime:status に variant/torchVersion を表示

### DIFF
--- a/.changeset/runtime-status-manifest-detail.md
+++ b/.changeset/runtime-status-manifest-detail.md
@@ -1,0 +1,8 @@
+---
+"@modular-prompt/driver": patch
+---
+
+runtime:status で PyTorch runtime の variant / torch バージョンを表示
+
+- `RuntimeManifest` 型に `variant` / `torchVersion` を追加
+- `collectInstalledPackages` が venv の Python を明示参照するよう修正

--- a/packages/driver/scripts/runtime-cli.js
+++ b/packages/driver/scripts/runtime-cli.js
@@ -174,14 +174,25 @@ function setupPytorch() {
   }
 }
 
+function formatManifestDetail(manifest) {
+  const parts = [`driver ${manifest.driverVersion}`];
+  if (manifest.variant) {
+    parts.push(`variant ${manifest.variant}`);
+  }
+  const torchVersion = manifest.torchVersion ?? manifest.packages?.torch;
+  if (torchVersion) {
+    parts.push(`torch ${torchVersion}`);
+  }
+  parts.push(manifest.createdAt);
+  return ` (${parts.join(', ')})`;
+}
+
 function printStatus() {
   console.log(`modular-prompt home: ${getModularPromptHome()}\n`);
   for (const profile of RUNTIME_PROFILES) {
     const ready = isRuntimeReady(profile);
     const manifest = ready ? readManifest(profile) : null;
-    const detail = manifest
-      ? ` (driver ${manifest.driverVersion}, ${manifest.createdAt})`
-      : '';
+    const detail = manifest ? formatManifestDetail(manifest) : '';
     const icon = ready ? '✅' : '❌';
     const runtimePath = getRuntimeDir(profile);
     console.log(`${icon} ${profile}: ${ready ? 'ready' : 'not installed'}${detail}`);

--- a/packages/driver/src/runtime/manifest-core.mjs
+++ b/packages/driver/src/runtime/manifest-core.mjs
@@ -1,6 +1,13 @@
 import { execSync } from 'child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import { getManifestPath, getRuntimeDir } from './paths-core.mjs';
+
+function resolveVenvPython(venvPath) {
+  return process.platform === 'win32'
+    ? join(venvPath, 'Scripts', 'python.exe')
+    : join(venvPath, 'bin', 'python');
+}
 
 /**
  * @param {string} pythonDir
@@ -9,12 +16,9 @@ import { getManifestPath, getRuntimeDir } from './paths-core.mjs';
  */
 export function collectInstalledPackages(pythonDir, venvPath) {
   try {
-    const output = execSync('uv pip list --format=json', {
+    const venvPython = resolveVenvPython(venvPath);
+    const output = execSync(`uv pip list --format=json --python "${venvPython}"`, {
       cwd: pythonDir,
-      env: {
-        ...process.env,
-        UV_PROJECT_ENVIRONMENT: venvPath,
-      },
       encoding: 'utf8',
     });
     const list = JSON.parse(output);
@@ -58,5 +62,7 @@ export function writeManifest(profile, manifest) {
  * @property {string} platform
  * @property {string} pythonVersion
  * @property {string} createdAt
+ * @property {string} [variant]
+ * @property {string} [torchVersion]
  * @property {Record<string, string>} [packages]
  */

--- a/packages/driver/src/runtime/manifest-core.mjs.d.ts
+++ b/packages/driver/src/runtime/manifest-core.mjs.d.ts
@@ -4,6 +4,8 @@ export interface RuntimeManifest {
   platform: string;
   pythonVersion: string;
   createdAt: string;
+  variant?: string;
+  torchVersion?: string;
   packages?: Record<string, string>;
 }
 

--- a/packages/driver/src/runtime/manifest.ts
+++ b/packages/driver/src/runtime/manifest.ts
@@ -11,6 +11,10 @@ export interface RuntimeManifest {
   platform: string;
   pythonVersion: string;
   createdAt: string;
+  /** PyTorch 等の runtime variant（例: cpu-minimal） */
+  variant?: string;
+  /** セットアップ時に記録した torch バージョン */
+  torchVersion?: string;
   packages?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary

#319 マージ後に未 push だった細かい指摘へのフォローアップです。

- `RuntimeManifest` 型に `variant?` / `torchVersion?` を追加
- `runtime:status` で manifest の variant・torch バージョンを表示（`packages.torch` にフォールバック）
- `collectInstalledPackages` が venv の Python を `--python` で明示参照（次回 `setup-pytorch` 時に `torchVersion` が manifest に記録される）

## Test plan

- [x] `pnpm run build -w @modular-prompt/driver`
- [x] `pnpm run runtime:status -w @modular-prompt/driver` — `variant cpu-minimal` 表示を確認


Made with [Cursor](https://cursor.com)